### PR TITLE
Update to Bot Api 6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nutgram/nutgram.svg?style=flat-square)](https://packagist.org/packages/nutgram/nutgram)
 [![Total Downloads](https://img.shields.io/packagist/dt/nutgram/nutgram.svg?style=flat-square)](https://packagist.org/packages/nutgram/nutgram)
 ![GitHub](https://img.shields.io/github/license/nutgram/nutgram)
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-6.4%09--%20December%2030,%202022-blue.svg)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-6.5%09--%20February%203,%202023-blue.svg)](https://core.telegram.org/bots/api)
 
 [![Test Suite](https://github.com/nutgram/nutgram/actions/workflows/php.yml/badge.svg)](https://github.com/nutgram/nutgram/actions/workflows/php.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/86c4ca3dae8f64db80f7/maintainability)](https://codeclimate.com/github/nutgram/nutgram/maintainability)

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -752,6 +752,7 @@ trait AvailableMethods
      * @param  int  $user_id Unique identifier of the target user
      * @param  ChatPermissions  $permissions An object for new user permissions
      * @param  array{
+     *     use_independent_chat_permissions?:bool,
      *     until_date?:int
      * }  $opt
      * @return bool|null
@@ -858,7 +859,9 @@ trait AvailableMethods
      * @param  string|int  $chat_id Unique identifier for the target chat or username of the target supergroup (in the
      *     format [at]supergroupusername)
      * @param  ChatPermissions  $permissions New default chat permissions
-     * @param  array  $opt
+     * @param  array{
+     *     use_independent_chat_permissions?:bool
+     * }  $opt
      * @return bool|null
      */
     public function setChatPermissions(string|int $chat_id, ChatPermissions $permissions, array $opt = []): ?bool

--- a/src/Telegram/Types/Chat/ChatJoinRequest.php
+++ b/src/Telegram/Types/Chat/ChatJoinRequest.php
@@ -22,6 +22,17 @@ class ChatJoinRequest extends BaseType
     public User $from;
 
     /**
+     * Identifier of a private chat with the user who sent the join request.
+     * This number may have more than 32 significant bits and some programming languages
+     * may have difficulty/silent defects in interpreting it.
+     * But it has at most 52 significant bits, so a 64-bit integer or double-precision float type
+     * are safe for storing this identifier.
+     * The bot can use this identifier for 24 hours to send messages until the join request is processed,
+     * assuming no other administrator contacted the user.
+     */
+    public int $user_chat_id;
+
+    /**
      * Date the request was sent in Unix time
      */
     public int $date;

--- a/src/Telegram/Types/Chat/ChatMemberRestricted.php
+++ b/src/Telegram/Types/Chat/ChatMemberRestricted.php
@@ -48,10 +48,34 @@ class ChatMemberRestricted extends ChatMember
     public ?bool $can_send_messages = null;
 
     /**
-     * True, if the user can send audios, documents, photos, videos,
-     * video notes and voice notes, implies can_send_messages
+     * True, if the user is allowed to send audios
      */
-    public ?bool $can_send_media_messages = null;
+    public ?bool $can_send_audios = null;
+
+    /**
+     * True, if the user is allowed to send documents
+     */
+    public ?bool $can_send_documents = null;
+
+    /**
+     * True, if the user is allowed to send photos
+     */
+    public ?bool $can_send_photos = null;
+
+    /**
+     * True, if the user is allowed to send videos
+     */
+    public ?bool $can_send_videos = null;
+
+    /**
+     * True, if the user is allowed to send video notes
+     */
+    public ?bool $can_send_video_notes = null;
+
+    /**
+     * True, if the user is allowed to send voice notes
+     */
+    public ?bool $can_send_voice_notes = null;
 
     /**
      * True, if the user is allowed to send polls

--- a/src/Telegram/Types/Chat/ChatPermissions.php
+++ b/src/Telegram/Types/Chat/ChatPermissions.php
@@ -16,10 +16,34 @@ class ChatPermissions extends BaseType
     public ?bool $can_send_messages = null;
 
     /**
-     * Optional. True, if the user is allowed to send audios, documents, photos, videos, video notes and voice notes,
-     * implies can_send_messages
+     * Optional. True, if the user is allowed to send audios
      */
-    public ?bool $can_send_media_messages = null;
+    public ?bool $can_send_audios = null;
+
+    /**
+     * Optional. True, if the user is allowed to send documents
+     */
+    public ?bool $can_send_documents = null;
+
+    /**
+     * Optional. True, if the user is allowed to send photos
+     */
+    public ?bool $can_send_photos = null;
+
+    /**
+     * Optional. True, if the user is allowed to send videos
+     */
+    public ?bool $can_send_videos = null;
+
+    /**
+     * Optional. True, if the user is allowed to send video notes
+     */
+    public ?bool $can_send_video_notes = null;
+
+    /**
+     * Optional. True, if the user is allowed to send voice notes
+     */
+    public ?bool $can_send_voice_notes = null;
 
     /**
      * Optional. True, if the user is allowed to send polls, implies can_send_messages

--- a/src/Telegram/Types/Keyboard/KeyboardButton.php
+++ b/src/Telegram/Types/Keyboard/KeyboardButton.php
@@ -11,8 +11,18 @@ use SergiX44\Nutgram\Telegram\Types\WebApp\WebAppInfo;
  * For simple text buttons String can be used instead of this object to specify text of the button.
  * Optional fields are mutually exclusive.
  *
- * Note: request_contact and request_location options will only work in Telegram versions released after 9 April, 2016.
+ * **Note**: request_contact and request_location options will only work in Telegram versions released after 9 April, 2016.
  * Older clients will ignore them.
+ *
+ * **Note**: request_poll option will only work in Telegram versions released after 23 January, 2020.
+ * Older clients will display unsupported message.
+ *
+ * **Note**: web_app option will only work in Telegram versions released after 16 April, 2022.
+ * Older clients will display unsupported message.
+ *
+ * **Note**: request_user and request_chat options will only work in Telegram versions released after 3 February, 2023.
+ * Older clients will display unsupported message.
+ *
  * @see https://core.telegram.org/bots/api#keyboardbutton
  */
 class KeyboardButton extends BaseType implements JsonSerializable
@@ -22,6 +32,20 @@ class KeyboardButton extends BaseType implements JsonSerializable
      * If none of the optional fields are used, it will be sent to the bot as a message when the button is pressed
      */
     public string $text;
+
+    /**
+     * Optional. If specified, pressing the button will open a list of suitable users.
+     * Tapping on any user will send their identifier to the bot in a “user_shared” service message.
+     * Available in private chats only.
+     */
+    public ?KeyboardButtonRequestUser $request_user = null;
+
+    /**
+     * Optional. If specified, pressing the button will open a list of suitable chats.
+     * Tapping on a chat will send its identifier to the bot in a “chat_shared” service message.
+     * Available in private chats only.
+     */
+    public ?KeyboardButtonRequestChat $request_chat = null;
 
     /**
      * Optional. If True, the user's phone number will be sent as a contact when the button is pressed.
@@ -55,6 +79,8 @@ class KeyboardButton extends BaseType implements JsonSerializable
         ?bool $request_location = null,
         ?KeyboardButtonPollType $request_poll = null,
         ?WebAppInfo $web_app = null,
+        ?KeyboardButtonRequestUser $request_user = null,
+        ?KeyboardButtonRequestChat $request_chat = null,
     ) {
         parent::__construct();
         $this->text = $text;
@@ -62,6 +88,8 @@ class KeyboardButton extends BaseType implements JsonSerializable
         $this->request_location = $request_location;
         $this->request_poll = $request_poll;
         $this->web_app = $web_app;
+        $this->request_user = $request_user;
+        $this->request_chat = $request_chat;
     }
 
     public static function make(
@@ -70,6 +98,8 @@ class KeyboardButton extends BaseType implements JsonSerializable
         ?bool $request_location = null,
         ?KeyboardButtonPollType $request_poll = null,
         ?WebAppInfo $web_app = null,
+        ?KeyboardButtonRequestUser $request_user = null,
+        ?KeyboardButtonRequestChat $request_chat = null,
     ): self {
         return new self(
             $text,
@@ -77,6 +107,8 @@ class KeyboardButton extends BaseType implements JsonSerializable
             $request_location,
             $request_poll,
             $web_app,
+            $request_user,
+            $request_chat,
         );
     }
 
@@ -84,6 +116,8 @@ class KeyboardButton extends BaseType implements JsonSerializable
     {
         return array_filter([
             'text' => $this->text,
+            'request_user' => $this->request_user,
+            'request_chat' => $this->request_chat,
             'request_contact' => $this->request_contact,
             'request_location' => $this->request_location,
             'request_poll' => $this->request_poll,

--- a/src/Telegram/Types/Keyboard/KeyboardButtonRequestChat.php
+++ b/src/Telegram/Types/Keyboard/KeyboardButtonRequestChat.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Keyboard;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Chat\ChatAdministratorRights;
+
+/**
+ * This object defines the criteria used to request a suitable chat.
+ * The identifier of the selected chat will be shared with the bot when the corresponding button is pressed.
+ * @see https://core.telegram.org/bots/api#keyboardbuttonrequestchat
+ */
+class KeyboardButtonRequestChat extends BaseType
+{
+    /**
+     * Signed 32-bit identifier of the request
+     */
+    public int $request_id;
+
+    /**
+     * Pass True to request a channel chat, pass False to request a group or a supergroup chat.
+     */
+    public bool $chat_is_channel;
+
+    /**
+     * Optional. Pass True to request a forum supergroup, pass False to request a non-forum chat.
+     * If not specified, no additional restrictions are applied.
+     */
+    public ?bool $chat_is_forum = null;
+
+    /**
+     * Optional. Pass True to request a supergroup or a channel with a username,
+     * pass False to request a chat without a username.
+     * If not specified, no additional restrictions are applied.
+     */
+    public ?bool $chat_has_username = null;
+
+    /**
+     * Optional. Pass True to request a chat owned by the user.
+     * Otherwise, no additional restrictions are applied.
+     */
+    public ?bool $chat_is_created = null;
+
+    /**
+     * Optional. A JSON-serialized object listing the required administrator rights of the user in the chat.
+     * If not specified, no additional restrictions are applied.
+     */
+    public ?ChatAdministratorRights $user_administrator_rights = null;
+
+    /**
+     * Optional. A JSON-serialized object listing the required administrator rights of the bot in the chat.
+     * The rights must be a subset of user_administrator_rights. If not specified, no additional restrictions are applied.
+     */
+    public ?ChatAdministratorRights $bot_administrator_rights = null;
+
+    /**
+     * Optional. Pass True to request a chat with the bot as a member.
+     * Otherwise, no additional restrictions are applied.
+     */
+    public ?bool $bot_is_member = null;
+}

--- a/src/Telegram/Types/Keyboard/KeyboardButtonRequestUser.php
+++ b/src/Telegram/Types/Keyboard/KeyboardButtonRequestUser.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Keyboard;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object defines the criteria used to request a suitable user.
+ * The identifier of the selected user will be shared with the bot when the corresponding button is pressed.
+ * @see https://core.telegram.org/bots/api#keyboardbuttonrequestuser
+ */
+class KeyboardButtonRequestUser extends BaseType
+{
+    /**
+     * Signed 32-bit identifier of the request
+     */
+    public int $request_id;
+
+    /**
+     * Optional. Pass True to request a bot, pass False to request a regular user.
+     * If not specified, no additional restrictions are applied.
+     */
+    public ?bool $user_is_bot = null;
+
+    /**
+     * Optional. Pass True to request a premium user, pass False to request a non-premium user.
+     * If not specified, no additional restrictions are applied.
+     */
+    public ?bool $user_is_premium = null;
+}

--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -31,6 +31,8 @@ use SergiX44\Nutgram\Telegram\Types\Passport\PassportData;
 use SergiX44\Nutgram\Telegram\Types\Payment\Invoice;
 use SergiX44\Nutgram\Telegram\Types\Payment\SuccessfulPayment;
 use SergiX44\Nutgram\Telegram\Types\Poll\Poll;
+use SergiX44\Nutgram\Telegram\Types\Shared\ChatShared;
+use SergiX44\Nutgram\Telegram\Types\Shared\UserShared;
 use SergiX44\Nutgram\Telegram\Types\Sticker\Sticker;
 use SergiX44\Nutgram\Telegram\Types\User\User;
 use SergiX44\Nutgram\Telegram\Types\VideoChat\VideoChatEnded;
@@ -353,6 +355,16 @@ class Message extends BaseType
      * @see https://core.telegram.org/bots/api#payments More about payments
      */
     public ?SuccessfulPayment $successful_payment = null;
+
+    /**
+     * Optional. Service message: a user was shared with the bot
+     */
+    public ?UserShared $user_shared = null;
+
+    /**
+     * Optional. Service message: a chat was shared with the bot
+     */
+    public ?ChatShared $chat_shared = null;
 
     /**
      * Optional. The domain name of the website on which the user has logged in.

--- a/src/Telegram/Types/Shared/ChatShared.php
+++ b/src/Telegram/Types/Shared/ChatShared.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Shared;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object contains information about the chat whose identifier was shared with the bot using a
+ * {@see https://core.telegram.org/bots/api#keyboardbuttonrequestchat KeyboardButtonRequestChat} button.
+ * @see https://core.telegram.org/bots/api#chatshared
+ */
+class ChatShared extends BaseType
+{
+    /**
+     * Identifier of the request
+     */
+    public int $request_id;
+
+    /**
+     * Identifier of the shared chat. This number may have more than 32 significant bits and
+     * some programming languages may have difficulty/silent defects in interpreting it.
+     * But it has at most 52 significant bits, so a 64-bit integer or double-precision float type
+     * are safe for storing this identifier.
+     * The bot may not have access to the chat and could be unable to use this identifier,
+     * unless the chat is already known to the bot by some other means.
+     */
+    public int $chat_id;
+}

--- a/src/Telegram/Types/Shared/UserShared.php
+++ b/src/Telegram/Types/Shared/UserShared.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Shared;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object contains information about the user whose identifier was shared with the bot using a
+ * {@see https://core.telegram.org/bots/api#keyboardbuttonrequestuser KeyboardButtonRequestUser} button.
+ * @see https://core.telegram.org/bots/api#usershared
+ */
+class UserShared extends BaseType
+{
+    /**
+     * Identifier of the request
+     */
+    public int $request_id;
+
+    /**
+     * Identifier of the shared user. This number may have more than 32 significant bits and
+     * some programming languages may have difficulty/silent defects in interpreting it.
+     * But it has at most 52 significant bits, so a 64-bit integer or double-precision float type
+     * are safe for storing this identifier.
+     * The bot may not have access to the user and could be unable to use this identifier,
+     * unless the user is already known to the bot by some other means.
+     */
+    public int $user_id;
+}

--- a/tests/Updates/chat_join_request.json
+++ b/tests/Updates/chat_join_request.json
@@ -15,6 +15,7 @@
       "last_name": "Bros",
       "username": "mariobros"
     },
+    "user_chat_id": 123654789,
     "date": 123456789
   }
 }


### PR DESCRIPTION
https://core.telegram.org/bots/api#february-3-2023

**Bot API 6.5 - February 3, 2023**

- Added [requests for users and chats](https://telegram.org/blog/profile-pics-emoji-translations#chat-selection-for-bots) and support for [granular media permissions](https://telegram.org/blog/profile-pics-emoji-translations#granular-media-permissions).
- Added the class [KeyboardButtonRequestUser](https://core.telegram.org/bots/api#keyboardbuttonrequestuser) and the field request_user to the class [KeyboardButton](https://core.telegram.org/bots/api#keyboardbutton).
- Added the class [KeyboardButtonRequestChat](https://core.telegram.org/bots/api#keyboardbuttonrequestchat) and the field request_chat to the class [KeyboardButton](https://core.telegram.org/bots/api#keyboardbutton).
- Added the classes [UserShared](https://core.telegram.org/bots/api#usershared), [ChatShared](https://core.telegram.org/bots/api#chatshared) and the fields user_shared, and chat_shared to the class [Message](https://core.telegram.org/bots/api#message).
- Replaced the fields can_send_media_messages in the classes [ChatMemberRestricted](https://core.telegram.org/bots/api#chatmemberrestricted) and [ChatPermissions](https://core.telegram.org/bots/api#chatpermissions) with separate fields can_send_audios, can_send_documents, can_send_photos, can_send_videos, can_send_video_notes, and can_send_voice_notes for different media types.
- Added the parameter use_independent_chat_permissions to the methods [restrictChatMember](https://core.telegram.org/bots/api#restrictchatmember) and [setChatPermissions](https://core.telegram.org/bots/api#setchatpermissions).
- Added the field user_chat_id to the class [ChatJoinRequest](https://core.telegram.org/bots/api#chatjoinrequest).