### PR TITLE
[3.x] Add currentParameters method to obtain target handler parameters

### DIFF
--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -90,6 +90,11 @@ class Handler extends MiddlewareChain
         return $this;
     }
 
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
     /**
      * @param  array  $parameters
      * @return Handler

--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -95,6 +95,11 @@ class Handler extends MiddlewareChain
         return $this->parameters;
     }
 
+    public function hasParameters(): bool
+    {
+        return !empty($this->parameters);
+    }
+
     /**
      * @param  array  $parameters
      * @return Handler

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -46,11 +46,6 @@ abstract class ResolveHandlers extends CollectHandlers
 
     abstract public function getConfig(): array;
 
-    public function currentParameters(): array
-    {
-        return $this->currentParameters;
-    }
-
     /**
      * @return array
      */

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -128,7 +128,7 @@ abstract class ResolveHandlers extends CollectHandlers
                 ($value !== null && $handler->matching($value))
             ) {
                 $handlers[] = $handler;
-                $this->handlersParameters = [...$this->handlersParameters, ...$handler->getParameters()];
+                $this->handlersParameters = array_merge($this->handlersParameters, $handler->getParameters());
             }
         }
     }

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -42,13 +42,13 @@ abstract class ResolveHandlers extends CollectHandlers
      */
     protected ?Update $update = null;
 
-    protected array $handlersParameters = [];
+    protected array $currentParameters = [];
 
     abstract public function getConfig(): array;
 
-    public function getHandlersParameters(): array
+    public function currentParameters(): array
     {
-        return $this->handlersParameters;
+        return $this->currentParameters;
     }
 
     /**
@@ -91,6 +91,8 @@ abstract class ResolveHandlers extends CollectHandlers
 
         $this->addHandlersBy($resolvedHandlers, Update::class);
 
+        $this->setCurrentParametersFrom($resolvedHandlers);
+
         return $resolvedHandlers;
     }
 
@@ -128,7 +130,6 @@ abstract class ResolveHandlers extends CollectHandlers
                 ($value !== null && $handler->matching($value))
             ) {
                 $handlers[] = $handler;
-                $this->handlersParameters = array_merge($this->handlersParameters, $handler->getParameters());
             }
         }
     }
@@ -237,5 +238,20 @@ abstract class ResolveHandlers extends CollectHandlers
         $currentAttributes = $getAttributes->call($conversation);
         $attributes = array_diff_key($freshAttributes, $currentAttributes);
         $setAttributes->call($conversation, $attributes);
+    }
+
+    /**
+     * @param  Handler[]  $handlers
+     * @return void
+     */
+    protected function setCurrentParametersFrom(array $handlers): void
+    {
+        $parameters = [];
+        foreach ($handlers as $handler) {
+            if ($handler->hasParameters()) {
+                $parameters[] = $handler->getParameters();
+            }
+        }
+        $this->currentParameters = array_merge(...$parameters);
     }
 }

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -42,7 +42,14 @@ abstract class ResolveHandlers extends CollectHandlers
      */
     protected ?Update $update = null;
 
+    protected array $handlersParameters = [];
+
     abstract public function getConfig(): array;
+
+    public function getHandlersParameters(): array
+    {
+        return $this->handlersParameters;
+    }
 
     /**
      * @return array
@@ -121,6 +128,7 @@ abstract class ResolveHandlers extends CollectHandlers
                 ($value !== null && $handler->matching($value))
             ) {
                 $handlers[] = $handler;
+                $this->handlersParameters = [...$this->handlersParameters, ...$handler->getParameters()];
             }
         }
     }

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -122,7 +122,7 @@ class Nutgram extends ResolveHandlers
             '%s/bot%s/%s',
             $this->config['api_url'] ?? self::DEFAULT_API_URL,
             $this->token,
-            $this->config['test_env'] ?? false ? 'test/' : ''
+                $this->config['test_env'] ?? false ? 'test/' : ''
         );
 
         $this->http = new Guzzle(array_merge([
@@ -452,5 +452,15 @@ class Nutgram extends ResolveHandlers
     public function getBulkMessenger(): BulkMessenger
     {
         return $this->container->get(BulkMessenger::class);
+    }
+
+    /**
+     * Returns a list of all parameters parsed by the current handlers
+     *
+     * @return array
+     */
+    public function currentParameters(): array
+    {
+        return $this->currentParameters;
     }
 }

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -773,3 +773,21 @@ it('calls beforeApiRequest without global middlewares', function ($update) {
 
     expect($history)->toBe(['nope']);
 })->with('text');
+
+it('get handler parameters inside local middleware', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onText('I want {number} portions of (pizza|cake)', function (Nutgram $bot, $amount, $dish) {
+        expect($amount)->toBe('12')
+            ->and($dish)->toBe('pizza');
+    })->middleware(function (Nutgram $bot, $next) {
+        [$amount, $dish] = $bot->getHandlersParameters();
+
+        expect($amount)->toBe('12')
+            ->and($dish)->toBe('pizza');
+
+        $next($bot);
+    });
+
+    $bot->run();
+})->with('food');

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -781,7 +781,7 @@ it('get handler parameters inside local middleware', function ($update) {
         expect($amount)->toBe('12')
             ->and($dish)->toBe('pizza');
     })->middleware(function (Nutgram $bot, $next) {
-        [$amount, $dish] = $bot->getHandlersParameters();
+        [$amount, $dish] = $bot->currentParameters();
 
         expect($amount)->toBe('12')
             ->and($dish)->toBe('pizza');
@@ -790,6 +790,8 @@ it('get handler parameters inside local middleware', function ($update) {
     });
 
     $bot->run();
+    $bot->run();
+    $bot->run();
 })->with('food');
 
 
@@ -797,7 +799,7 @@ it('get handlers parameters inside local middleware', function () {
     $bot = Nutgram::fake();
 
     $checkUserID = function (Nutgram $bot, $next) {
-        expect($bot->getHandlersParameters())
+        expect($bot->currentParameters())
             ->sequence(
                 fn ($item) => $item->toBe('123'),
                 fn ($item) => $item->toBe('123'),

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -791,3 +791,29 @@ it('get handler parameters inside local middleware', function ($update) {
 
     $bot->run();
 })->with('food');
+
+
+it('get handlers parameters inside local middleware', function () {
+    $bot = Nutgram::fake();
+
+    $checkUserID = function (Nutgram $bot, $next) {
+        expect($bot->getHandlersParameters())
+            ->sequence(
+                fn ($item) => $item->toBe('123'),
+                fn ($item) => $item->toBe('123'),
+            );
+
+        $next($bot);
+    };
+
+    $bot->group($checkUserID, function (Nutgram $bot) {
+        $bot->onCallbackQueryData('user/([0-9]+)/show', function (Nutgram $bot, string $id) {
+            expect($id)->toBe('123');
+        });
+        $bot->onCallbackQueryData('user/([0-9]+)/.*', function (Nutgram $bot, string $id) {
+            expect($id)->toBe('123');
+        });
+    });
+
+    $bot->hearCallbackQueryData('user/123/show')->reply();
+});


### PR DESCRIPTION
This PR introduces the `currentParameters` method to the `Nutgram` class, allowing you to obtain the parameters of the target handlers. You can use this method in any context of the code, not just within middleware. 

## Context:
Handlers can be defined with one or more parameters to receive specific information about the messages. 
Until now, it has been difficult to access the parameters of handlers within the bot's code. 
With the introduction of the new `currentParameters` method, it is possible to access the parameters of handlers in any context of the code.

## Functionality of the method: 
The `currentParameters` method returns an `array` containing the parameters of the target handlers. 
In the bot's code, you can use the array returned by the method to access the handler's parameters and use them in your own code.

## Example usage:
### Use case:
```php
$bot = new Nutgram('TOKEN');

$bot->group(CheckUserMiddleware::class, function(Nutgram $bot){
    $bot->onCallbackQueryData('user/([0-9]+)/show', [UserController::class, 'show']);
    $bot->onCallbackQueryData('user/([0-9]+)/edit', [UserController::class, 'edit']);
    $bot->onCallbackQueryData('user/([0-9]+)/delete', [UserController::class, 'delete']);
});

$bot->run();
```

### Before this PR:
```php
class CheckUserMiddleware
{
	public function __invoke(Nutgram $bot, $next)
	{
		preg_match('/user\/([0-9]+)\/.*/', $bot->callbackQuery()->data, $matches);
	    $id = $matches[1];
	    //TODO: check user by $id
	    $next($bot);
	}
}
``` 

### After this PR:
```php
class CheckUserMiddleware
{
	public function __invoke(Nutgram $bot, $next)
	{
		[$id] = $bot->currentParameters();
	    //TODO: check user by $id
	    $next($bot);
	}
}
``` 

## Warning
The `currentParameters` method returns an array containing **all parameters of all resolved handlers**. 
This behavior can lead to unexpected results in some cases, so be sure to use the method carefully and be aware of the parameters of the resolved handlers.

Example:
```php
// CheckUserMiddleware.php
class CheckUserMiddleware
{
	public function __invoke(Nutgram $bot, $next)
	{
		$parameters = $bot->currentParameters();
	    //$parameters[0] = 'your-value'; <= for onCallbackQueryData('user/([0-9]+)/show')
	    //$parameters[1] = 'your-value'; <= for onCallbackQueryData('user/([0-9]+)/.*')
	    $next($bot);
	}
}

// bot.php
$bot = new Nutgram('TOKEN');

$bot->group(CheckUserMiddleware::class, function(Nutgram $bot){
    $bot->onCallbackQueryData('user/([0-9]+)/show', [UserController::class, 'show']);
    $bot->onCallbackQueryData('user/([0-9]+)/.*', [UserController::class, 'edit']);
});

$bot->run();
```