### PR TITLE
Fix LoggerHandler.php

### DIFF
--- a/src/Laravel/Log/LoggerHandler.php
+++ b/src/Laravel/Log/LoggerHandler.php
@@ -2,6 +2,7 @@
 
 namespace SergiX44\Nutgram\Laravel\Log;
 
+use ArrayAccess;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\AbstractProcessingHandler;

--- a/src/Laravel/Log/LoggerHandler.php
+++ b/src/Laravel/Log/LoggerHandler.php
@@ -27,7 +27,7 @@ class LoggerHandler extends AbstractProcessingHandler
         return new LineFormatter("%message% %context% %extra%\n");
     }
 
-    protected function write(array $record): void
+    protected function write(array|ArrayAccess $record): void
     {
         $oldSplitConfig = config('nutgram.config.split_long_messages', false);
         config(['nutgram.config.split_long_messages' => true]);
@@ -40,7 +40,7 @@ class LoggerHandler extends AbstractProcessingHandler
         config(['nutgram.config.split_long_messages' => $oldSplitConfig]);
     }
 
-    protected function formatText(array $record): string
+    protected function formatText(array|ArrayAccess $record): string
     {
         return sprintf(
             "<b>%s %s</b> (%s):\n<pre>%s</pre>",


### PR DESCRIPTION
Fixes the following exception
```
Declaration of SergiX44\Nutgram\Laravel\Log\LoggerHandler::write(array $record): void must be compatible with Monolog\Handler\AbstractProcessingHandler::write(Monolog\LogRecord $record): void
```