### PR TITLE
Fix specific and generic handlers

### DIFF
--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -59,7 +59,7 @@ abstract class ResolveHandlers extends CollectHandlers
                 $username = $this->getConfig()['bot_name'] ?? null;
                 $text = $this->update?->message?->getParsedCommand($username) ?? $this->update->message?->text;
 
-                if ($text !== null) {
+                if ($text !== null && isset($this->handlers[UpdateTypes::MESSAGE][MessageTypes::TEXT])) {
                     $this->addHandlersBy($resolvedHandlers, $updateType, $messageType, $text);
                 }
             } elseif ($messageType === MessageTypes::SUCCESSFUL_PAYMENT) {
@@ -67,7 +67,9 @@ abstract class ResolveHandlers extends CollectHandlers
                 $this->addHandlersBy($resolvedHandlers, $updateType, $messageType, $data);
             }
 
-            $this->addHandlersBy($resolvedHandlers, $updateType, $messageType);
+            if (isset($this->handlers[$updateType][$messageType])) {
+                $this->addHandlersBy($resolvedHandlers, $updateType, $messageType);
+            }
             $this->addHandlersBy($resolvedHandlers, UpdateTypes::MESSAGE);
         } elseif ($updateType === UpdateTypes::CALLBACK_QUERY) {
             $data = $this->update->callback_query?->data;

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -67,9 +67,8 @@ abstract class ResolveHandlers extends CollectHandlers
                 $this->addHandlersBy($resolvedHandlers, $updateType, $messageType, $data);
             }
 
-            if (count($resolvedHandlers) === 0) {
-                $this->addHandlersBy($resolvedHandlers, $updateType, $messageType);
-            }
+            $this->addHandlersBy($resolvedHandlers, $updateType, $messageType);
+            $this->addHandlersBy($resolvedHandlers, UpdateTypes::MESSAGE);
         } elseif ($updateType === UpdateTypes::CALLBACK_QUERY) {
             $data = $this->update->callback_query?->data;
             $this->addHandlersBy($resolvedHandlers, $updateType, value: $data);

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -733,3 +733,25 @@ it('calls the message handler with multiple global middlewares', function ($upda
 
     expect($test)->toBe('ABM');
 })->with('message');
+
+it('calls specific and generic handlers', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onText('aaaaaaaaaa', function (Nutgram $bot) {
+        $bot->setGlobalData('onText', true);
+    });
+
+    $bot->onMessageType(MessageTypes::TEXT, function (Nutgram $bot) {
+        $bot->setGlobalData('onMessageType', true);
+    });
+
+    $bot->onMessage(function (Nutgram $bot) {
+        $bot->setGlobalData('onMessage', true);
+    });
+
+    $bot->run();
+
+    expect($bot->getGlobalData('onText', false))->toBeTrue();
+    expect($bot->getGlobalData('onMessageType', false))->toBeTrue();
+    expect($bot->getGlobalData('onMessage', false))->toBeTrue();
+})->with('text');

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -116,7 +116,7 @@ it('calls the right handler and no the fallback', function ($update) {
     $bot->run();
 })->with('message');
 
-it('calls the right handler and no the generic one', function ($update) {
+it('calls the right handler and the generic one', function ($update) {
     $bot = Nutgram::fake($update);
 
     $bot->onText('Ciao', function ($bot) {
@@ -124,7 +124,7 @@ it('calls the right handler and no the generic one', function ($update) {
     });
 
     $bot->onMessage(function ($bot) {
-        throw new Exception();
+        expect($bot)->toBeInstanceOf(Nutgram::class);
     });
 
     $bot->fallback(function ($bot) {
@@ -146,7 +146,7 @@ it('calls the right on command', function ($update) {
     });
 
     $bot->onMessage(function ($bot) {
-        throw new Exception();
+        expect($bot)->toBeInstanceOf(Nutgram::class);
     });
 
     $bot->run();
@@ -167,7 +167,7 @@ it('allows defining commands with command instances', function ($update) {
     $bot->registerCommand($c);
 
     $bot->onMessage(function ($bot) {
-        throw new Exception();
+        expect($bot)->toBeInstanceOf(Nutgram::class);
     });
 
     $bot->run();
@@ -180,7 +180,7 @@ it('allows defining commands with classes', function ($update) {
     $bot->registerCommand(TestStartCommand::class);
 
     $bot->onMessage(function ($bot) {
-        throw new Exception();
+        expect($bot)->toBeInstanceOf(Nutgram::class);
     });
 
     $bot->run();
@@ -353,7 +353,7 @@ it('call the typed message handler', function ($update) {
     $bot = Nutgram::fake($update);
 
     $bot->onMessage(function ($bot) {
-        throw new Exception();
+        expect($bot)->toBeInstanceOf(Nutgram::class);
     });
 
     $bot->onMessageType(MessageTypes::PHOTO, function ($bot) {
@@ -428,7 +428,7 @@ it('parse successful payment with specific data', function ($update) {
     });
 
     $bot->onMessage(function ($bot) {
-        throw new Exception();
+        expect($bot)->toBeInstanceOf(Nutgram::class);
     });
 
 


### PR DESCRIPTION
### Use case
Input:
`something`

Handlers:
```php
$bot->onText('something',function(Nutgram $bot) {
    $bot->sendMessage('onText');
});

$bot->onMessageType(MessageTypes::TEXT,function(Nutgram $bot) {
    $bot->sendMessage('onMessageType(MessageTypes::TEXT)');
});

$bot->onMessage(function(Nutgram $bot) {
    $bot->sendMessage('onMessage');
});


``` 

### Before this PR
```mermaid
sequenceDiagram
    User->>+Bot: something
    Bot->>+User: onText
``` 

### After this PR
```mermaid
sequenceDiagram
    User->>+Bot: something
    Bot->>+User: onText
    Bot->>+User: onMessageType(MessageTypes::TEXT)
    Bot->>+User: onMessage
``` 