### PR TITLE
[4.x] Fix InputFile inside InputMedia* classes

### DIFF
--- a/src/Telegram/Endpoints/UpdatesMessages.php
+++ b/src/Telegram/Endpoints/UpdatesMessages.php
@@ -123,7 +123,6 @@ trait UpdatesMessages
             'reply_markup',
             'clientOpt'
         );
-        $parameters['media'] = json_encode($media, JSON_THROW_ON_ERROR);
         $target = $this->targetChatMessageOrInlineMessageId($parameters);
 
         return $this->requestMultipart(

--- a/src/Telegram/Types/Input/InputMediaAnimation.php
+++ b/src/Telegram/Types/Input/InputMediaAnimation.php
@@ -2,6 +2,7 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Input;
 
+use JsonSerializable;
 use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Nutgram\Telegram\Properties\InputMediaType;
 use SergiX44\Nutgram\Telegram\Properties\ParseMode;
@@ -12,7 +13,7 @@ use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
  * Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent.
  * @see https://core.telegram.org/bots/api#inputmediaanimation
  */
-class InputMediaAnimation extends InputMedia
+class InputMediaAnimation extends InputMedia implements JsonSerializable
 {
     /** Type of the result, must be animation */
     public InputMediaType $type = InputMediaType::ANIMATION;
@@ -82,7 +83,6 @@ class InputMediaAnimation extends InputMedia
     public ?bool $has_spoiler = null;
 
     public function __construct(
-        InputMediaType $type,
         InputFile|string $media,
         InputFile|string|null $thumbnail,
         ?string $caption,
@@ -94,7 +94,6 @@ class InputMediaAnimation extends InputMedia
         ?bool $has_spoiler
     ) {
         parent::__construct();
-        $this->type = $type;
         $this->media = $media;
         $this->thumbnail = $thumbnail;
         $this->caption = $caption;
@@ -107,7 +106,6 @@ class InputMediaAnimation extends InputMedia
     }
 
     public static function make(
-        InputMediaType $type,
         InputFile|string $media,
         InputFile|string|null $thumbnail = null,
         ?string $caption = null,
@@ -119,7 +117,6 @@ class InputMediaAnimation extends InputMedia
         ?bool $has_spoiler = null
     ): self {
         return new self(
-            type: $type,
             media: $media,
             thumbnail: $thumbnail,
             caption: $caption,
@@ -130,5 +127,21 @@ class InputMediaAnimation extends InputMedia
             duration: $duration,
             has_spoiler: $has_spoiler
         );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return array_filter([
+            'type' => $this->type,
+            'media' => $this->media,
+            'thumb' => $this->thumbnail,
+            'caption' => $this->caption,
+            'parse_mode' => $this->parse_mode?->value,
+            'caption_entities' => $this->caption_entities,
+            'width' => $this->width,
+            'height' => $this->height,
+            'duration' => $this->duration,
+            'has_spoiler' => $this->has_spoiler,
+        ]);
     }
 }

--- a/src/Telegram/Types/Input/InputMediaAnimation.php
+++ b/src/Telegram/Types/Input/InputMediaAnimation.php
@@ -80,4 +80,55 @@ class InputMediaAnimation extends InputMedia
      * Pass True if the animation needs to be covered with a spoiler animation
      */
     public ?bool $has_spoiler = null;
+
+    public function __construct(
+        InputMediaType $type,
+        InputFile|string $media,
+        InputFile|string|null $thumbnail,
+        ?string $caption,
+        ?ParseMode $parse_mode,
+        ?array $caption_entities,
+        ?int $width,
+        ?int $height,
+        ?int $duration,
+        ?bool $has_spoiler
+    ) {
+        parent::__construct();
+        $this->type = $type;
+        $this->media = $media;
+        $this->thumbnail = $thumbnail;
+        $this->caption = $caption;
+        $this->parse_mode = $parse_mode;
+        $this->caption_entities = $caption_entities;
+        $this->width = $width;
+        $this->height = $height;
+        $this->duration = $duration;
+        $this->has_spoiler = $has_spoiler;
+    }
+
+    public static function make(
+        InputMediaType $type,
+        InputFile|string $media,
+        InputFile|string|null $thumbnail = null,
+        ?string $caption = null,
+        ?ParseMode $parse_mode = null,
+        ?array $caption_entities = null,
+        ?int $width = null,
+        ?int $height = null,
+        ?int $duration = null,
+        ?bool $has_spoiler = null
+    ): self {
+        return new self(
+            type: $type,
+            media: $media,
+            thumbnail: $thumbnail,
+            caption: $caption,
+            parse_mode: $parse_mode,
+            caption_entities: $caption_entities,
+            width: $width,
+            height: $height,
+            duration: $duration,
+            has_spoiler: $has_spoiler
+        );
+    }
 }

--- a/src/Telegram/Types/Input/InputMediaAudio.php
+++ b/src/Telegram/Types/Input/InputMediaAudio.php
@@ -74,4 +74,51 @@ class InputMediaAudio extends InputMedia
      * Title of the audio
      */
     public ?string $title = null;
+
+    public function __construct(
+        InputMediaType $type,
+        InputFile|string $media,
+        InputFile|string|null $thumbnail,
+        ?string $caption,
+        ?ParseMode $parse_mode,
+        ?array $caption_entities,
+        ?int $duration,
+        ?string $performer,
+        ?string $title
+    ) {
+        parent::__construct();
+        $this->type = $type;
+        $this->media = $media;
+        $this->thumbnail = $thumbnail;
+        $this->caption = $caption;
+        $this->parse_mode = $parse_mode;
+        $this->caption_entities = $caption_entities;
+        $this->duration = $duration;
+        $this->performer = $performer;
+        $this->title = $title;
+    }
+
+    public static function make(
+        InputMediaType $type,
+        InputFile|string $media,
+        InputFile|string|null $thumbnail = null,
+        ?string $caption = null,
+        ?ParseMode $parse_mode = null,
+        ?array $caption_entities = null,
+        ?int $duration = null,
+        ?string $performer = null,
+        ?string $title = null
+    ): self {
+        return new self(
+            type: $type,
+            media: $media,
+            thumbnail: $thumbnail,
+            caption: $caption,
+            parse_mode: $parse_mode,
+            caption_entities: $caption_entities,
+            duration: $duration,
+            performer: $performer,
+            title: $title
+        );
+    }
 }

--- a/src/Telegram/Types/Input/InputMediaAudio.php
+++ b/src/Telegram/Types/Input/InputMediaAudio.php
@@ -2,6 +2,7 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Input;
 
+use JsonSerializable;
 use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Nutgram\Telegram\Properties\InputMediaType;
 use SergiX44\Nutgram\Telegram\Properties\ParseMode;
@@ -12,7 +13,7 @@ use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
  * Represents an audio file to be treated as music to be sent.
  * @see https://core.telegram.org/bots/api#inputmediaaudio
  */
-class InputMediaAudio extends InputMedia
+class InputMediaAudio extends InputMedia implements JsonSerializable
 {
     /** Type of the result, must be audio */
     public InputMediaType $type = InputMediaType::AUDIO;
@@ -76,7 +77,6 @@ class InputMediaAudio extends InputMedia
     public ?string $title = null;
 
     public function __construct(
-        InputMediaType $type,
         InputFile|string $media,
         InputFile|string|null $thumbnail,
         ?string $caption,
@@ -87,7 +87,6 @@ class InputMediaAudio extends InputMedia
         ?string $title
     ) {
         parent::__construct();
-        $this->type = $type;
         $this->media = $media;
         $this->thumbnail = $thumbnail;
         $this->caption = $caption;
@@ -99,7 +98,6 @@ class InputMediaAudio extends InputMedia
     }
 
     public static function make(
-        InputMediaType $type,
         InputFile|string $media,
         InputFile|string|null $thumbnail = null,
         ?string $caption = null,
@@ -110,7 +108,6 @@ class InputMediaAudio extends InputMedia
         ?string $title = null
     ): self {
         return new self(
-            type: $type,
             media: $media,
             thumbnail: $thumbnail,
             caption: $caption,
@@ -120,5 +117,20 @@ class InputMediaAudio extends InputMedia
             performer: $performer,
             title: $title
         );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return array_filter([
+            'type' => $this->type,
+            'media' => $this->media,
+            'thumb' => $this->thumbnail,
+            'caption' => $this->caption,
+            'parse_mode' => $this->parse_mode?->value,
+            'caption_entities' => $this->caption_entities,
+            'duration' => $this->duration,
+            'performer' => $this->performer,
+            'title' => $this->title
+        ]);
     }
 }

--- a/src/Telegram/Types/Input/InputMediaDocument.php
+++ b/src/Telegram/Types/Input/InputMediaDocument.php
@@ -63,4 +63,43 @@ class InputMediaDocument extends InputMedia
      * Always True, if the document is sent as part of an album.
      */
     public ?bool $disable_content_type_detection = null;
+
+    public function __construct(
+        InputMediaType $type,
+        InputFile|string $media,
+        InputFile|string|null $thumbnail,
+        ?string $caption,
+        ?ParseMode $parse_mode,
+        ?array $caption_entities,
+        ?bool $disable_content_type_detection
+    ) {
+        parent::__construct();
+        $this->type = $type;
+        $this->media = $media;
+        $this->thumbnail = $thumbnail;
+        $this->caption = $caption;
+        $this->parse_mode = $parse_mode;
+        $this->caption_entities = $caption_entities;
+        $this->disable_content_type_detection = $disable_content_type_detection;
+    }
+
+    public static function make(
+        InputMediaType $type,
+        InputFile|string $media,
+        InputFile|string|null $thumbnail = null,
+        ?string $caption = null,
+        ?ParseMode $parse_mode = null,
+        ?array $caption_entities = null,
+        ?bool $disable_content_type_detection = null
+    ): self {
+        return new self(
+            type: $type,
+            media: $media,
+            thumbnail: $thumbnail,
+            caption: $caption,
+            parse_mode: $parse_mode,
+            caption_entities: $caption_entities,
+            disable_content_type_detection: $disable_content_type_detection
+        );
+    }
 }

--- a/src/Telegram/Types/Input/InputMediaDocument.php
+++ b/src/Telegram/Types/Input/InputMediaDocument.php
@@ -2,6 +2,7 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Input;
 
+use JsonSerializable;
 use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Nutgram\Telegram\Properties\InputMediaType;
 use SergiX44\Nutgram\Telegram\Properties\ParseMode;
@@ -12,7 +13,7 @@ use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
  * Represents a general file to be sent.
  * @see https://core.telegram.org/bots/api#inputmediadocument
  */
-class InputMediaDocument extends InputMedia
+class InputMediaDocument extends InputMedia implements JsonSerializable
 {
     /** Type of the result, must be document */
     public InputMediaType $type = InputMediaType::DOCUMENT;
@@ -65,7 +66,6 @@ class InputMediaDocument extends InputMedia
     public ?bool $disable_content_type_detection = null;
 
     public function __construct(
-        InputMediaType $type,
         InputFile|string $media,
         InputFile|string|null $thumbnail,
         ?string $caption,
@@ -74,7 +74,6 @@ class InputMediaDocument extends InputMedia
         ?bool $disable_content_type_detection
     ) {
         parent::__construct();
-        $this->type = $type;
         $this->media = $media;
         $this->thumbnail = $thumbnail;
         $this->caption = $caption;
@@ -84,7 +83,6 @@ class InputMediaDocument extends InputMedia
     }
 
     public static function make(
-        InputMediaType $type,
         InputFile|string $media,
         InputFile|string|null $thumbnail = null,
         ?string $caption = null,
@@ -93,7 +91,6 @@ class InputMediaDocument extends InputMedia
         ?bool $disable_content_type_detection = null
     ): self {
         return new self(
-            type: $type,
             media: $media,
             thumbnail: $thumbnail,
             caption: $caption,
@@ -101,5 +98,18 @@ class InputMediaDocument extends InputMedia
             caption_entities: $caption_entities,
             disable_content_type_detection: $disable_content_type_detection
         );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return array_filter([
+            'type' => $this->type,
+            'media' => $this->media,
+            'thumb' => $this->thumbnail,
+            'caption' => $this->caption,
+            'parse_mode' => $this->parse_mode?->value,
+            'caption_entities' => $this->caption_entities,
+            'disable_content_type_detection' => $this->disable_content_type_detection,
+        ]);
     }
 }

--- a/src/Telegram/Types/Input/InputMediaPhoto.php
+++ b/src/Telegram/Types/Input/InputMediaPhoto.php
@@ -50,4 +50,39 @@ class InputMediaPhoto extends InputMedia
      * Pass True if the photo needs to be covered with a spoiler animation
      */
     public ?bool $has_spoiler = null;
+
+    public function __construct(
+        InputMediaType $type,
+        InputFile|string $media,
+        ?string $caption,
+        ?ParseMode $parse_mode,
+        ?array $caption_entities,
+        ?bool $has_spoiler
+    ) {
+        parent::__construct();
+        $this->type = $type;
+        $this->media = $media;
+        $this->caption = $caption;
+        $this->parse_mode = $parse_mode;
+        $this->caption_entities = $caption_entities;
+        $this->has_spoiler = $has_spoiler;
+    }
+
+    public static function make(
+        InputMediaType $type,
+        InputFile|string $media,
+        ?string $caption = null,
+        ?ParseMode $parse_mode = null,
+        ?array $caption_entities = null,
+        ?bool $has_spoiler = null
+    ): self {
+        return new self(
+            type: $type,
+            media: $media,
+            caption: $caption,
+            parse_mode: $parse_mode,
+            caption_entities: $caption_entities,
+            has_spoiler: $has_spoiler
+        );
+    }
 }

--- a/src/Telegram/Types/Input/InputMediaPhoto.php
+++ b/src/Telegram/Types/Input/InputMediaPhoto.php
@@ -2,6 +2,7 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Input;
 
+use JsonSerializable;
 use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Nutgram\Telegram\Properties\InputMediaType;
 use SergiX44\Nutgram\Telegram\Properties\ParseMode;
@@ -12,7 +13,7 @@ use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
  * Represents a photo to be sent.
  * @see https://core.telegram.org/bots/api#inputmediaphoto
  */
-class InputMediaPhoto extends InputMedia
+class InputMediaPhoto extends InputMedia implements JsonSerializable
 {
     /** Type of the result, must be photo */
     public InputMediaType $type = InputMediaType::PHOTO;
@@ -52,7 +53,6 @@ class InputMediaPhoto extends InputMedia
     public ?bool $has_spoiler = null;
 
     public function __construct(
-        InputMediaType $type,
         InputFile|string $media,
         ?string $caption,
         ?ParseMode $parse_mode,
@@ -60,7 +60,6 @@ class InputMediaPhoto extends InputMedia
         ?bool $has_spoiler
     ) {
         parent::__construct();
-        $this->type = $type;
         $this->media = $media;
         $this->caption = $caption;
         $this->parse_mode = $parse_mode;
@@ -69,7 +68,6 @@ class InputMediaPhoto extends InputMedia
     }
 
     public static function make(
-        InputMediaType $type,
         InputFile|string $media,
         ?string $caption = null,
         ?ParseMode $parse_mode = null,
@@ -77,12 +75,24 @@ class InputMediaPhoto extends InputMedia
         ?bool $has_spoiler = null
     ): self {
         return new self(
-            type: $type,
             media: $media,
             caption: $caption,
             parse_mode: $parse_mode,
             caption_entities: $caption_entities,
             has_spoiler: $has_spoiler
         );
+    }
+
+
+    public function jsonSerialize(): array
+    {
+        return array_filter([
+            'type' => $this->type->value,
+            'media' => $this->media,
+            'caption' => $this->caption,
+            'parse_mode' => $this->parse_mode?->value,
+            'caption_entities' => $this->caption_entities,
+            'has_spoiler' => $this->has_spoiler,
+        ]);
     }
 }

--- a/src/Telegram/Types/Input/InputMediaVideo.php
+++ b/src/Telegram/Types/Input/InputMediaVideo.php
@@ -2,6 +2,7 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Input;
 
+use JsonSerializable;
 use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Nutgram\Telegram\Properties\InputMediaType;
 use SergiX44\Nutgram\Telegram\Properties\ParseMode;
@@ -12,7 +13,7 @@ use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
  * Represents a video to be sent.
  * @see https://core.telegram.org/bots/api#inputmediavideo
  */
-class InputMediaVideo extends InputMedia
+class InputMediaVideo extends InputMedia implements JsonSerializable
 {
     /** Type of the result, must be video */
     public InputMediaType $type = InputMediaType::VIDEO;
@@ -88,7 +89,6 @@ class InputMediaVideo extends InputMedia
     public ?bool $has_spoiler = null;
 
     public function __construct(
-        InputMediaType $type,
         InputFile|string $media,
         InputFile|string|null $thumbnail,
         ?string $caption,
@@ -101,7 +101,6 @@ class InputMediaVideo extends InputMedia
         ?bool $has_spoiler
     ) {
         parent::__construct();
-        $this->type = $type;
         $this->media = $media;
         $this->thumbnail = $thumbnail;
         $this->caption = $caption;
@@ -115,7 +114,6 @@ class InputMediaVideo extends InputMedia
     }
 
     public static function make(
-        InputMediaType $type,
         InputFile|string $media,
         InputFile|string|null $thumbnail = null,
         ?string $caption = null,
@@ -128,7 +126,6 @@ class InputMediaVideo extends InputMedia
         ?bool $has_spoiler = null
     ): self {
         return new self(
-            $type,
             $media,
             $thumbnail,
             $caption,
@@ -140,5 +137,21 @@ class InputMediaVideo extends InputMedia
             $supports_streaming,
             $has_spoiler
         );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return array_filter([
+            'type' => $this->type,
+            'media' => $this->media,
+            'caption' => $this->caption,
+            'parse_mode' => $this->parse_mode?->value,
+            'caption_entities' => $this->caption_entities,
+            'width' => $this->width,
+            'height' => $this->height,
+            'duration' => $this->duration,
+            'supports_streaming' => $this->supports_streaming,
+            'has_spoiler' => $this->has_spoiler,
+        ]);
     }
 }

--- a/src/Telegram/Types/Input/InputMediaVideo.php
+++ b/src/Telegram/Types/Input/InputMediaVideo.php
@@ -86,4 +86,59 @@ class InputMediaVideo extends InputMedia
      * Pass True if the video needs to be covered with a spoiler animation
      */
     public ?bool $has_spoiler = null;
+
+    public function __construct(
+        InputMediaType $type,
+        InputFile|string $media,
+        InputFile|string|null $thumbnail,
+        ?string $caption,
+        ?ParseMode $parse_mode,
+        ?array $caption_entities,
+        ?int $width,
+        ?int $height,
+        ?int $duration,
+        ?bool $supports_streaming,
+        ?bool $has_spoiler
+    ) {
+        parent::__construct();
+        $this->type = $type;
+        $this->media = $media;
+        $this->thumbnail = $thumbnail;
+        $this->caption = $caption;
+        $this->parse_mode = $parse_mode;
+        $this->caption_entities = $caption_entities;
+        $this->width = $width;
+        $this->height = $height;
+        $this->duration = $duration;
+        $this->supports_streaming = $supports_streaming;
+        $this->has_spoiler = $has_spoiler;
+    }
+
+    public static function make(
+        InputMediaType $type,
+        InputFile|string $media,
+        InputFile|string|null $thumbnail = null,
+        ?string $caption = null,
+        ?ParseMode $parse_mode = null,
+        ?array $caption_entities = null,
+        ?int $width = null,
+        ?int $height = null,
+        ?int $duration = null,
+        ?bool $supports_streaming = null,
+        ?bool $has_spoiler = null
+    ): self {
+        return new self(
+            $type,
+            $media,
+            $thumbnail,
+            $caption,
+            $parse_mode,
+            $caption_entities,
+            $width,
+            $height,
+            $duration,
+            $supports_streaming,
+            $has_spoiler
+        );
+    }
 }

--- a/src/Telegram/Types/Internal/InputFile.php
+++ b/src/Telegram/Types/Internal/InputFile.php
@@ -2,6 +2,8 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Internal;
 
+use InvalidArgumentException;
+
 /**
  * This object represents the contents of a file to be uploaded. Must be posted using
  * multipart/form-data in the usual way that files are uploaded via the browser.
@@ -30,12 +32,12 @@ class InputFile implements \JsonSerializable
         } elseif (is_string($resource) && file_exists($resource)) {
             $res = fopen($resource, 'rb+');
             if ($res === false) {
-                throw new \InvalidArgumentException('Invalid resource specified.');
+                throw new InvalidArgumentException('Cannot open the specified resource.');
             }
 
             $this->resource = $res;
         } else {
-            throw new \InvalidArgumentException('Invalid resource specified.');
+            throw new InvalidArgumentException('Invalid resource specified.');
         }
     }
 
@@ -81,22 +83,8 @@ class InputFile implements \JsonSerializable
         return basename($this->filename ?? uniqid(more_entropy: true));
     }
 
-    public function jsonSerialize(): mixed
+    public function jsonSerialize(): string
     {
-        return $this->getAttachString();
-    }
-
-    public function getAttachString(): string
-    {
-        return 'attach://'.$this->getFilename();
-    }
-
-    public function toMultipart(): array
-    {
-        return [
-            'name' => $this->getFilename(),
-            'contents' => $this->getResource(),
-            'filename' => $this->getFilename(),
-        ];
+        return "attach://{$this->getFilename()}";
     }
 }

--- a/src/Telegram/Types/Internal/InputFile.php
+++ b/src/Telegram/Types/Internal/InputFile.php
@@ -6,7 +6,7 @@ namespace SergiX44\Nutgram\Telegram\Types\Internal;
  * This object represents the contents of a file to be uploaded. Must be posted using
  * multipart/form-data in the usual way that files are uploaded via the browser.
  */
-class InputFile
+class InputFile implements \JsonSerializable
 {
     /**
      * @var resource
@@ -79,5 +79,24 @@ class InputFile
         }
 
         return basename($this->filename ?? uniqid(more_entropy: true));
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->getAttachString();
+    }
+
+    public function getAttachString(): string
+    {
+        return 'attach://'.$this->getFilename();
+    }
+
+    public function toMultipart(): array
+    {
+        return [
+            'name' => $this->getFilename(),
+            'contents' => $this->getResource(),
+            'filename' => $this->getFilename(),
+        ];
     }
 }

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -835,7 +835,6 @@ it('get handler parameters inside local middleware', function ($update) {
     $bot->run();
 })->with('food');
 
-
 it('get handlers parameters inside local middleware', function () {
     $bot = Nutgram::fake();
 


### PR DESCRIPTION
# TODO
- [x] Add constructor + make to `InputMedia*` classes
- [x] Add `json_encode` to `media` and `thumbnail` property if value is `InputFile`
- [x] Update `InputFile` (take inspiration from https://github.com/telegram-bot-sdk/telegram-bot-sdk/blob/1d9337a4a1db802256bb468efe8620ada1e62809/src/FileUpload/InputFile.php)
- [x] Test
- [x] Optimize this schifo

# Use Case
```php
$bot = new Nutgram('TOKEN');

$bot->onCommand('start', function (Nutgram $bot) {
    $message = $bot->sendPhoto(
        photo: InputFile::make('A.jpg'),
        caption: 'A',
    );
    
    sleep(1);
    
    $bot->editMessageMedia(
        media: InputMediaPhoto::make(
            media: InputFile::make('B.jpg'),
			caption: 'B',
        ),
        chat_id: $message->chat->id,
        message_id: $message->message_id
    );
});

$bot->run();
``` 