### PR TITLE
Case insensitive onText for Cyrillic

### DIFF
--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -68,7 +68,7 @@ class Handler extends MiddlewareChain
         $pattern = str_replace('/', '\/', $this->pattern);
 
         // replace named parameters with regex
-        $regex = '/^'.preg_replace(self::PARAM_NAME_REGEX, '(?<$1>.*)', $pattern).'?$/miU';
+        $regex = '/^'.preg_replace(self::PARAM_NAME_REGEX, '(?<$1>.*)', $pattern).'?$/miUu';
 
         // match + return only named parameters
         $regexMatched = (bool)preg_match($regex, $value, $matches, PREG_UNMATCHED_AS_NULL);


### PR DESCRIPTION
When using code like this, it is expected that the handler will respond equally to both the "example" message and the "EXAMPLE" message. And that the same behavior would be for "пример" and "ПРИМЕР":
```php
$bot->onText('example', function (Nutgram $bot) {
    $bot->sendMessage('It works for English');
});

$bot->onText('пример', function (Nutgram $bot) {
    $bot->sendMessage('It works for Russian');
});
```

However, case insensitivity does not work for Cyrillic:

![Screenshot_20230512_035446_Telegram](https://github.com/nutgram/nutgram/assets/40361422/cf38d8e8-0ea9-4ede-bc96-bdacc484d7ef)
