### PR TITLE
[3.x] Command Scope Support

### DIFF
--- a/src/Handlers/Type/Command.php
+++ b/src/Handlers/Type/Command.php
@@ -6,12 +6,15 @@ use RuntimeException;
 use SergiX44\Nutgram\Handlers\Handler;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommand;
+use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScope;
 
 class Command extends Handler
 {
     protected string $command = '#';
 
     protected ?string $description = null;
+
+    protected array $scopes = [];
 
     /**
      * @param  callable|callable-string  $callable
@@ -56,6 +59,28 @@ class Command extends Handler
     {
         $this->description = $description;
         return $this;
+    }
+
+    /**
+     * @param  BotCommandScope|BotCommandScope[]  $scope
+     * @return $this
+     */
+    public function scope(BotCommandScope|array $scope): Command
+    {
+        if (!is_array($scope)) {
+            $scope = [$scope];
+        }
+
+        $this->scopes = array_merge($this->scopes, $scope);
+        return $this;
+    }
+
+    /**
+     * @return BotCommandScope[]
+     */
+    public function scopes(): array
+    {
+        return $this->scopes;
     }
 
     /**

--- a/src/Handlers/Type/Command.php
+++ b/src/Handlers/Type/Command.php
@@ -7,6 +7,7 @@ use SergiX44\Nutgram\Handlers\Handler;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommand;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScope;
+use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScopeDefault;
 
 class Command extends Handler
 {
@@ -80,7 +81,7 @@ class Command extends Handler
      */
     public function scopes(): array
     {
-        return $this->scopes;
+        return !empty($this->scopes) ? $this->scopes : [new BotCommandScopeDefault];
     }
 
     /**

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -442,13 +442,14 @@ class Nutgram extends ResolveHandlers
                 if (!array_key_exists($scope->getHash(), $commandsByScope)) {
                     $commandsByScope[$scope->getHash()] = ['scope' => $scope, 'commands' => []];
                 }
-                $commandsByScope[$scope->getHash()]['commands'][] = $command->toBotCommand();
+                $commandsByScope[$scope->getHash()]['commands'][$command->getPattern()] = $command->toBotCommand();
             }
         }
+        unset($commands);
 
         // set commands for each scope
         foreach ($commandsByScope as $scope) {
-            $this->setMyCommands($scope['commands'], [
+            $this->setMyCommands(array_values($scope['commands']), [
                 'scope' => $scope['scope'],
             ]);
         }

--- a/src/Telegram/Attributes/BotCommandScopeType.php
+++ b/src/Telegram/Attributes/BotCommandScopeType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Attributes;
+
+class BotCommandScopeType
+{
+    public const DEFAULT = 'default';
+    public const ALL_PRIVATE_CHATS = 'all_private_chats';
+    public const ALL_GROUP_CHATS = 'all_group_chats';
+    public const ALL_CHAT_ADMINISTRATORS = 'all_chat_administrators';
+    public const CHAT = 'chat';
+    public const CHAT_ADMINISTRATORS = 'chat_administrators';
+    public const CHAT_MEMBER = 'chat_member';
+}

--- a/src/Telegram/Attributes/MenuButtonType.php
+++ b/src/Telegram/Attributes/MenuButtonType.php
@@ -2,13 +2,9 @@
 
 namespace SergiX44\Nutgram\Telegram\Attributes;
 
-use SergiX44\Nutgram\Telegram\Types\Command\MenuButtonCommands;
-use SergiX44\Nutgram\Telegram\Types\Command\MenuButtonDefault;
-use SergiX44\Nutgram\Telegram\Types\Command\MenuButtonWebApp;
-
 class MenuButtonType extends BaseEnum
 {
-    public const COMMANDS = MenuButtonCommands::class;
-    public const DEFAULT = MenuButtonDefault::class;
-    public const WEB_APP = MenuButtonWebApp::class;
+    public const COMMANDS = 'commands';
+    public const DEFAULT = 'default';
+    public const WEB_APP = 'web_app';
 }

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -11,6 +11,7 @@ use SergiX44\Nutgram\Telegram\Types\Chat\ChatInviteLink;
 use SergiX44\Nutgram\Telegram\Types\Chat\ChatMember;
 use SergiX44\Nutgram\Telegram\Types\Chat\ChatPermissions;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommand;
+use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScope;
 use SergiX44\Nutgram\Telegram\Types\Command\MenuButton;
 use SergiX44\Nutgram\Telegram\Types\Description\BotDescription;
 use SergiX44\Nutgram\Telegram\Types\Description\BotShortDescription;
@@ -1453,7 +1454,7 @@ trait AvailableMethods
      * {@see https://core.telegram.org/bots/api#botcommand BotCommand} on success.
      * @see https://core.telegram.org/bots/api#getmycommands
      * @param  array{
-     *     scope?:object,
+     *     scope?:BotCommandScope,
      *     language_code?:string
      * }  $opt
      * @return BotCommand[]|null

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -1430,6 +1430,9 @@ trait AvailableMethods
     public function setMyCommands(array $commands = [], array $opt = []): ?bool
     {
         $required = ['commands' => json_encode($commands)];
+        if (array_key_exists('scope', $opt)) {
+            $opt['scope'] = json_encode($opt['scope']);
+        }
         return $this->requestJson(__FUNCTION__, array_merge($required, $opt));
     }
 

--- a/src/Telegram/Types/Command/BotCommandScope.php
+++ b/src/Telegram/Types/Command/BotCommandScope.php
@@ -20,7 +20,15 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
 #[BotCommandScopeResolver]
 abstract class BotCommandScope extends BaseType
 {
-    abstract public function getType(): string;
+    public string $type;
 
-    abstract public function getHash(): string;
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function __serialize(): array
+    {
+        return ['type' => $this->getType()];
+    }
 }

--- a/src/Telegram/Types/Command/BotCommandScope.php
+++ b/src/Telegram/Types/Command/BotCommandScope.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Command;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object represents the scope to which bot commands are applied.
+ * Currently, the following 7 scopes are supported:
+ * - {@see BotCommandScopeDefault BotCommandScopeDefault}
+ * - {@see BotCommandScopeAllPrivateChats BotCommandScopeAllPrivateChats}
+ * - {@see BotCommandScopeAllGroupChats BotCommandScopeAllGroupChats}
+ * - {@see BotCommandScopeAllChatAdministrators BotCommandScopeAllChatAdministrators}
+ * - {@see BotCommandScopeChat BotCommandScopeChat}
+ * - {@see BotCommandScopeChatAdministrators BotCommandScopeChatAdministrators}
+ * - {@see BotCommandScopeChatMember BotCommandScopeChatMember}
+ *
+ * @see https://core.telegram.org/bots/api#botcommandscope
+ */
+#[BotCommandScopeResolver]
+abstract class BotCommandScope extends BaseType
+{
+    abstract public function getType(): string;
+
+    abstract public function getHash(): string;
+}

--- a/src/Telegram/Types/Command/BotCommandScopeAllChatAdministrators.php
+++ b/src/Telegram/Types/Command/BotCommandScopeAllChatAdministrators.php
@@ -2,16 +2,33 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Command;
 
+use SergiX44\Nutgram\Telegram\Attributes\BotCommandScopeType;
+
 /**
  * Represents the {@see https://core.telegram.org/bots/api#botcommandscope scope}
  * of bot commands, covering all group and supergroup chat administrators.
  *
  * @see https://core.telegram.org/bots/api#botcommandscopeallchatadministrators
  */
-class BotCommandScopeAllChatAdministrators
+class BotCommandScopeAllChatAdministrators extends BotCommandScope
 {
     /**
      * Scope type, must be all_chat_administrators
      */
-    public string $type;
+    public string $type = 'all_chat_administrators';
+
+    public function getType(): string
+    {
+        return BotCommandScopeType::ALL_CHAT_ADMINISTRATORS;
+    }
+
+    public function getHash(): string
+    {
+        return $this->type;
+    }
+
+    public static function apply(): static
+    {
+        return new static();
+    }
 }

--- a/src/Telegram/Types/Command/BotCommandScopeAllChatAdministrators.php
+++ b/src/Telegram/Types/Command/BotCommandScopeAllChatAdministrators.php
@@ -15,20 +15,5 @@ class BotCommandScopeAllChatAdministrators extends BotCommandScope
     /**
      * Scope type, must be all_chat_administrators
      */
-    public string $type = 'all_chat_administrators';
-
-    public function getType(): string
-    {
-        return BotCommandScopeType::ALL_CHAT_ADMINISTRATORS;
-    }
-
-    public function getHash(): string
-    {
-        return $this->type;
-    }
-
-    public static function apply(): static
-    {
-        return new static();
-    }
+    public string $type = BotCommandScopeType::ALL_CHAT_ADMINISTRATORS;
 }

--- a/src/Telegram/Types/Command/BotCommandScopeAllGroupChats.php
+++ b/src/Telegram/Types/Command/BotCommandScopeAllGroupChats.php
@@ -15,20 +15,5 @@ class BotCommandScopeAllGroupChats extends BotCommandScope
     /**
      * Scope type, must be all_group_chats
      */
-    public string $type = 'all_group_chats';
-
-    public function getType(): string
-    {
-        return BotCommandScopeType::ALL_GROUP_CHATS;
-    }
-
-    public function getHash(): string
-    {
-        return $this->type;
-    }
-
-    public static function apply(): static
-    {
-        return new static();
-    }
+    public string $type = BotCommandScopeType::ALL_GROUP_CHATS;
 }

--- a/src/Telegram/Types/Command/BotCommandScopeAllGroupChats.php
+++ b/src/Telegram/Types/Command/BotCommandScopeAllGroupChats.php
@@ -2,16 +2,33 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Command;
 
+use SergiX44\Nutgram\Telegram\Attributes\BotCommandScopeType;
+
 /**
  * Represents the {@see https://core.telegram.org/bots/api#botcommandscope scope}
  * of bot commands, covering all group and supergroup chats.
  *
  * @see https://core.telegram.org/bots/api#botcommandscopeallgroupchats
  */
-class BotCommandScopeAllGroupChats
+class BotCommandScopeAllGroupChats extends BotCommandScope
 {
     /**
      * Scope type, must be all_group_chats
      */
-    public string $type;
+    public string $type = 'all_group_chats';
+
+    public function getType(): string
+    {
+        return BotCommandScopeType::ALL_GROUP_CHATS;
+    }
+
+    public function getHash(): string
+    {
+        return $this->type;
+    }
+
+    public static function apply(): static
+    {
+        return new static();
+    }
 }

--- a/src/Telegram/Types/Command/BotCommandScopeAllPrivateChats.php
+++ b/src/Telegram/Types/Command/BotCommandScopeAllPrivateChats.php
@@ -2,16 +2,33 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Command;
 
+use SergiX44\Nutgram\Telegram\Attributes\BotCommandScopeType;
+
 /**
  * Represents the {@see https://core.telegram.org/bots/api#botcommandscope scope}
  * of bot commands, covering all private chats.
  *
  * @see https://core.telegram.org/bots/api#botcommandscopeallprivatechats
  */
-class BotCommandScopeAllPrivateChats
+class BotCommandScopeAllPrivateChats extends BotCommandScope
 {
     /**
      * Scope type, must be all_private_chats
      */
-    public string $type;
+    public string $type = 'all_private_chats';
+
+    public function getType(): string
+    {
+        return BotCommandScopeType::ALL_PRIVATE_CHATS;
+    }
+
+    public function getHash(): string
+    {
+        return $this->type;
+    }
+
+    public static function apply(): static
+    {
+        return new static();
+    }
 }

--- a/src/Telegram/Types/Command/BotCommandScopeAllPrivateChats.php
+++ b/src/Telegram/Types/Command/BotCommandScopeAllPrivateChats.php
@@ -15,20 +15,5 @@ class BotCommandScopeAllPrivateChats extends BotCommandScope
     /**
      * Scope type, must be all_private_chats
      */
-    public string $type = 'all_private_chats';
-
-    public function getType(): string
-    {
-        return BotCommandScopeType::ALL_PRIVATE_CHATS;
-    }
-
-    public function getHash(): string
-    {
-        return $this->type;
-    }
-
-    public static function apply(): static
-    {
-        return new static();
-    }
+    public string $type = BotCommandScopeType::ALL_PRIVATE_CHATS;
 }

--- a/src/Telegram/Types/Command/BotCommandScopeChat.php
+++ b/src/Telegram/Types/Command/BotCommandScopeChat.php
@@ -2,22 +2,41 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Command;
 
+use SergiX44\Nutgram\Telegram\Attributes\BotCommandScopeType;
+
 /**
  * Represents the {@see https://core.telegram.org/bots/api#botcommandscope scope}
  * of bot commands, covering a specific chat.
  *
  * @see https://core.telegram.org/bots/api#botcommandscopechat
  */
-class BotCommandScopeChat
+class BotCommandScopeChat extends BotCommandScope
 {
     /**
      * Scope type, must be chat
      */
-    public string $type;
+    public string $type = 'chat';
 
     /**
      * Unique identifier for the target chat or username
      * of the target supergroup (in the format  &#64;supergroupusername)
      */
     public int|string $chat_id;
+
+    public function getType(): string
+    {
+        return BotCommandScopeType::CHAT;
+    }
+
+    public function getHash(): string
+    {
+        return $this->type.':'.$this->chat_id;
+    }
+
+    public static function apply(int|string $chat_id): static
+    {
+        $obj = new static();
+        $obj->chat_id = $chat_id;
+        return $obj;
+    }
 }

--- a/src/Telegram/Types/Command/BotCommandScopeChat.php
+++ b/src/Telegram/Types/Command/BotCommandScopeChat.php
@@ -15,7 +15,7 @@ class BotCommandScopeChat extends BotCommandScope
     /**
      * Scope type, must be chat
      */
-    public string $type = 'chat';
+    public string $type = BotCommandScopeType::CHAT;
 
     /**
      * Unique identifier for the target chat or username
@@ -23,20 +23,9 @@ class BotCommandScopeChat extends BotCommandScope
      */
     public int|string $chat_id;
 
-    public function getType(): string
+    public function __construct(int|string $chat_id)
     {
-        return BotCommandScopeType::CHAT;
-    }
-
-    public function getHash(): string
-    {
-        return $this->type.':'.$this->chat_id;
-    }
-
-    public static function apply(int|string $chat_id): static
-    {
-        $obj = new static();
-        $obj->chat_id = $chat_id;
-        return $obj;
+        parent::__construct();
+        $this->chat_id = $chat_id;
     }
 }

--- a/src/Telegram/Types/Command/BotCommandScopeChatAdministrators.php
+++ b/src/Telegram/Types/Command/BotCommandScopeChatAdministrators.php
@@ -15,7 +15,7 @@ class BotCommandScopeChatAdministrators extends BotCommandScope
     /**
      * Scope type, must be chat_administrators
      */
-    public string $type = 'chat_administrators';
+    public string $type = BotCommandScopeType::CHAT_ADMINISTRATORS;
 
     /**
      * Unique identifier for the target chat or username
@@ -23,20 +23,9 @@ class BotCommandScopeChatAdministrators extends BotCommandScope
      */
     public int|string $chat_id;
 
-    public function getType(): string
+    public function __construct(int|string $chat_id)
     {
-        return BotCommandScopeType::CHAT_ADMINISTRATORS;
-    }
-
-    public function getHash(): string
-    {
-        return $this->type.':'.$this->chat_id;
-    }
-
-    public static function apply(int|string $chat_id): static
-    {
-        $obj = new static();
-        $obj->chat_id = $chat_id;
-        return $obj;
+        parent::__construct();
+        $this->chat_id = $chat_id;
     }
 }

--- a/src/Telegram/Types/Command/BotCommandScopeChatAdministrators.php
+++ b/src/Telegram/Types/Command/BotCommandScopeChatAdministrators.php
@@ -2,22 +2,41 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Command;
 
+use SergiX44\Nutgram\Telegram\Attributes\BotCommandScopeType;
+
 /**
  * Represents the {@see https://core.telegram.org/bots/api#botcommandscope scope}
  * of bot commands, covering all administrators of a specific group or supergroup chat.
  *
  * @see https://core.telegram.org/bots/api#botcommandscopechatadministrators
  */
-class BotCommandScopeChatAdministrators
+class BotCommandScopeChatAdministrators extends BotCommandScope
 {
     /**
      * Scope type, must be chat_administrators
      */
-    public string $type;
+    public string $type = 'chat_administrators';
 
     /**
      * Unique identifier for the target chat or username
      * of the target supergroup (in the format  &#64;supergroupusername)
      */
     public int|string $chat_id;
+
+    public function getType(): string
+    {
+        return BotCommandScopeType::CHAT_ADMINISTRATORS;
+    }
+
+    public function getHash(): string
+    {
+        return $this->type.':'.$this->chat_id;
+    }
+
+    public static function apply(int|string $chat_id): static
+    {
+        $obj = new static();
+        $obj->chat_id = $chat_id;
+        return $obj;
+    }
 }

--- a/src/Telegram/Types/Command/BotCommandScopeChatMember.php
+++ b/src/Telegram/Types/Command/BotCommandScopeChatMember.php
@@ -15,7 +15,7 @@ class BotCommandScopeChatMember extends BotCommandScope
     /**
      * Scope type, must be chat_member
      */
-    public string $type = 'chat_member';
+    public string $type = BotCommandScopeType::CHAT_MEMBER;
 
     /**
      * Unique identifier for the target chat or username
@@ -28,21 +28,10 @@ class BotCommandScopeChatMember extends BotCommandScope
      */
     public int $user_id;
 
-    public function getType(): string
+    public function __construct(int|string $chat_id, int $user_id)
     {
-        return BotCommandScopeType::CHAT_MEMBER;
-    }
-
-    public function getHash(): string
-    {
-        return $this->type.':'.$this->chat_id.':'.$this->user_id;
-    }
-
-    public static function apply(int|string $chat_id, int $user_id): static
-    {
-        $obj = new static();
-        $obj->chat_id = $chat_id;
-        $obj->user_id = $user_id;
-        return $obj;
+        parent::__construct();
+        $this->chat_id = $chat_id;
+        $this->user_id = $user_id;
     }
 }

--- a/src/Telegram/Types/Command/BotCommandScopeChatMember.php
+++ b/src/Telegram/Types/Command/BotCommandScopeChatMember.php
@@ -2,18 +2,20 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Command;
 
+use SergiX44\Nutgram\Telegram\Attributes\BotCommandScopeType;
+
 /**
  * Represents the {@see https://core.telegram.org/bots/api#botcommandscope scope}
  * of bot commands, covering a specific member of a group or supergroup chat.
  *
  * @see https://core.telegram.org/bots/api#botcommandscopechatmember
  */
-class BotCommandScopeChatMember
+class BotCommandScopeChatMember extends BotCommandScope
 {
     /**
      * Scope type, must be chat_member
      */
-    public string $type;
+    public string $type = 'chat_member';
 
     /**
      * Unique identifier for the target chat or username
@@ -25,4 +27,22 @@ class BotCommandScopeChatMember
      * Unique identifier of the target user
      */
     public int $user_id;
+
+    public function getType(): string
+    {
+        return BotCommandScopeType::CHAT_MEMBER;
+    }
+
+    public function getHash(): string
+    {
+        return $this->type.':'.$this->chat_id.':'.$this->user_id;
+    }
+
+    public static function apply(int|string $chat_id, int $user_id): static
+    {
+        $obj = new static();
+        $obj->chat_id = $chat_id;
+        $obj->user_id = $user_id;
+        return $obj;
+    }
 }

--- a/src/Telegram/Types/Command/BotCommandScopeDefault.php
+++ b/src/Telegram/Types/Command/BotCommandScopeDefault.php
@@ -2,6 +2,8 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Command;
 
+use SergiX44\Nutgram\Telegram\Attributes\BotCommandScopeType;
+
 /**
  * Represents the default {@see https://core.telegram.org/bots/api#botcommandscope scope} of bot commands.
  * Default commands are used if no commands with a
@@ -9,10 +11,25 @@ namespace SergiX44\Nutgram\Telegram\Types\Command;
  *
  * @see https://core.telegram.org/bots/api#botcommandscopedefault
  */
-class BotCommandScopeDefault
+class BotCommandScopeDefault extends BotCommandScope
 {
     /**
      * Scope type, must be default
      */
-    public string $type;
+    public string $type = 'default';
+
+    public function getType(): string
+    {
+        return BotCommandScopeType::DEFAULT;
+    }
+
+    public function getHash(): string
+    {
+        return $this->type;
+    }
+
+    public static function apply(): static
+    {
+        return new static();
+    }
 }

--- a/src/Telegram/Types/Command/BotCommandScopeDefault.php
+++ b/src/Telegram/Types/Command/BotCommandScopeDefault.php
@@ -16,20 +16,5 @@ class BotCommandScopeDefault extends BotCommandScope
     /**
      * Scope type, must be default
      */
-    public string $type = 'default';
-
-    public function getType(): string
-    {
-        return BotCommandScopeType::DEFAULT;
-    }
-
-    public function getHash(): string
-    {
-        return $this->type;
-    }
-
-    public static function apply(): static
-    {
-        return new static();
-    }
+    public string $type = BotCommandScopeType::DEFAULT;
 }

--- a/src/Telegram/Types/Command/BotCommandScopeResolver.php
+++ b/src/Telegram/Types/Command/BotCommandScopeResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Command;
+
+use Attribute;
+use InvalidArgumentException;
+use SergiX44\Hydrator\Annotation\ConcreteResolver;
+use SergiX44\Nutgram\Telegram\Attributes\BotCommandScopeType;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class BotCommandScopeResolver extends ConcreteResolver
+{
+    protected array $concretes = [
+        BotCommandScopeType::DEFAULT => BotCommandScopeDefault::class,
+        BotCommandScopeType::ALL_PRIVATE_CHATS => BotCommandScopeAllPrivateChats::class,
+        BotCommandScopeType::ALL_GROUP_CHATS => BotCommandScopeAllGroupChats::class,
+        BotCommandScopeType::ALL_CHAT_ADMINISTRATORS => BotCommandScopeAllChatAdministrators::class,
+        BotCommandScopeType::CHAT => BotCommandScopeChat::class,
+        BotCommandScopeType::CHAT_ADMINISTRATORS => BotCommandScopeChatAdministrators::class,
+        BotCommandScopeType::CHAT_MEMBER => BotCommandScopeChatMember::class,
+    ];
+
+    public function concreteFor(array $data): ?string
+    {
+        return $this->concretes[$data['type']] ?? throw new InvalidArgumentException('Unknown BotCommandScope type: '.$data['type']);
+    }
+}

--- a/src/Telegram/Types/Command/MenuButton.php
+++ b/src/Telegram/Types/Command/MenuButton.php
@@ -17,5 +17,10 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
 #[MenuButtonResolver]
 abstract class MenuButton extends BaseType
 {
-    abstract public function getType(): string;
+    public string $type;
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
 }

--- a/src/Telegram/Types/Command/MenuButtonCommands.php
+++ b/src/Telegram/Types/Command/MenuButtonCommands.php
@@ -13,10 +13,5 @@ class MenuButtonCommands extends MenuButton
     /**
      * Type of the button, must be commands
      */
-    public string $type = 'commands';
-
-    public function getType(): string
-    {
-        return MenuButtonType::COMMANDS;
-    }
+    public string $type = MenuButtonType::COMMANDS;
 }

--- a/src/Telegram/Types/Command/MenuButtonDefault.php
+++ b/src/Telegram/Types/Command/MenuButtonDefault.php
@@ -13,10 +13,5 @@ class MenuButtonDefault extends MenuButton
     /**
      * Type of the button, must be default
      */
-    public string $type = 'default';
-
-    public function getType(): string
-    {
-        return MenuButtonType::DEFAULT;
-    }
+    public string $type = MenuButtonType::DEFAULT;
 }

--- a/src/Telegram/Types/Command/MenuButtonWebApp.php
+++ b/src/Telegram/Types/Command/MenuButtonWebApp.php
@@ -14,7 +14,7 @@ class MenuButtonWebApp extends MenuButton
     /**
      * Type of the button, must be web_app
      */
-    public string $type = 'web_app';
+    public string $type = MenuButtonType::WEB_APP;
 
     /**
      * Text on the button
@@ -27,9 +27,4 @@ class MenuButtonWebApp extends MenuButton
      * the method {@see https://core.telegram.org/bots/api#answerwebappquery answerWebAppQuery}.
      */
     public ?WebAppInfo $web_app = null;
-
-    public function getType(): string
-    {
-        return MenuButtonType::WEB_APP;
-    }
 }

--- a/tests/Feature/RegisterMyCommandsTest.php
+++ b/tests/Feature/RegisterMyCommandsTest.php
@@ -1,0 +1,369 @@
+<?php
+
+use SergiX44\Nutgram\Handlers\Type\Command;
+use SergiX44\Nutgram\Nutgram;
+use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScopeAllChatAdministrators;
+use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScopeAllGroupChats;
+use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScopeAllPrivateChats;
+use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScopeChat;
+use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScopeChatAdministrators;
+use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScopeChatMember;
+use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScopeDefault;
+
+test('onCommand without description', function () {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('Hello World!');
+    });
+
+    $bot->beforeApiRequest(function (Nutgram $bot, array $request) {
+        $bot->setGlobalData('called', true);
+        return $request;
+    });
+
+    $bot->registerMyCommands();
+
+    expect($bot->getGlobalData('called', false))->toBeFalse();
+});
+
+test('registerCommand without description', function () {
+    $bot = Nutgram::fake();
+
+    $bot->registerCommand(new class extends Command {
+        protected string $command = 'start';
+
+        public function handle(Nutgram $bot): void
+        {
+            $bot->sendMessage('Hello World!');
+        }
+    });
+
+    $bot->beforeApiRequest(function (Nutgram $bot, array $request) {
+        $bot->setGlobalData('called', true);
+        return $request;
+    });
+
+    $bot->registerMyCommands();
+
+    expect($bot->getGlobalData('called', false))->toBeFalse();
+});
+
+test('onCommand with description', function () {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('Hello World!');
+    })->description('Start command');
+
+    $bot->beforeApiRequest(function (Nutgram $bot, array $request) {
+        expect($request['json'])
+            ->scope->toBe('{"type":"default"}')
+            ->commands->toBe('[{"command":"start","description":"Start command"}]');
+
+        return $request;
+    });
+
+    $bot->registerMyCommands();
+});
+
+test('registerCommand with description', function () {
+    $bot = Nutgram::fake();
+
+    $bot->registerCommand(new class extends Command {
+        protected string $command = 'start';
+        protected ?string $description = 'Start command';
+
+        public function handle(Nutgram $bot): void
+        {
+            $bot->sendMessage('Hello World!');
+        }
+    });
+
+    $bot->beforeApiRequest(function (Nutgram $bot, array $request) {
+        expect($request['json'])
+            ->scope->toBe('{"type":"default"}')
+            ->commands->toBe('[{"command":"start","description":"Start command"}]');
+
+        return $request;
+    });
+
+    $bot->registerMyCommands();
+});
+
+test('onCommand with description and scope', function () {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('Hello World!');
+    })->description('Start command')->scope(BotCommandScopeAllPrivateChats::apply());
+
+    $bot->beforeApiRequest(function (Nutgram $bot, array $request) {
+        expect($request['json'])
+            ->scope->toBe('{"type":"all_private_chats"}')
+            ->commands->toBe('[{"command":"start","description":"Start command"}]');
+
+        return $request;
+    });
+
+    $bot->registerMyCommands();
+});
+
+test('registerCommand with description and scope', function () {
+    $bot = Nutgram::fake();
+
+    $bot->registerCommand(new class extends Command {
+        protected string $command = 'start';
+        protected ?string $description = 'Start command';
+
+        public function scopes(): array
+        {
+            return [
+                BotCommandScopeAllPrivateChats::apply(),
+            ];
+        }
+
+        public function handle(Nutgram $bot): void
+        {
+            $bot->sendMessage('Hello World!');
+        }
+    });
+
+    $bot->beforeApiRequest(function (Nutgram $bot, array $request) {
+        expect($request['json'])
+            ->scope->toBe('{"type":"all_private_chats"}')
+            ->commands->toBe('[{"command":"start","description":"Start command"}]');
+
+        return $request;
+    });
+
+    $bot->registerMyCommands();
+});
+
+test('onCommand with description and scopes (multiple calls)', function () {
+    $bot = Nutgram::fake();
+
+    $history = [];
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('Hello World!');
+    })->description('Start command')
+        ->scope(BotCommandScopeAllPrivateChats::apply())
+        ->scope(BotCommandScopeAllGroupChats::apply());
+
+    $bot->beforeApiRequest(function (Nutgram $bot, array $request) use (&$history) {
+        $history[] = $request['json'];
+
+        return $request;
+    });
+
+    $bot->registerMyCommands();
+
+    expect($history)->sequence(
+        fn ($x) => $x
+            ->scope->toBe('{"type":"all_private_chats"}')
+            ->commands->toBe('[{"command":"start","description":"Start command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"all_group_chats"}')
+            ->commands->toBe('[{"command":"start","description":"Start command"}]'),
+    );
+});
+
+test('onCommand with description and scopes (as array)', function () {
+    $bot = Nutgram::fake();
+
+    $history = [];
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('Hello World!');
+    })->description('Start command')
+        ->scope([
+            BotCommandScopeAllPrivateChats::apply(),
+            BotCommandScopeAllGroupChats::apply()
+        ]);
+
+    $bot->beforeApiRequest(function (Nutgram $bot, array $request) use (&$history) {
+        $history[] = $request['json'];
+
+        return $request;
+    });
+
+    $bot->registerMyCommands();
+
+    expect($history)->sequence(
+        fn ($x) => $x
+            ->scope->toBe('{"type":"all_private_chats"}')
+            ->commands->toBe('[{"command":"start","description":"Start command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"all_group_chats"}')
+            ->commands->toBe('[{"command":"start","description":"Start command"}]'),
+    );
+});
+
+test('grouped scopes', function () {
+    $bot = Nutgram::fake();
+
+    $history = [];
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('Start command!');
+    })
+        ->description('Start command')
+        ->scope(BotCommandScopeAllPrivateChats::apply())
+        ->scope(BotCommandScopeAllGroupChats::apply());
+
+    $bot->onCommand('help', function (Nutgram $bot) {
+        $bot->sendMessage('Help command!');
+    })
+        ->description('Help command')
+        ->scope(BotCommandScopeAllPrivateChats::apply());
+
+    $bot->onCommand('about', function (Nutgram $bot) {
+        $bot->sendMessage('About command!');
+    })
+        ->description('About command')
+        ->scope(BotCommandScopeAllGroupChats::apply())
+        ->scope(BotCommandScopeAllChatAdministrators::apply());
+
+    $bot->beforeApiRequest(function (Nutgram $bot, array $request) use (&$history) {
+        $history[] = $request['json'];
+
+        return $request;
+    });
+
+    $bot->registerMyCommands();
+
+    expect($history)->sequence(
+        fn ($x) => $x
+            ->scope->toBe('{"type":"all_private_chats"}')
+            ->commands->toBe('[{"command":"start","description":"Start command"},{"command":"help","description":"Help command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"all_group_chats"}')
+            ->commands->toBe('[{"command":"start","description":"Start command"},{"command":"about","description":"About command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"all_chat_administrators"}')
+            ->commands->toBe('[{"command":"about","description":"About command"}]'),
+    );
+});
+
+test('all scopes', function () {
+    $bot = Nutgram::fake();
+
+    $history = [];
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('Start command!');
+    })
+        ->description('Start command');
+
+    $bot->onCommand('help', function (Nutgram $bot) {
+        $bot->sendMessage('Help command!');
+    })
+        ->description('Help command')
+        ->scope(BotCommandScopeDefault::apply());
+
+    $bot->onCommand('admins', function (Nutgram $bot) {
+        $bot->sendMessage('Admins command!');
+    })
+        ->description('Admins command')
+        ->scope(BotCommandScopeAllChatAdministrators::apply());
+
+    $bot->onCommand('groups', function (Nutgram $bot) {
+        $bot->sendMessage('Groups command!');
+    })
+        ->description('Groups command')
+        ->scope(BotCommandScopeAllGroupChats::apply());
+
+    $bot->onCommand('private', function (Nutgram $bot) {
+        $bot->sendMessage('Private command!');
+    })
+        ->description('Private command')
+        ->scope(BotCommandScopeAllPrivateChats::apply());
+
+    $bot->onCommand('chat_a', function (Nutgram $bot) {
+        $bot->sendMessage('ChatA command!');
+    })
+        ->description('ChatA command')
+        ->scope(BotCommandScopeChat::apply(123));
+
+    $bot->onCommand('chat_b', function (Nutgram $bot) {
+        $bot->sendMessage('ChatB command!');
+    })
+        ->description('ChatB command')
+        ->scope(BotCommandScopeChat::apply(456));
+
+    $bot->onCommand('chat_admin_a', function (Nutgram $bot) {
+        $bot->sendMessage('ChatAdminA command!');
+    })
+        ->description('ChatAdminA command')
+        ->scope(BotCommandScopeChatAdministrators::apply(123));
+
+    $bot->onCommand('chat_admin_b', function (Nutgram $bot) {
+        $bot->sendMessage('ChatAdminB command!');
+    })
+        ->description('ChatAdminB command')
+        ->scope(BotCommandScopeChatAdministrators::apply(456));
+
+    $bot->onCommand('chat_member_a', function (Nutgram $bot) {
+        $bot->sendMessage('ChatMemberA command!');
+    })
+        ->description('ChatMemberA command')
+        ->scope(BotCommandScopeChatMember::apply(123, 987));
+
+    $bot->onCommand('chat_member_b', function (Nutgram $bot) {
+        $bot->sendMessage('ChatMemberB command!');
+    })
+        ->description('ChatMemberB command')
+        ->scope(BotCommandScopeChatMember::apply(123, 654));
+
+    $bot->onCommand('chat_member_c', function (Nutgram $bot) {
+        $bot->sendMessage('ChatMemberC command!');
+    })
+        ->description('ChatMemberC command')
+        ->scope(BotCommandScopeChatMember::apply(456, 321))
+        ->scope(BotCommandScopeChatMember::apply(123, 654));
+
+    $bot->beforeApiRequest(function (Nutgram $bot, array $request) use (&$history) {
+        $history[] = $request['json'];
+
+        return $request;
+    });
+
+    $bot->registerMyCommands();
+
+    expect($history)->sequence(
+        fn ($x) => $x
+            ->scope->toBe('{"type":"default"}')
+            ->commands->toBe('[{"command":"start","description":"Start command"},{"command":"help","description":"Help command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"all_chat_administrators"}')
+            ->commands->toBe('[{"command":"admins","description":"Admins command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"all_group_chats"}')
+            ->commands->toBe('[{"command":"groups","description":"Groups command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"all_private_chats"}')
+            ->commands->toBe('[{"command":"private","description":"Private command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"chat","chat_id":123}')
+            ->commands->toBe('[{"command":"chat_a","description":"ChatA command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"chat","chat_id":456}')
+            ->commands->toBe('[{"command":"chat_b","description":"ChatB command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"chat_administrators","chat_id":123}')
+            ->commands->toBe('[{"command":"chat_admin_a","description":"ChatAdminA command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"chat_administrators","chat_id":456}')
+            ->commands->toBe('[{"command":"chat_admin_b","description":"ChatAdminB command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"chat_member","chat_id":123,"user_id":987}')
+            ->commands->toBe('[{"command":"chat_member_a","description":"ChatMemberA command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"chat_member","chat_id":123,"user_id":654}')
+            ->commands->toBe('[{"command":"chat_member_b","description":"ChatMemberB command"},{"command":"chat_member_c","description":"ChatMemberC command"}]'),
+        fn ($x) => $x
+            ->scope->toBe('{"type":"chat_member","chat_id":456,"user_id":321}')
+            ->commands->toBe('[{"command":"chat_member_c","description":"ChatMemberC command"}]'),
+    );
+});

--- a/tests/Feature/RegisterMyCommandsTest.php
+++ b/tests/Feature/RegisterMyCommandsTest.php
@@ -96,7 +96,7 @@ test('onCommand with description and scope', function () {
 
     $bot->onCommand('start', function (Nutgram $bot) {
         $bot->sendMessage('Hello World!');
-    })->description('Start command')->scope(BotCommandScopeAllPrivateChats::apply());
+    })->description('Start command')->scope(new BotCommandScopeAllPrivateChats);
 
     $bot->beforeApiRequest(function (Nutgram $bot, array $request) {
         expect($request['json'])
@@ -119,7 +119,7 @@ test('registerCommand with description and scope', function () {
         public function scopes(): array
         {
             return [
-                BotCommandScopeAllPrivateChats::apply(),
+                new BotCommandScopeAllPrivateChats,
             ];
         }
 
@@ -148,8 +148,8 @@ test('onCommand with description and scopes (multiple calls)', function () {
     $bot->onCommand('start', function (Nutgram $bot) {
         $bot->sendMessage('Hello World!');
     })->description('Start command')
-        ->scope(BotCommandScopeAllPrivateChats::apply())
-        ->scope(BotCommandScopeAllGroupChats::apply());
+        ->scope(new BotCommandScopeAllPrivateChats)
+        ->scope(new BotCommandScopeAllGroupChats);
 
     $bot->beforeApiRequest(function (Nutgram $bot, array $request) use (&$history) {
         $history[] = $request['json'];
@@ -178,8 +178,8 @@ test('onCommand with description and scopes (as array)', function () {
         $bot->sendMessage('Hello World!');
     })->description('Start command')
         ->scope([
-            BotCommandScopeAllPrivateChats::apply(),
-            BotCommandScopeAllGroupChats::apply()
+            new BotCommandScopeAllPrivateChats,
+            new BotCommandScopeAllGroupChats
         ]);
 
     $bot->beforeApiRequest(function (Nutgram $bot, array $request) use (&$history) {
@@ -209,21 +209,21 @@ test('grouped scopes', function () {
         $bot->sendMessage('Start command!');
     })
         ->description('Start command')
-        ->scope(BotCommandScopeAllPrivateChats::apply())
-        ->scope(BotCommandScopeAllGroupChats::apply());
+        ->scope(new BotCommandScopeAllPrivateChats)
+        ->scope(new BotCommandScopeAllGroupChats);
 
     $bot->onCommand('help', function (Nutgram $bot) {
         $bot->sendMessage('Help command!');
     })
         ->description('Help command')
-        ->scope(BotCommandScopeAllPrivateChats::apply());
+        ->scope(new BotCommandScopeAllPrivateChats);
 
     $bot->onCommand('about', function (Nutgram $bot) {
         $bot->sendMessage('About command!');
     })
         ->description('About command')
-        ->scope(BotCommandScopeAllGroupChats::apply())
-        ->scope(BotCommandScopeAllChatAdministrators::apply());
+        ->scope(new BotCommandScopeAllGroupChats)
+        ->scope(new BotCommandScopeAllChatAdministrators);
 
     $bot->beforeApiRequest(function (Nutgram $bot, array $request) use (&$history) {
         $history[] = $request['json'];
@@ -255,15 +255,15 @@ test('avoid duplicated scopes', function () {
         $bot->sendMessage('Start command!');
     })
         ->description('Start command')
-        ->scope(BotCommandScopeAllPrivateChats::apply())
-        ->scope(BotCommandScopeAllGroupChats::apply());
+        ->scope(new BotCommandScopeAllPrivateChats)
+        ->scope(new BotCommandScopeAllGroupChats);
 
     $bot->onCommand('help', function (Nutgram $bot) {
         $bot->sendMessage('Help command!');
     })
         ->description('Help command')
-        ->scope(BotCommandScopeAllPrivateChats::apply())
-        ->scope(BotCommandScopeAllPrivateChats::apply());
+        ->scope(new BotCommandScopeAllPrivateChats)
+        ->scope(new BotCommandScopeAllPrivateChats);
 
 
     $bot->beforeApiRequest(function (Nutgram $bot, array $request) use (&$history) {
@@ -298,68 +298,68 @@ test('all scopes', function () {
         $bot->sendMessage('Help command!');
     })
         ->description('Help command')
-        ->scope(BotCommandScopeDefault::apply());
+        ->scope(new BotCommandScopeDefault);
 
     $bot->onCommand('admins', function (Nutgram $bot) {
         $bot->sendMessage('Admins command!');
     })
         ->description('Admins command')
-        ->scope(BotCommandScopeAllChatAdministrators::apply());
+        ->scope(new BotCommandScopeAllChatAdministrators);
 
     $bot->onCommand('groups', function (Nutgram $bot) {
         $bot->sendMessage('Groups command!');
     })
         ->description('Groups command')
-        ->scope(BotCommandScopeAllGroupChats::apply());
+        ->scope(new BotCommandScopeAllGroupChats);
 
     $bot->onCommand('private', function (Nutgram $bot) {
         $bot->sendMessage('Private command!');
     })
         ->description('Private command')
-        ->scope(BotCommandScopeAllPrivateChats::apply());
+        ->scope(new BotCommandScopeAllPrivateChats);
 
     $bot->onCommand('chat_a', function (Nutgram $bot) {
         $bot->sendMessage('ChatA command!');
     })
         ->description('ChatA command')
-        ->scope(BotCommandScopeChat::apply(123));
+        ->scope(new BotCommandScopeChat(123));
 
     $bot->onCommand('chat_b', function (Nutgram $bot) {
         $bot->sendMessage('ChatB command!');
     })
         ->description('ChatB command')
-        ->scope(BotCommandScopeChat::apply(456));
+        ->scope(new BotCommandScopeChat(456));
 
     $bot->onCommand('chat_admin_a', function (Nutgram $bot) {
         $bot->sendMessage('ChatAdminA command!');
     })
         ->description('ChatAdminA command')
-        ->scope(BotCommandScopeChatAdministrators::apply(123));
+        ->scope(new BotCommandScopeChatAdministrators(123));
 
     $bot->onCommand('chat_admin_b', function (Nutgram $bot) {
         $bot->sendMessage('ChatAdminB command!');
     })
         ->description('ChatAdminB command')
-        ->scope(BotCommandScopeChatAdministrators::apply(456));
+        ->scope(new BotCommandScopeChatAdministrators(456));
 
     $bot->onCommand('chat_member_a', function (Nutgram $bot) {
         $bot->sendMessage('ChatMemberA command!');
     })
         ->description('ChatMemberA command')
-        ->scope(BotCommandScopeChatMember::apply(123, 987));
+        ->scope(new BotCommandScopeChatMember(123, 987));
 
     $bot->onCommand('chat_member_b', function (Nutgram $bot) {
         $bot->sendMessage('ChatMemberB command!');
     })
         ->description('ChatMemberB command')
-        ->scope(BotCommandScopeChatMember::apply(123, 654));
+        ->scope(new BotCommandScopeChatMember(123, 654));
 
     $bot->onCommand('chat_member_c', function (Nutgram $bot) {
         $bot->sendMessage('ChatMemberC command!');
     })
         ->description('ChatMemberC command')
-        ->scope(BotCommandScopeChatMember::apply(456, 321))
-        ->scope(BotCommandScopeChatMember::apply(123, 654));
+        ->scope(new BotCommandScopeChatMember(456, 321))
+        ->scope(new BotCommandScopeChatMember(123, 654));
 
     $bot->beforeApiRequest(function (Nutgram $bot, array $request) use (&$history) {
         $history[] = $request['json'];


### PR DESCRIPTION
This PR adds support for registering commands with [Command Scopes](https://core.telegram.org/bots/features#command-scopes). Command scope allows for more granular control over which users or groups can access specific commands in the bot. 

However, the support for language codes in command scope **is not implemented** in this PR.
If language code support is required, commands **must be manually set** using the `setMyCommands` method.

Overall, this update provides a useful feature for developers who want to control command access in their Telegram bots, and allows for easy integration of command scope without the need for manual command registration.

### How to set a scope

#### Single scope
```php
$bot
    ->onCommand('start',  StartCommand::class)
    ->description('Start command')
    ->scope(new BotCommandScopeAllPrivateChats);
```

#### Multiple scopes
```php
// multiple calls
$bot
    ->onCommand('start',  StartCommand::class)
    ->description('Start command')
    ->scope(new BotCommandScopeAllPrivateChats)
    ->scope(new BotCommandScopeAllGroupChats);

// as array
$bot
    ->onCommand('start',  StartCommand::class)
    ->description('Start command')
    ->scope([
        new BotCommandScopeAllPrivateChats,
        new BotCommandScopeAllGroupChats,
    ]);
```

#### Command class
```php
//StartCommand.php
<?php

class StartCommand extends Command 
{
    protected string $command = 'start';
    protected ?string $description = 'Start command';

    public function scopes(): array
    {
        return [
            new BotCommandScopeAllPrivateChats,
        ];
    }

    public function handle(Nutgram $bot): void
    {
        $bot->sendMessage('Hello World!');
    }
});

// handlers
$bot->registerCommand(StartCommand::class);
```

### Available scopes
```php
new BotCommandScopeDefault;
new BotCommandScopeAllChatAdministrators;
new BotCommandScopeAllGroupChats;
new BotCommandScopeAllPrivateChats;
new BotCommandScopeChat(chat_id: 123);
new BotCommandScopeChatAdministrators(chat_id: 123);
new BotCommandScopeChatMember(chat_id: 123, user_id: 987);
``` 