### PR TITLE
Fixing UpdateType could not be converted to string error

### DIFF
--- a/src/RunningMode/Webhook.php
+++ b/src/RunningMode/Webhook.php
@@ -62,7 +62,7 @@ class Webhook implements RunningMode
 
         $bot->getContainer()
             ->get(LoggerInterface::class)
-            ->debug(sprintf('Received update: %s%s%s', $update->getType(), PHP_EOL, $input));
+            ->debug(sprintf('Received update: %s%s%s', $update->getType()?->value, PHP_EOL, $input));
 
         $bot->processUpdate($update);
     }


### PR DESCRIPTION
Hello!
When using framework in webhook running mode I've got **Object of class SergiX44\Nutgram\Telegram\Properties\UpdateType could not be converted to string** error, located in **nutgram/src/RunningMode/Webhook.php:65**.

As far as I understand the problem is that the GetType() method in line 65 returns enumeration Update Type. The simplest solution seems to be the transfer of value, like this: $update->getType()?->value