### PR TITLE
Add download mode interface

### DIFF
--- a/src/DownloadMode/DownloadMode.php
+++ b/src/DownloadMode/DownloadMode.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SergiX44\Nutgram\DownloadMode;
+
+use SergiX44\Nutgram\Nutgram;
+
+interface DownloadMode
+{
+    public function buildPath(Nutgram $bot, string $path): string;
+
+    public function downloadPath(Nutgram $bot, string $fromPath, string $toPath, array $opt = []): bool;
+}

--- a/src/DownloadMode/Local.php
+++ b/src/DownloadMode/Local.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SergiX44\Nutgram\DownloadMode;
+
+use SergiX44\Nutgram\Nutgram;
+
+class Local implements DownloadMode
+{
+    public function buildPath(Nutgram $bot, string $path): string
+    {
+        return $path;
+    }
+
+    public function downloadPath(Nutgram $bot, string $fromPath, string $toPath, array $opt = []): bool
+    {
+        return copy($fromPath, $toPath);
+    }
+}

--- a/src/DownloadMode/Remote.php
+++ b/src/DownloadMode/Remote.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\DownloadMode;
+
+use SergiX44\Nutgram\Nutgram;
+use Symfony\Component\HttpFoundation\Response;
+
+class Remote implements DownloadMode
+{
+    public function buildPath(Nutgram $bot, string $path): string
+    {
+        return sprintf(
+            "%s/file/bot%s/%s",
+            $bot->getConfig()['api_url'] ?? Nutgram::DEFAULT_API_URL,
+            $bot->getToken(),
+            $path
+        );
+    }
+
+    public function downloadPath(Nutgram $bot, string $fromPath, string $toPath, array $opt = []): bool
+    {
+        $response = $bot->getHttp()->get($fromPath, array_merge(['sink' => $toPath], $opt['clientOpt'] ?? []));
+        return $response->getStatusCode() === Response::HTTP_OK;
+    }
+}

--- a/src/Telegram/Client.php
+++ b/src/Telegram/Client.php
@@ -28,7 +28,6 @@ use SergiX44\Nutgram\Telegram\Types\Internal\InputFile;
 use SergiX44\Nutgram\Telegram\Types\Media\File;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use stdClass;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Trait Client
@@ -176,8 +175,7 @@ trait Client
             throw new RuntimeException(sprintf('Error creating directory "%s"', $concurrentDirectory));
         }
 
-        $response = $this->http->get($this->downloadUrl($file), array_merge(['sink' => $path], $clientOpt));
-        return $response->getStatusCode() === Response::HTTP_OK;
+        return $this->downloadMode->downloadPath($this, $this->downloadUrl($file), $path, ['clientOpt' => $clientOpt]);
     }
 
     /**
@@ -186,12 +184,7 @@ trait Client
      */
     public function downloadUrl(File $file): string|null
     {
-        if (isset($this->config['is_local']) && $this->config['is_local']) {
-            return $file->file_path;
-        }
-
-        $baseUri = $this->config['api_url'] ?? self::DEFAULT_API_URL;
-        return "$baseUri/file/bot$this->token/$file->file_path";
+        return $this->downloadMode->buildPath($this, $file->file_path);
     }
 
     /**


### PR DESCRIPTION
1. ⚠️ This PR fixes the `downloadFile` method when used with config key `"is_local" => true`
2. This PR adds the ability to handle file paths for remote or local bot API server

## Use case example:
You can't download files when Nutgram instance is used in combination with:
- is_local => true
- telegram bot API local + docker
- windows os

**docker-compose.yml**
![immagine](https://user-images.githubusercontent.com/4071613/169418695-2d463287-0894-407e-9bee-b8444af49233.png)

**nutgram.php config**
![immagine](https://user-images.githubusercontent.com/4071613/169418801-7c0bfa48-33a6-4ae6-a4b2-6403cbd1945b.png)

**Wrong behavior**
![immagine](https://user-images.githubusercontent.com/4071613/169419233-b6599bd2-8473-40d2-97b3-c951be762d90.png)

### How to fix (with this PR)
![immagine](https://user-images.githubusercontent.com/4071613/169419614-0660c619-add7-42c1-b117-4f0dbc755b3d.png)

**Right behavior**
![immagine](https://user-images.githubusercontent.com/4071613/169419893-c6b505f3-476f-4171-ae6b-b148773c8ec4.png)
