### PR TITLE
Add parameters support to TelegramException

### DIFF
--- a/src/Telegram/Client.php
+++ b/src/Telegram/Client.php
@@ -313,9 +313,10 @@ trait Client
         }
 
         $e = new TelegramException(
-            $json?->description ?? 'Client exception',
-            $json?->error_code ?? 0,
-            $clientException
+            message: $json?->description ?? 'Client exception',
+            code: $json?->error_code ?? 0,
+            parameters: (array)($json?->parameters ?? []),
+            previous: $clientException
         );
 
         if (!empty($this->handlers[self::API_ERROR])) {

--- a/src/Telegram/Client.php
+++ b/src/Telegram/Client.php
@@ -315,8 +315,8 @@ trait Client
         $e = new TelegramException(
             message: $json?->description ?? 'Client exception',
             code: $json?->error_code ?? 0,
+            previous: $clientException,
             parameters: (array)($json?->parameters ?? []),
-            previous: $clientException
         );
 
         if (!empty($this->handlers[self::API_ERROR])) {

--- a/src/Telegram/Exceptions/TelegramException.php
+++ b/src/Telegram/Exceptions/TelegramException.php
@@ -6,14 +6,33 @@ use Exception;
 
 class TelegramException extends Exception
 {
+    protected array $parameters;
+
     /**
      * TelegramException constructor.
      * @param $message
      * @param  int  $code
-     * @param  Exception|null  $previous
+     * @param  array  $parameters
+     * @param  null  $previous
      */
-    public function __construct($message, $code = 0, Exception $previous = null)
+    public function __construct($message, $code = 0, array $parameters = [], $previous = null)
     {
+        $this->parameters = $parameters;
         parent::__construct($message, $code, $previous);
+    }
+
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    public function getParameter(string $key, mixed $default = null): mixed
+    {
+        return $this->parameters[$key] ?? $default;
+    }
+
+    public function hasParameter(string $key): bool
+    {
+        return array_key_exists($key, $this->parameters);
     }
 }

--- a/src/Telegram/Exceptions/TelegramException.php
+++ b/src/Telegram/Exceptions/TelegramException.php
@@ -15,7 +15,7 @@ class TelegramException extends Exception
      * @param  array  $parameters
      * @param  null  $previous
      */
-    public function __construct($message, $code = 0, array $parameters = [], $previous = null)
+    public function __construct($message, $code = 0, $previous = null, array $parameters = [])
     {
         $this->parameters = $parameters;
         parent::__construct($message, $code, $previous);

--- a/tests/Datasets/too_many_requests.php
+++ b/tests/Datasets/too_many_requests.php
@@ -1,0 +1,6 @@
+<?php
+
+dataset('too_many_requests', function () {
+    $file = file_get_contents(__DIR__.'/../Responses/too_many_requests.json');
+    return [$file];
+});

--- a/tests/Feature/ApiErrorTest.php
+++ b/tests/Feature/ApiErrorTest.php
@@ -79,3 +79,22 @@ it('throws exception if no handler specified', function ($responseBody) {
 
     $bot->sendMessage('hi');
 })->with('response_wrong_file_id')->expectException(TelegramException::class);
+
+
+it('throws exception if too many requests', function ($responseBody) {
+    $bot = Nutgram::fake(responses: [
+        new Response(429, body: $responseBody),
+    ]);
+
+    try {
+        $bot->sendMessage('hi');
+    } catch (TelegramException $e) {
+        expect($e)->toBeInstanceOf(TelegramException::class)
+            ->getMessage()->toBe('Too Many Requests: retry after 14')
+            ->getCode()->toBe(429)
+            ->getParameters()->toBe(['retry_after' => 14])
+            ->getParameter('retry_after')->toBe(14)
+            ->hasParameter('retry_after')->toBeTrue()
+            ->hasParameter('foo')->toBeFalse();
+    }
+})->with('too_many_requests');

--- a/tests/Responses/too_many_requests.json
+++ b/tests/Responses/too_many_requests.json
@@ -1,0 +1,8 @@
+{
+  "ok": false,
+  "error_code": 429,
+  "description": "Too Many Requests: retry after 14",
+  "parameters": {
+    "retry_after": 14
+  }
+}


### PR DESCRIPTION
```php
$bot->onApiError('.*Too Many Requests.*', function(Nutgram $bot, TelegramException $e){
    $e->getParameters(); // ['retry_after' => 14]
    $e->getParameter('retry_after'); // 14
    $e->hasParameter('retry_after'); // true
});
```