### PR TITLE
Get current parameters for the current resolved handler

### DIFF
--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -44,8 +44,6 @@ abstract class ResolveHandlers extends CollectHandlers
      */
     protected ?Update $update = null;
 
-    protected array $currentParameters = [];
-
     abstract public function getConfig(): Configuration;
 
     /**
@@ -87,8 +85,6 @@ abstract class ResolveHandlers extends CollectHandlers
         }
 
         $this->addHandlersBy($resolvedHandlers, Update::class);
-
-        $this->setCurrentParametersFrom($resolvedHandlers);
 
         return $resolvedHandlers;
     }
@@ -235,21 +231,6 @@ abstract class ResolveHandlers extends CollectHandlers
         $currentAttributes = $getAttributes->call($conversation);
         $attributes = array_diff_key($freshAttributes, $currentAttributes);
         $setAttributes->call($conversation, $attributes);
-    }
-
-    /**
-     * @param Handler[] $handlers
-     * @return void
-     */
-    protected function setCurrentParametersFrom(array $handlers): void
-    {
-        $parameters = [];
-        foreach ($handlers as $handler) {
-            if ($handler->hasParameters()) {
-                $parameters[] = $handler->getParameters();
-            }
-        }
-        $this->currentParameters = array_merge(...$parameters);
     }
 
     protected function resolveGroups(): void

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -69,10 +69,12 @@ class Nutgram extends ResolveHandlers
      */
     protected ContainerInterface $container;
 
+    protected ?Handler $currentHandler = null;
+
     /**
      * Nutgram constructor.
-     * @param  string  $token
-     * @param  Configuration|null  $config
+     * @param string $token
+     * @param Configuration|null $config
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
@@ -268,6 +270,7 @@ class Nutgram extends ResolveHandlers
         /** @var Handler $handler */
         foreach ($handlers as $handler) {
             try {
+                $this->currentHandler = $handler;
                 $result = $handler->addParameters($parameters)->getHead()($this);
             } catch (Throwable $e) {
                 if (!empty($this->handlers[self::EXCEPTION])) {
@@ -449,6 +452,6 @@ class Nutgram extends ResolveHandlers
      */
     public function currentParameters(): array
     {
-        return $this->currentParameters;
+        return $this->currentHandler?->getParameters() ?? [];
     }
 }


### PR DESCRIPTION
## Use case
```php
// bot.php
$bot = new Nutgram('TOKEN');

$bot->group(CheckUserMiddleware::class, function(Nutgram $bot){
    $bot->onCallbackQueryData('user/([0-9]+)/show', [UserController::class, 'show']);
    $bot->onCallbackQueryData('user/([0-9]+)/.*', [UserController::class, 'edit']);
});

$bot->run();
``` 

# Before this PR
```php
// CheckUserMiddleware.php
class CheckUserMiddleware
{
    public function __invoke(Nutgram $bot, $next)
    {
        $parameters = $bot->currentParameters();
        //$parameters[0] = 'your-value'; <= for onCallbackQueryData('user/([0-9]+)/show')
        //$parameters[1] = 'your-value'; <= for onCallbackQueryData('user/([0-9]+)/.*')
        $next($bot);
    }
}
``` 

# After this PR
```php
// CheckUserMiddleware.php
class CheckUserMiddleware
{
    public function __invoke(Nutgram $bot, $next)
    {
        $parameters = $bot->currentParameters();
        //$parameters[0] = 'your-value'; <= for both handlers
        $next($bot);
    }
}
``` 