### PR TITLE
Add Laravel logger

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
             <directory suffix=".php">./tests</directory>
             <directory suffix=".php">./src/Telegram/Endpoints</directory>
             <directory suffix=".php">./src/Telegram/Types</directory>
+            <directory suffix=".php">./src/Laravel/Log</directory>
             <directory suffix=".php">./src/RunningMode</directory>
             <file>./src/NutgramServiceProvider.php</file>
             <file>./src/Laravel/Commands/RunCommand.php</file>

--- a/src/Laravel/Log/LoggerHandler.php
+++ b/src/Laravel/Log/LoggerHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SergiX44\Nutgram\Laravel\Log;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
+use SergiX44\Nutgram\Nutgram;
+
+class LoggerHandler extends AbstractProcessingHandler
+{
+    protected Nutgram $bot;
+
+    protected string|int $chat_id;
+
+    public function __construct(array $config)
+    {
+        parent::__construct(Logger::toMonologLevel($config['level']), true);
+
+        $this->bot = app(Nutgram::class);
+        $this->chat_id = $config['chat_id'];
+    }
+
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new LineFormatter("%message% %context% %extra%\n");
+    }
+
+    protected function write(array $record): void
+    {
+        $oldSplitConfig = config('nutgram.config.split_long_messages', false);
+        config(['nutgram.config.split_long_messages' => true]);
+
+        $this->bot->sendMessage($this->formatText($record), [
+            'chat_id' => $this->chat_id,
+            'parse_mode' => 'html',
+        ]);
+
+        config(['nutgram.config.split_long_messages' => $oldSplitConfig]);
+    }
+
+    protected function formatText(array $record): string
+    {
+        return sprintf("<b>%s %s</b> (%s):\n<pre>%s</pre>",
+            config('app.name'),
+            $record['level_name'],
+            config('app.env'),
+            $record['formatted']
+        );
+    }
+}

--- a/src/Laravel/Log/NutgramLogger.php
+++ b/src/Laravel/Log/NutgramLogger.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SergiX44\Nutgram\Laravel\Log;
+
+use Monolog\Logger;
+
+class NutgramLogger
+{
+    public function __invoke(array $config)
+    {
+        return new Logger(
+            name: config('app.name'),
+            handlers: [new LoggerHandler($config)]
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a new logging driver for Laravel useful for printing errors and informations to your chat.

```php
// config/logger.php

'telegram' => [
    'driver' => 'custom',
    'via' => NutgramLogger::class,
    'level' => 'debug',
    'chat_id' => env('NUTGRAM_LOG_CHAT_ID'), // any chat_id where bot can write messages
]
```