### PR TITLE
Add onSuccessfulPayment + onSuccessfulPaymentPayload handlers

### DIFF
--- a/src/Handlers/CollectHandlers.php
+++ b/src/Handlers/CollectHandlers.php
@@ -172,6 +172,26 @@ abstract class CollectHandlers
      * @param $callable
      * @return Handler
      */
+    public function onSuccessfulPayment($callable): Handler
+    {
+        return $this->handlers[UpdateTypes::MESSAGE][MessageTypes::SUCCESSFUL_PAYMENT][] = new Handler($callable);
+    }
+
+    /**
+     * @param  string  $pattern
+     * @param $callable
+     * @return Handler
+     */
+    public function onSuccessfulPaymentPayload(string $pattern, $callable): Handler
+    {
+        return $this->handlers[UpdateTypes::MESSAGE][MessageTypes::SUCCESSFUL_PAYMENT][$pattern] = new Handler($callable,
+            $pattern);
+    }
+
+    /**
+     * @param $callable
+     * @return Handler
+     */
     public function onPoll($callable): Handler
     {
         return $this->handlers[UpdateTypes::POLL][] = new Handler($callable);

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -55,15 +55,15 @@ abstract class ResolveHandlers extends CollectHandlers
                 $text = $this->update?->message?->getParsedCommand() ?? $this->update->message?->text;
 
                 if ($text !== null) {
-                    $this->addHandlersBy($resolvedHandlers, $updateType, $this->update?->message?->getType(), $text);
+                    $this->addHandlersBy($resolvedHandlers, $updateType, $messageType, $text);
                 }
             } elseif ($messageType === MessageTypes::SUCCESSFUL_PAYMENT) {
                 $data = $this->update->message->successful_payment?->invoice_payload;
-                $this->addHandlersBy($resolvedHandlers, $updateType, $this->update?->message?->getType(), $data);
+                $this->addHandlersBy($resolvedHandlers, $updateType, $messageType, $data);
             }
 
             if (count($resolvedHandlers) === 0) {
-                $this->addHandlersBy($resolvedHandlers, $updateType, $this->update?->message?->getType());
+                $this->addHandlersBy($resolvedHandlers, $updateType, $messageType);
             }
         } elseif ($updateType === UpdateTypes::CALLBACK_QUERY) {
             $data = $this->update->callback_query?->data;

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -8,6 +8,7 @@ use SergiX44\Nutgram\Cache\GlobalCache;
 use SergiX44\Nutgram\Cache\UserCache;
 use SergiX44\Nutgram\Conversations\Conversation;
 use SergiX44\Nutgram\Proxies\UpdateProxy;
+use SergiX44\Nutgram\Telegram\Attributes\MessageTypes;
 use SergiX44\Nutgram\Telegram\Attributes\UpdateTypes;
 use SergiX44\Nutgram\Telegram\Types\Common\Update;
 
@@ -48,10 +49,17 @@ abstract class ResolveHandlers extends CollectHandlers
         $updateType = $this->update->getType();
 
         if ($updateType === UpdateTypes::MESSAGE) {
-            $text = $this->update?->message?->getParsedCommand() ?? $this->update->message?->text;
+            $messageType = $this->update->message->getType();
 
-            if ($text !== null) {
-                $this->addHandlersBy($resolvedHandlers, $updateType, $this->update?->message?->getType(), $text);
+            if ($messageType === MessageTypes::TEXT) {
+                $text = $this->update?->message?->getParsedCommand() ?? $this->update->message?->text;
+
+                if ($text !== null) {
+                    $this->addHandlersBy($resolvedHandlers, $updateType, $this->update?->message?->getType(), $text);
+                }
+            } elseif ($messageType === MessageTypes::SUCCESSFUL_PAYMENT) {
+                $data = $this->update->message->successful_payment?->invoice_payload;
+                $this->addHandlersBy($resolvedHandlers, $updateType, $this->update?->message?->getType(), $data);
             }
 
             if (count($resolvedHandlers) === 0) {

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -342,6 +342,25 @@ it('parse pre checkout queries with specific data', function ($update) {
     $bot->run();
 })->with('pre_checkout_query_payload');
 
+it('parse successful payment with specific data', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onSuccessfulPaymentPayload('thedata', function ($bot) {
+        expect($bot)->toBeInstanceOf(Nutgram::class);
+    });
+
+    $bot->onMessage(function ($bot) {
+        throw new Exception();
+    });
+
+
+    $bot->fallback(function ($bot) {
+        throw new Exception();
+    });
+
+    $bot->run();
+})->with('successful_payment');
+
 test('commands can have descriptions', function ($update) {
     $bot = Nutgram::fake($update);
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -66,6 +66,12 @@ dataset('pre_checkout_query_payload', function () {
     return [json_decode($file)];
 });
 
+dataset('successful_payment', function () {
+    $file = file_get_contents(__DIR__.'/Updates/successful_payment.json');
+
+    return [json_decode($file)];
+});
+
 dataset('edited_message', function () {
     $file = file_get_contents(__DIR__.'/Updates/edited_message.json');
 

--- a/tests/Updates/successful_payment.json
+++ b/tests/Updates/successful_payment.json
@@ -1,0 +1,29 @@
+{
+  "update_id": 1,
+  "message": {
+    "message_id": 123,
+    "from": {
+      "id": 456,
+      "is_bot": false,
+      "first_name": "Mario",
+      "username": "Bros",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 456,
+      "first_name": "Mario",
+      "username": "Bros",
+      "type": "private"
+    },
+    "date": 1684984664,
+    "successful_payment": {
+      "currency": "USD",
+      "total_amount": 100,
+      "invoice_payload": "thedata",
+      "shipping_option_id": null,
+      "order_info": null,
+      "telegram_payment_charge_id": "thepaymentid",
+      "provider_payment_charge_id": "theproviderid"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds 2 new handlers:
- `onSuccessfulPayment`
- `onSuccessfulPaymentPayload`


### Before this PR
```php
$bot->onMessageType(MessageTypes::SUCCESSFUL_PAYMENT, SuccessfulPaymentHandler::class);
```
```php
class SuccessfulPaymentHandler
{
    public function __invoke(Nutgram $bot): void
    {
        $payload = $bot->message()->successful_payment?->invoice_payload;

        if($payload === 'donation') {
            $bot->sendMessage('Thank you for your donation!');
            return;
        }

        if($payload === 'premium') {
            $bot->sendMessage('Thank you for your premium subscription!');
            return;
        }

        $bot->sendMessage('Thank you for your purchase!');
    }
}
```

### After this PR
```php
$bot->onSuccessfulPaymentPayload('donation', [SuccessfulPaymentHandler::class, 'donation']);
$bot->onSuccessfulPaymentPayload('premium', [SuccessfulPaymentHandler::class, 'premium']);
```
```php
class SuccessfulPaymentHandler
{
    public function donation(Nutgram $bot): void
    {
        $bot->sendMessage('Thank you for your donation!');
    }
    
    public function premium(Nutgram $bot): void
    {
        $bot->sendMessage('Thank you for premium subscription!');
    }
}
```