### PR TITLE
Add onPreCheckoutQueryPayload handler

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,3 +22,6 @@ ij_php_space_before_closure_left_parenthesis = true
 ij_php_keep_indents_on_empty_lines = false
 ij_php_space_after_type_cast = false
 ij_php_concat_spaces = false
+
+[*.json]
+indent_size = 2

--- a/src/Handlers/CollectHandlers.php
+++ b/src/Handlers/CollectHandlers.php
@@ -159,6 +159,16 @@ abstract class CollectHandlers
     }
 
     /**
+     * @param  string  $pattern
+     * @param $callable
+     * @return Handler
+     */
+    public function onPreCheckoutQueryPayload(string $pattern, $callable): Handler
+    {
+        return $this->handlers[UpdateTypes::PRE_CHECKOUT_QUERY][$pattern] = new Handler($callable, $pattern);
+    }
+
+    /**
      * @param $callable
      * @return Handler
      */

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -60,6 +60,9 @@ abstract class ResolveHandlers extends CollectHandlers
         } elseif ($updateType === UpdateTypes::CALLBACK_QUERY) {
             $data = $this->update->callback_query?->data;
             $this->addHandlersBy($resolvedHandlers, $updateType, value: $data);
+        } elseif ($updateType === UpdateTypes::PRE_CHECKOUT_QUERY) {
+            $data = $this->update->pre_checkout_query?->invoice_payload;
+            $this->addHandlersBy($resolvedHandlers, $updateType, value: $data);
         }
 
         if (empty($resolvedHandlers) && $updateType !== null) {

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -323,6 +323,25 @@ it('the catch all handler text not called for media', function ($update) {
     $bot->run();
 })->with('photo');
 
+it('parse pre checkout queries with specific data', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onPreCheckoutQueryPayload('thedata', function ($bot) {
+        expect($bot)->toBeInstanceOf(Nutgram::class);
+    });
+
+    $bot->onMessage(function ($bot) {
+        throw new Exception();
+    });
+
+
+    $bot->fallback(function ($bot) {
+        throw new Exception();
+    });
+
+    $bot->run();
+})->with('pre_checkout_query_payload');
+
 test('commands can have descriptions', function ($update) {
     $bot = Nutgram::fake($update);
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -60,6 +60,12 @@ dataset('callback_query', function () {
     return [json_decode($file)];
 });
 
+dataset('pre_checkout_query_payload', function () {
+    $file = file_get_contents(__DIR__.'/Updates/pre_checkout_query_payload.json');
+
+    return [json_decode($file)];
+});
+
 dataset('edited_message', function () {
     $file = file_get_contents(__DIR__.'/Updates/edited_message.json');
 

--- a/tests/Updates/pre_checkout_query_payload.json
+++ b/tests/Updates/pre_checkout_query_payload.json
@@ -1,0 +1,19 @@
+{
+  "update_id": 2,
+  "pre_checkout_query": {
+    "id": "999728699048485871",
+    "bot": null,
+    "from": {
+      "id": 222222222,
+      "is_bot": false,
+      "first_name": "Mario",
+      "username": "Super",
+      "language_code": "it"
+    },
+    "currency": "USD",
+    "total_amount": 100,
+    "invoice_payload": "thedata",
+    "shipping_option_id": null,
+    "order_info": null
+  }
+}


### PR DESCRIPTION
### Before this PR
```php
$bot->onPreCheckoutQuery(PreCheckoutQueryHandler::class);
```

```php
class PreCheckoutQueryHandler
{
    public function __invoke(Nutgram $bot): void
    {
        $payload = $bot->preCheckoutQuery()->invoice_payload;
        
        if($payload === 'donation') {
            //do things
            $bot->answerPreCheckoutQuery(true);
        } else {
            //do things
            $bot->answerPreCheckoutQuery(true);
        }
    }
}
```

### After this PR
```php
$bot->onPreCheckoutQueryPayload('donation', [PreCheckoutQueryHandler::class, 'donation']);
$bot->onPreCheckoutQueryPayload('premium', [PreCheckoutQueryHandler::class, 'premium']);
```
```php
class PreCheckoutQueryHandler
{
    public function donation(Nutgram $bot): void
    {
        //do things
        $bot->answerPreCheckoutQuery(true);
    }

    public function premium(Nutgram $bot): void
    {
        //do things
        $bot->answerPreCheckoutQuery(true);
    }
}
```