### PR TITLE
Add Update and Message helpers

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
             <directory suffix=".php">./src/Laravel/Log</directory>
             <directory suffix=".php">./src/RunningMode</directory>
             <directory suffix=".php">./src/Testing/Constraints</directory>
+            <directory suffix=".php">./src/Helpers</directory>
             <file>./src/NutgramServiceProvider.php</file>
             <file>./src/Laravel/Commands/RunCommand.php</file>
             <file>./src/Support/StrUtils.php</file>

--- a/src/Helpers/MessageHelpers.php
+++ b/src/Helpers/MessageHelpers.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace SergiX44\Nutgram\Helpers;
+
+use SergiX44\Nutgram\Telegram\Types\Message\Message;
+use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
+
+/**
+ * @mixin Message
+ */
+trait MessageHelpers
+{
+    public function isCommand(): bool
+    {
+        /** @var MessageEntity $entity */
+        $entity = $this->entities[0] ?? null;
+
+        return $entity !== null && $entity->offset === 0 && $entity->type === 'bot_command';
+    }
+
+    public function isText(): bool
+    {
+        return $this->text !== null;
+    }
+
+    public function isAnimation(): bool
+    {
+        return $this->animation !== null;
+    }
+
+    public function isAudio(): bool
+    {
+        return $this->audio !== null;
+    }
+
+    public function isDocument(): bool
+    {
+        return $this->document !== null;
+    }
+
+    public function isGame(): bool
+    {
+        return $this->game !== null;
+    }
+
+    public function isPhoto(): bool
+    {
+        return $this->photo !== null;
+    }
+
+    public function isSticker(): bool
+    {
+        return $this->sticker !== null;
+    }
+
+    public function isVideo(): bool
+    {
+        return $this->video !== null;
+    }
+
+    public function isVoice(): bool
+    {
+        return $this->voice !== null;
+    }
+
+    public function isVideoNote(): bool
+    {
+        return $this->video_note !== null;
+    }
+
+    public function isContact(): bool
+    {
+        return $this->contact !== null;
+    }
+
+    public function isLocation(): bool
+    {
+        return $this->location !== null;
+    }
+
+    public function isVenue(): bool
+    {
+        return $this->venue !== null;
+    }
+
+    public function isPoll(): bool
+    {
+        return $this->poll !== null;
+    }
+
+    public function isDice(): bool
+    {
+        return $this->dice !== null;
+    }
+
+    public function isInvoice(): bool
+    {
+        return $this->invoice !== null;
+    }
+
+    public function isPassportData(): bool
+    {
+        return $this->passport_data !== null;
+    }
+}

--- a/src/Helpers/UpdateHelpers.php
+++ b/src/Helpers/UpdateHelpers.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SergiX44\Nutgram\Helpers;
+
+use SergiX44\Nutgram\Telegram\Types\Common\Update;
+
+/**
+ * @mixin Update
+ */
+trait UpdateHelpers
+{
+    public function isMessage(): bool
+    {
+        return $this->message !== null;
+    }
+
+    public function isEditedMessage(): bool
+    {
+        return $this->edited_message !== null;
+    }
+
+    public function isChannelPost(): bool
+    {
+        return $this->channel_post !== null;
+    }
+
+    public function isEditedChannelPost(): bool
+    {
+        return $this->edited_channel_post !== null;
+    }
+
+    public function isInlineQuery(): bool
+    {
+        return $this->inline_query !== null;
+    }
+
+    public function isChosenInlineResult(): bool
+    {
+        return $this->chosen_inline_result !== null;
+    }
+
+    public function isCallbackQuery(): bool
+    {
+        return $this->callback_query !== null;
+    }
+
+    public function isShippingQuery(): bool
+    {
+        return $this->shipping_query !== null;
+    }
+
+    public function isPreCheckoutQuery(): bool
+    {
+        return $this->pre_checkout_query !== null;
+    }
+
+    public function isPoll(): bool
+    {
+        return $this->poll !== null;
+    }
+
+    public function isPollAnswer(): bool
+    {
+        return $this->poll_answer !== null;
+    }
+
+    public function isMyChatMember(): bool
+    {
+        return $this->my_chat_member !== null;
+    }
+
+    public function isChatMember(): bool
+    {
+        return $this->chat_member !== null;
+    }
+
+    public function isChatJoinRequest(): bool
+    {
+        return $this->chat_join_request !== null;
+    }
+}

--- a/src/Proxies/UpdateProxy.php
+++ b/src/Proxies/UpdateProxy.php
@@ -11,7 +11,6 @@ use SergiX44\Nutgram\Telegram\Types\Inline\CallbackQuery;
 use SergiX44\Nutgram\Telegram\Types\Inline\ChosenInlineResult;
 use SergiX44\Nutgram\Telegram\Types\Inline\InlineQuery;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
-use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
 use SergiX44\Nutgram\Telegram\Types\Payment\PreCheckoutQuery;
 use SergiX44\Nutgram\Telegram\Types\Payment\ShippingQuery;
 use SergiX44\Nutgram\Telegram\Types\Poll\Poll;
@@ -85,7 +84,7 @@ trait UpdateProxy
      */
     public function isCallbackQuery(): bool
     {
-        return $this->update?->callback_query !== null;
+        return $this->update?->isCallbackQuery();
     }
 
     /**
@@ -101,7 +100,7 @@ trait UpdateProxy
      */
     public function isInlineQuery(): bool
     {
-        return $this->update?->inline_query !== null;
+        return $this->update?->isInlineQuery();
     }
 
     /**
@@ -133,7 +132,7 @@ trait UpdateProxy
      */
     public function isPreCheckoutQuery(): bool
     {
-        return $this->update?->pre_checkout_query !== null;
+        return $this->update?->isPreCheckoutQuery();
     }
 
     /**
@@ -165,7 +164,7 @@ trait UpdateProxy
      */
     public function isMyChatMember(): bool
     {
-        return $this->update?->my_chat_member !== null;
+        return $this->update?->isMyChatMember();
     }
 
     /**
@@ -198,11 +197,6 @@ trait UpdateProxy
      */
     public function isCommand(): bool
     {
-        /** @var MessageEntity $entity */
-        $entity = $this->update?->message?->entities[0] ?? null;
-
-        return $entity !== null &&
-            $entity->offset === 0 &&
-            $entity->type === 'bot_command';
+        return $this->update?->message?->isCommand();
     }
 }

--- a/src/Telegram/Types/Common/Update.php
+++ b/src/Telegram/Types/Common/Update.php
@@ -2,6 +2,7 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Common;
 
+use SergiX44\Nutgram\Helpers\UpdateHelpers;
 use SergiX44\Nutgram\Telegram\Attributes\UpdateTypes;
 use SergiX44\Nutgram\Telegram\Types\BaseType;
 use SergiX44\Nutgram\Telegram\Types\Channel\ChannelPost;
@@ -27,6 +28,8 @@ use SergiX44\Nutgram\Telegram\Types\User\User;
  */
 class Update extends BaseType
 {
+    use UpdateHelpers;
+
     /**
      * The update‘s unique identifier.
      * Update identifiers start from a certain positive number and increase sequentially.

--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -3,6 +3,7 @@
 namespace SergiX44\Nutgram\Telegram\Types\Message;
 
 use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Nutgram\Helpers\MessageHelpers;
 use SergiX44\Nutgram\Telegram\Attributes\MessageTypes;
 use SergiX44\Nutgram\Telegram\Types\BaseType;
 use SergiX44\Nutgram\Telegram\Types\Chat\Chat;
@@ -47,6 +48,8 @@ use SergiX44\Nutgram\Telegram\Types\WebApp\WebAppData;
  */
 class Message extends BaseType
 {
+    use MessageHelpers;
+
     /**
      * Unique message identifier inside this chat
      */


### PR DESCRIPTION
This PR add the following helpers:

```php
$bot->update()->isMessage();
$bot->update()->isEditedMessage();
$bot->update()->isChannelPost();
$bot->update()->isEditedChannelPost();
$bot->update()->isInlineQuery();
$bot->update()->isChosenInlineResult();
$bot->update()->isCallbackQuery();
$bot->update()->isShippingQuery();
$bot->update()->isPreCheckoutQuery();
$bot->update()->isPoll();
$bot->update()->isPollAnswer();
$bot->update()->isMyChatMember();
$bot->update()->isChatMember();
$bot->update()->isChatJoinRequest();

$bot->message()->isCommand();
$bot->message()->isText();
$bot->message()->isAnimation();
$bot->message()->isAudio();
$bot->message()->isDocument();
$bot->message()->isGame();
$bot->message()->isPhoto();
$bot->message()->isSticker();
$bot->message()->isVideo();
$bot->message()->isVoice();
$bot->message()->isVideoNote();
$bot->message()->isContact();
$bot->message()->isLocation();
$bot->message()->isVenue();
$bot->message()->isPoll();
$bot->message()->isDice();
$bot->message()->isInvoice();
$bot->message()->isPassportData();
```