### PR TITLE
Fix regex groups

### DIFF
--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -64,21 +64,17 @@ class Handler extends MiddlewareChain
             return false;
         }
 
-        //sanitize pattern
+        // sanitize pattern
         $pattern = str_replace('/', '\/', $this->pattern);
 
-        //look for named parameters
-        preg_match_all(self::PARAM_NAME_REGEX, $pattern, $matches);
-        $availableParameters = array_flip($matches[1]);
-        unset($matches);
-
-        //replace named parameters with regex
+        // replace named parameters with regex
         $regex = '/^'.preg_replace(self::PARAM_NAME_REGEX, '(?<$1>.*)', $pattern).'?$/miu';
 
-        //match + return only named parameters
+        // match + return only named parameters
         $regexMatched = (bool)preg_match($regex, $value, $matches);
         if ($regexMatched) {
-            $this->parameters = array_intersect_key($matches, $availableParameters);
+            array_shift($matches);
+            $this->parameters = array_filter($matches, 'is_numeric', ARRAY_FILTER_USE_KEY);
         }
 
         return $regexMatched;

--- a/tests/Datasets/food.php
+++ b/tests/Datasets/food.php
@@ -1,0 +1,7 @@
+<?php
+
+dataset('food', function () {
+    $file = file_get_contents(__DIR__.'/../Updates/food.json');
+
+    return [json_decode($file)];
+});

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -717,3 +717,16 @@ it('calls the message handler with regex groups', function ($update) {
 
     $bot->run();
 })->with('food');
+
+it('calls the message handler with regex groups + number', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onText('I want {number} portions of (pizza|cake)', function (Nutgram $bot, $amount, $dish) {
+        $bot->sendMessage("You will get {$amount} portions of {$dish}!");
+
+        expect($amount)->toBe('12');
+        expect($dish)->toBe('pizza');
+    });
+
+    $bot->run();
+})->with('food');

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -704,3 +704,16 @@ it('can manipulate the http response', function () {
 
     expect($message->text)->toBe('banane');
 });
+
+it('calls the message handler with regex groups', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onText('I want ([0-9]+) portions of (pizza|cake)', function (Nutgram $bot, $amount, $dish) {
+        $bot->sendMessage("You will get {$amount} portions of {$dish}!");
+
+        expect($amount)->toBe('12');
+        expect($dish)->toBe('pizza');
+    });
+
+    $bot->run();
+})->with('food');

--- a/tests/Updates/food.json
+++ b/tests/Updates/food.json
@@ -1,0 +1,21 @@
+{
+  "update_id": 1,
+  "message": {
+    "message_id": 123,
+    "from": {
+      "id": 456,
+      "is_bot": false,
+      "first_name": "Mario",
+      "username": "Bros",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 456,
+      "first_name": "Mario",
+      "username": "Bros",
+      "type": "private"
+    },
+    "date": 1684984664,
+    "text": "I want 12 portions of pizza"
+  }
+}


### PR DESCRIPTION
This code found in the documentation doesn't work:

```php
$bot->onText('I want ([0-9]+) portions of (pizza|cake)', function (Nutgram $bot, $amount, $dish) {
    $bot->sendMessage("You will get {$amount} portions of {$dish}!");
});
```

**ArgumentCountError : Too few arguments to function X, 1 passed and exactly 3 expected**