### PR TITLE
Optional enhanced command handler signature

### DIFF
--- a/src/Handlers/MessageHandlers.php
+++ b/src/Handlers/MessageHandlers.php
@@ -34,11 +34,9 @@ trait MessageHandlers
         if (is_array($command) && is_subclass_of($command[0], Command::class)) {
             //Case B: onCommand([CommandClass::class, 'method'])
             $commandClass = $command[0];
-        } else {
-            if (is_string($command) && is_subclass_of($command, Command::class)) {
-                //Case C: onCommand(CommandClass::class)
-                $commandClass = $command;
-            }
+        } elseif (is_string($command) && is_subclass_of($command, Command::class)) {
+            //Case C: onCommand(CommandClass::class)
+            $commandClass = $command;
         }
 
         if ($commandClass === null) {

--- a/src/Handlers/MessageHandlers.php
+++ b/src/Handlers/MessageHandlers.php
@@ -2,7 +2,7 @@
 
 namespace SergiX44\Nutgram\Handlers;
 
-use SergiX44\Nutgram\Handlers\Type\Command;
+use SergiX44\Nutgram\Handlers\Type\CommandHandler;
 use SergiX44\Nutgram\Telegram\Attributes\MessageTypes;
 use SergiX44\Nutgram\Telegram\Attributes\UpdateTypes;
 
@@ -14,13 +14,14 @@ trait MessageHandlers
     /**
      * @param  string  $command
      * @param $callable
-     * @return Command
+     * @return CommandHandler
      */
-    public function onCommand(string $command, $callable): Command
+    public function onCommand(string $command, $callable): CommandHandler
     {
         $command = "/$command";
 
-        return $this->handlers[UpdateTypes::MESSAGE][MessageTypes::TEXT][$command] = new Command($callable, $command);
+        return $this->handlers[UpdateTypes::MESSAGE][MessageTypes::TEXT][$command] = new CommandHandler($callable,
+            $command);
     }
 
     /**

--- a/src/Handlers/MessageHandlers.php
+++ b/src/Handlers/MessageHandlers.php
@@ -14,11 +14,11 @@ use SergiX44\Nutgram\Telegram\Attributes\UpdateTypes;
 trait MessageHandlers
 {
     /**
-     * @param  string  $command
-     * @param $callable
+     * @param  string|callable|array  $command
+     * @param  callable|array|null  $callable
      * @return CommandHandler
      */
-    public function onCommand(string $command, $callable = null): CommandHandler
+    public function onCommand($command, $callable = null): CommandHandler
     {
         if (is_subclass_of($command, Command::class)) {
             $commandName = "/{$command::$name}";

--- a/src/Handlers/Type/CommandHandler.php
+++ b/src/Handlers/Type/CommandHandler.php
@@ -5,7 +5,7 @@ namespace SergiX44\Nutgram\Handlers\Type;
 use SergiX44\Nutgram\Handlers\Handler;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommand;
 
-class Command extends Handler
+class CommandHandler extends Handler
 {
     protected ?string $description = null;
 
@@ -36,9 +36,9 @@ class Command extends Handler
 
     /**
      * @param  string  $description
-     * @return Command
+     * @return CommandHandler
      */
-    public function description(string $description): Command
+    public function description(string $description): CommandHandler
     {
         $this->description = $description;
         return $this;

--- a/src/Handlers/Type/CommandHandler.php
+++ b/src/Handlers/Type/CommandHandler.php
@@ -35,10 +35,10 @@ class CommandHandler extends Handler
     }
 
     /**
-     * @param  string  $description
+     * @param  string|null  $description
      * @return CommandHandler
      */
-    public function description(string $description): CommandHandler
+    public function description(?string $description): CommandHandler
     {
         $this->description = $description;
         return $this;

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -24,7 +24,7 @@ use SergiX44\Nutgram\Conversations\Conversation;
 use SergiX44\Nutgram\Exception\CannotSerializeException;
 use SergiX44\Nutgram\Handlers\Handler;
 use SergiX44\Nutgram\Handlers\ResolveHandlers;
-use SergiX44\Nutgram\Handlers\Type\Command;
+use SergiX44\Nutgram\Handlers\Type\CommandHandler;
 use SergiX44\Nutgram\Hydrator\Hydrator;
 use SergiX44\Nutgram\Hydrator\NutgramHydrator;
 use SergiX44\Nutgram\Proxies\GlobalCacheProxy;
@@ -396,7 +396,7 @@ class Nutgram extends ResolveHandlers
     {
         $commands = [];
         array_walk_recursive($this->handlers, static function ($handler) use (&$commands) {
-            if ($handler instanceof Command && !$handler->isHidden()) {
+            if ($handler instanceof CommandHandler && !$handler->isHidden()) {
                 $commands[] = $handler->toBotCommand();
             }
         });

--- a/src/Support/Command.php
+++ b/src/Support/Command.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SergiX44\Nutgram\Support;
+
+abstract class Command
+{
+    public static string $name;
+
+    public static ?string $description = null;
+
+    public static array $middlewares = [];
+
+    public static ?array $skipGlobalMiddlewares = null;
+}

--- a/tests/Datasets/command_abstract.php
+++ b/tests/Datasets/command_abstract.php
@@ -1,0 +1,12 @@
+<?php
+
+use SergiX44\Nutgram\Tests\Feature\OOP\TestCommand;
+
+dataset('command_abstract', function () {
+    $file = file_get_contents(__DIR__.'/../Updates/command.json');
+
+    return [
+        'class-string' => [json_decode($file), TestCommand::class, 'command called'],
+        'array' => [json_decode($file), [TestCommand::class, 'suchwow'], 'such command called'],
+    ];
+});

--- a/tests/Feature/CollectHandlersTest.php
+++ b/tests/Feature/CollectHandlersTest.php
@@ -5,6 +5,8 @@ use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Attributes\MessageTypes;
 use SergiX44\Nutgram\Telegram\Attributes\UpdateTypes;
 use SergiX44\Nutgram\Telegram\Exceptions\TelegramException;
+use SergiX44\Nutgram\Tests\Feature\OOP\MiddlewareA;
+use SergiX44\Nutgram\Tests\Feature\OOP\TestCommand;
 
 it('calls middleware() handler', function ($update) {
     $bot = Nutgram::fake($update);
@@ -30,6 +32,30 @@ it('calls onCommand() handler', function ($update) {
     $bot->run();
 
     expect($bot->getData('called'))->toBeTrue();
+})->with('command');
+
+it('calls onCommand() handler without callable', function ($update) {
+    $bot = Nutgram::fake($update);
+    $bot->onCommand('test');
+    $bot->run();
+})->with('command')->throws(InvalidArgumentException::class, 'You must provide a callable');
+
+it('calls onCommand() handler with abstract class Command', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->middleware(MiddlewareA::class);
+
+    $handler = $bot->onCommand(TestCommand::class);
+
+    $bot->run();
+
+    expect($bot->getData('command called'))->toBeTrue();
+    expect($bot->getData('middlewareA', false))->toBeFalse();
+    expect($bot->getData('middlewareB', false))->toBeTrue();
+
+    expect($handler)
+        ->getName()->toBe('test')
+        ->getDescription()->toBe('This is a test command');
 })->with('command');
 
 it('calls onCommand() handler with different tags', function ($update, $valid) {

--- a/tests/Feature/CollectHandlersTest.php
+++ b/tests/Feature/CollectHandlersTest.php
@@ -6,7 +6,6 @@ use SergiX44\Nutgram\Telegram\Attributes\MessageTypes;
 use SergiX44\Nutgram\Telegram\Attributes\UpdateTypes;
 use SergiX44\Nutgram\Telegram\Exceptions\TelegramException;
 use SergiX44\Nutgram\Tests\Feature\OOP\MiddlewareA;
-use SergiX44\Nutgram\Tests\Feature\OOP\TestCommand;
 
 it('calls middleware() handler', function ($update) {
     $bot = Nutgram::fake($update);
@@ -40,23 +39,31 @@ it('calls onCommand() handler without callable', function ($update) {
     $bot->run();
 })->with('command')->throws(InvalidArgumentException::class, 'You must provide a callable');
 
-it('calls onCommand() handler with abstract class Command', function ($update) {
+it('calls onCommand() handler with abstract class Command', function ($update, $handler, $data) {
     $bot = Nutgram::fake($update);
 
     $bot->middleware(MiddlewareA::class);
 
-    $handler = $bot->onCommand(TestCommand::class);
+    $handler = $bot->onCommand($handler);
 
     $bot->run();
 
-    expect($bot->getData('command called'))->toBeTrue();
+    expect($bot->getData($data))->toBeTrue();
     expect($bot->getData('middlewareA', false))->toBeFalse();
     expect($bot->getData('middlewareB', false))->toBeTrue();
 
     expect($handler)
         ->getName()->toBe('test')
         ->getDescription()->toBe('This is a test command');
-})->with('command');
+})->with('command_abstract');
+
+it('calls onCommand() handler with invalid callable', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onCommand(123);
+
+    $bot->run();
+})->with('command')->throws(InvalidArgumentException::class, 'You must provide a valid Command class');
 
 it('calls onCommand() handler with different tags', function ($update, $valid) {
     $bot = Nutgram::fake($update, config: ['bot_name' => 'foo']);

--- a/tests/Feature/OOP/MiddlewareA.php
+++ b/tests/Feature/OOP/MiddlewareA.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SergiX44\Nutgram\Tests\Feature\OOP;
+
+use SergiX44\Nutgram\Nutgram;
+
+class MiddlewareA
+{
+    public function __invoke(Nutgram $bot, $next)
+    {
+        $bot->setData('middlewareA', true);
+        $next($bot);
+    }
+}

--- a/tests/Feature/OOP/MiddlewareB.php
+++ b/tests/Feature/OOP/MiddlewareB.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SergiX44\Nutgram\Tests\Feature\OOP;
+
+use SergiX44\Nutgram\Nutgram;
+
+class MiddlewareB
+{
+    public function __invoke(Nutgram $bot, $next)
+    {
+        $bot->setData('middlewareB', true);
+        $next($bot);
+    }
+}

--- a/tests/Feature/OOP/TestCommand.php
+++ b/tests/Feature/OOP/TestCommand.php
@@ -19,4 +19,9 @@ class TestCommand extends Command
     {
         $bot->setData('command called', true);
     }
+
+    public function suchwow(Nutgram $bot): void
+    {
+        $bot->setData('such command called', true);
+    }
 }

--- a/tests/Feature/OOP/TestCommand.php
+++ b/tests/Feature/OOP/TestCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SergiX44\Nutgram\Tests\Feature\OOP;
+
+use SergiX44\Nutgram\Nutgram;
+use SergiX44\Nutgram\Support\Command;
+
+class TestCommand extends Command
+{
+    public static string $name = 'test';
+
+    public static ?string $description = 'This is a test command';
+
+    public static array $middlewares = [MiddlewareB::class];
+
+    public static ?array $skipGlobalMiddlewares = [];
+
+    public function __invoke(Nutgram $bot): void
+    {
+        $bot->setData('command called', true);
+    }
+}


### PR DESCRIPTION
# Before

```php
// TestCommand class

use SergiX44\Nutgram\Nutgram;

class TestCommand
{
    public function __invoke(Nutgram $bot): void
    {
        // your code
    }
}
```
```php
// Nutgram handlers

$bot = new Nutgram($token);

$bot->onCommand('/test', TestCommand::class)
      ->description('This is a test command')
      ->middleware(MiddlewareA::class)
      ->skipGlobalMiddlewares([MiddlewareB::class]);

$bot->run();

```

# After

```php
// TestCommand class

use SergiX44\Nutgram\Nutgram;
use SergiX44\Nutgram\Support\Command;

class TestCommand extends Command
{
    public static string $name = 'test';

    public static ?string $description = 'This is a test command';

    public static array $middlewares = [MiddlewareA::class];

    public static ?array $skipGlobalMiddlewares = [MiddlewareB::class];

    public function __invoke(Nutgram $bot): void
    {
        // your code
    }
}
```

```php
// Nutgram handlers

$bot = new Nutgram($token);

$bot->onCommand(TestCommand::class);

$bot->run();

```