### PR TITLE
Hide commands

### DIFF
--- a/src/Handlers/Type/Command.php
+++ b/src/Handlers/Type/Command.php
@@ -41,9 +41,10 @@ class Command extends Handler
     }
 
     /**
+     * @param  Nutgram  $bot
      * @return bool
      */
-    public function isHidden(): bool
+    public function isHidden(Nutgram $bot): bool
     {
         return empty($this->getDescription());
     }

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -400,8 +400,8 @@ class Nutgram extends ResolveHandlers
     public function registerMyCommands(array $opt = []): bool|null
     {
         $commands = [];
-        array_walk_recursive($this->handlers, static function ($handler) use (&$commands) {
-            if ($handler instanceof Command && !$handler->isHidden()) {
+        array_walk_recursive($this->handlers, function ($handler) use (&$commands) {
+            if ($handler instanceof Command && !$handler->isHidden($this)) {
                 $commands[] = $handler->toBotCommand();
             }
         });

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -453,15 +453,15 @@ test('commands can have descriptions', function ($update) {
 
     expect($cmd1->getName())->toBe('help');
     expect($cmd1->getDescription())->toBe('test');
-    expect($cmd1->isHidden())->toBeFalse();
+    expect($cmd1->isHidden($bot))->toBeFalse();
 
     expect($cmd2->getName())->toBe('start');
     expect($cmd2->getDescription())->toBe('test2');
-    expect($cmd2->isHidden())->toBeFalse();
+    expect($cmd2->isHidden($bot))->toBeFalse();
 
     expect($cmd3->getName())->toBe('end');
     expect($cmd3->getDescription())->toBeNull();
-    expect($cmd3->isHidden())->toBeTrue();
+    expect($cmd3->isHidden($bot))->toBeTrue();
 })->with('command_message');
 
 


### PR DESCRIPTION
```php
namespace App\Telegram\Commands;

use SergiX44\Nutgram\Handlers\Type\Command;
use SergiX44\Nutgram\Nutgram;

class HiddenCommand extends Command
{
    protected string $command = 'admin';

    protected ?string $description = 'Admin command';

    public function handle(Nutgram $bot): void
    {
        if ($this->isHidden($bot)) {
            return;
        }

        $bot->sendMessage('Shhh!');
    }

    public function isHidden(Nutgram $bot): bool
    {
        return $bot->getUserData('commands', default: [])[$this->command]['hidden'] ?? true;
    }
}
```