### PR TITLE
Add arguments support to Middlewares

### DIFF
--- a/src/Middleware/Link.php
+++ b/src/Middleware/Link.php
@@ -38,6 +38,7 @@ class Link
      */
     public function __invoke(Nutgram $bot): mixed
     {
-        return call_user_func($bot->resolve($this->callable), $bot, $this->next);
+        $args = $bot->resolveArguments($this->callable);
+        return call_user_func($bot->resolve($this->callable), $bot, $this->next, ...$args);
     }
 }

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -383,8 +383,13 @@ class Nutgram extends ResolveHandlers
         }
 
         // if passing a class, we probably want resolve that and call the __invoke method
-        if (is_string($callable) && class_exists($callable)) {
-            $callable = $this->container->get($callable);
+        if (is_string($callable)) {
+
+            [$callable,] = explode(':', $callable);
+
+            if (class_exists($callable)) {
+                $callable = $this->container->get($callable);
+            }
         }
 
         if (!is_callable($callable)) {
@@ -392,6 +397,16 @@ class Nutgram extends ResolveHandlers
         }
 
         return $callable;
+    }
+
+    public function resolveArguments(callable|array|string $callable): array
+    {
+        if (is_string($callable)) {
+            [, $parameters] = array_pad(explode(':', $callable), 2, null);
+            return array_filter(explode(',', $parameters));
+        }
+
+        return [];
     }
 
     /**

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -70,9 +70,23 @@ it('calls the message handler with multiple middlewares', function ($update) {
 it('calls the message handler with a middleware with parameters', function ($update) {
     $bot = Nutgram::fake($update);
 
-    $bot->onMessage(function ($bot) use (&$test) {
-        $test .= 'B';
+    $bot->onMessage(function ($bot) {
+        // your code
     })->middleware(FoodMiddleware::class.':pizza');
+
+    $bot->run();
+
+    expect($bot->getData('food'))->toBe('pizza');
+})->with('message');
+
+it('calls the message handler with a global middleware with parameters', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->middleware(FoodMiddleware::class.':pizza');
+
+    $bot->onMessage(function ($bot) {
+        // your code
+    });
 
     $bot->run();
 

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -9,6 +9,7 @@ use SergiX44\Nutgram\Telegram\Types\Chat\ChatMemberOwner;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommand;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
 use SergiX44\Nutgram\Tests\Fixtures\TestStartCommand;
+use SergiX44\Nutgram\Tests\Middlewares\FoodMiddleware;
 
 it('calls the message handler', function ($update) {
     $bot = Nutgram::fake($update);
@@ -64,6 +65,18 @@ it('calls the message handler with multiple middlewares', function ($update) {
     $bot->run();
 
     expect($test)->toBe('ABCD');
+})->with('message');
+
+it('calls the message handler with a middleware with parameters', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onMessage(function ($bot) use (&$test) {
+        $test .= 'B';
+    })->middleware(FoodMiddleware::class.':pizza');
+
+    $bot->run();
+
+    expect($bot->getData('food'))->toBe('pizza');
 })->with('message');
 
 it('calls the fallback if not match any handler', function ($update) {

--- a/tests/Middlewares/FoodMiddleware.php
+++ b/tests/Middlewares/FoodMiddleware.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SergiX44\Nutgram\Tests\Middlewares;
+
+use SergiX44\Nutgram\Nutgram;
+
+class FoodMiddleware
+{
+    public function __invoke(Nutgram $bot, $next, $type): void
+    {
+        $bot->setData('food', $type);
+        $next($bot);
+    }
+}


### PR DESCRIPTION
⚠️ For class-string only

```php
// no arguments
$bot->onCommand('start', StartCommand::class)->middleware(AdminMiddleware::class);
$bot->onCommand('help', HelpCommand::class)->middleware(GuestMiddleware::class);

// with arguments
$bot->onCommand('start', StartCommand::class)->middleware(PermissionMiddleware::class.':admin');
$bot->onCommand('help', HelpCommand::class)->middleware(PermissionMiddleware::class.':guest');

class PermissionMiddleware
{
    public function __invoke(Nutgram $bot, $next, $role): void
    {
        //TODO: use $role for check permission

        $next($bot);
    }
}

// with multiple arguments
$bot->onCommand('start', StartCommand::class)->middleware(PermissionMiddleware::class.':admin,lvl1,ok');

class PermissionMiddleware
{
    public function __invoke(Nutgram $bot, $next, $role, $lvl, $ok): void
    {
        // $role = 'admin';
        // $lvl= 'lvl1';
        // $ok= 'ok';

        $next($bot);
    }
}
```