### PR TITLE
Fix null token

### DIFF
--- a/src/NutgramServiceProvider.php
+++ b/src/NutgramServiceProvider.php
@@ -49,7 +49,7 @@ class NutgramServiceProvider extends ServiceProvider
                 'cache' => $app->make(Cache::class),
             ], config('nutgram.config'));
 
-            $bot = new Nutgram(config('nutgram.token', 'MISSING-TOKEN'), $config);
+            $bot = new Nutgram(config('nutgram.token') ?? 'MISSING-TOKEN', $config);
 
             if ($app->runningInConsole()) {
                 $bot->setRunningMode(Polling::class);


### PR DESCRIPTION
When config is empty **$token** is null

```
   TypeError

  SergiX44\Nutgram\Nutgram::__construct(): Argument #1 ($token) must be of type string, null given, calle
d in /home/vagrant/code/g2x/laravel/vendor/nutgram/nutgram/src/NutgramServiceProvider.php on line 46

  at vendor/nutgram/nutgram/src/Nutgram.php:78

