### PR TITLE
[3.x] Skip global middlewares for group method

### DIFF
--- a/src/Handlers/CollectHandlers.php
+++ b/src/Handlers/CollectHandlers.php
@@ -42,6 +42,11 @@ abstract class CollectHandlers
     protected array $handlers = [];
 
     /**
+     * @var HandlersGroup[]
+     */
+    protected array $handlersGroups = [];
+
+    /**
      * @param  callable|callable-string|array  $callable
      */
     public function middleware($callable): void
@@ -64,9 +69,9 @@ abstract class CollectHandlers
     /**
      * @param  callable|callable-string|array  $middlewares
      * @param  callable  $closure
-     * @return void
+     * @return HandlersGroup
      */
-    public function group($middlewares, callable $closure): void
+    public function group($middlewares, callable $closure): HandlersGroup
     {
         $middlewares = is_array($middlewares) ? array_reverse($middlewares) : [$middlewares];
 
@@ -102,6 +107,11 @@ abstract class CollectHandlers
         // restore the status of the parent group, if any
         $this->groupMiddlewares = $beforeMyMiddlewares;
         $this->groupHandlers = $beforeMyHandlers;
+
+        // return the group
+        $handlersGroup = new HandlersGroup($this->handlers);
+        $this->handlersGroups[] = $handlersGroup;
+        return $handlersGroup;
     }
 
     /**

--- a/src/Handlers/HandlersGroup.php
+++ b/src/Handlers/HandlersGroup.php
@@ -21,7 +21,7 @@ class HandlersGroup
         $this->skippedGlobalMiddlewares = $middlewares;
     }
 
-    public function unapplyGlobalMiddlewares(): void
+    public function evaluateGroupMethods(): void
     {
         if (!$this->skipGlobalMiddlewares) {
             return;

--- a/src/Handlers/HandlersGroup.php
+++ b/src/Handlers/HandlersGroup.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SergiX44\Nutgram\Handlers;
+
+class HandlersGroup
+{
+    protected array $handlers;
+    private bool $skipGlobalMiddlewares;
+    protected array $skippedGlobalMiddlewares;
+
+    public function __construct(array $handlers = [])
+    {
+        $this->handlers = $handlers;
+        $this->skipGlobalMiddlewares = false;
+        $this->skippedGlobalMiddlewares = [];
+    }
+
+    public function skipGlobalMiddlewares(array $middlewares = []): void
+    {
+        $this->skipGlobalMiddlewares = true;
+        $this->skippedGlobalMiddlewares = $middlewares;
+    }
+
+    public function unapplyGlobalMiddlewares(): void
+    {
+        if (!$this->skipGlobalMiddlewares) {
+            return;
+        }
+
+        array_walk_recursive($this->handlers, function ($handler) {
+            if ($handler instanceof Handler) {
+                $handler->skipGlobalMiddlewares($this->skippedGlobalMiddlewares);
+            }
+        });
+    }
+}

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -215,6 +215,13 @@ class Nutgram extends ResolveHandlers
         $this->userCache = $this->container->get(UserCache::class);
     }
 
+    protected function evaluateGroupsMethods(): void
+    {
+        foreach ($this->handlersGroups as $group) {
+            $group->evaluateGroupMethods();
+        }
+    }
+
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -222,10 +229,7 @@ class Nutgram extends ResolveHandlers
     public function run(): void
     {
         if (!$this->middlewareApplied) {
-            foreach ($this->handlersGroups as $group) {
-                $group->unapplyGlobalMiddlewares();
-            }
-
+            $this->evaluateGroupsMethods();
             $this->applyGlobalMiddleware();
             $this->middlewareApplied = true;
         }

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -222,6 +222,10 @@ class Nutgram extends ResolveHandlers
     public function run(): void
     {
         if (!$this->middlewareApplied) {
+            foreach ($this->handlersGroups as $group) {
+                $group->unapplyGlobalMiddlewares();
+            }
+
             $this->applyGlobalMiddleware();
             $this->middlewareApplied = true;
         }


### PR DESCRIPTION
This PR adds the ability to skip global middlewares for groups in the Nutgram framework. 
Currently, to skip global middlewares for a group, each route within the group needs to be individually specified. 
With this PR, you can skip global middlewares for the entire group with just one line of code.

This PR provides the requested solution by adding a skipGlobalMiddlewares method to the group method. 
The skipGlobalMiddlewares method takes an array of middleware classes to skip for the entire group.

Overall, this PR aims to enhance the usability and flexibility of the Nutgram framework by providing a more straightforward way to skip global middlewares for groups.

# Before this PR
```php
$bot->group(new CheckAdminChatMiddleware(config('bot.chats.withdraw')), function (Nutgram $bot) {
    $bot->onCommand('success', [OperationHandler::class, 'success'])
        ->skipGlobalMiddlewares([SpecifyClientMiddleware::class]);
    $bot->onCommand('cancel', [OperationHandler::class, 'cancel'])
        ->skipGlobalMiddlewares([SpecifyClientMiddleware::class]);
});
``` 

# After this PR
```php
$bot->group(new CheckAdminChatMiddleware(config('bot.chats.withdraw')), function (Nutgram $bot) {
    $bot->onCommand('success', [OperationHandler::class, 'success']);
    $bot->onCommand('cancel', [OperationHandler::class, 'cancel']);
})->skipGlobalMiddlewares([SpecifyClientMiddleware::class]);
``` 