### PR TITLE
[4.x] Throttle system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `nutgram` will be documented in this file.
 
+## 3.20.2 - 2023-06-23
+
+### What's Changed
+
+- [3.x] Fix missing temp file deletion when using the mixin method by @Lukasss93 in https://github.com/nutgram/nutgram/pull/500
+
+**Full Changelog**: https://github.com/nutgram/nutgram/compare/3.20.1...3.20.2
+
 ## 4.0.2 - 2023-06-23
 
 ### What's Changed

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
             <file>./src/Telegram/Limits.php</file>
             <file>./src/RunningMode/RunningMode.php</file>
             <file>./src/Hydrator/Hydrator.php</file>
+            <file>./src/Support/RateLimiter.php</file>
         </exclude>
     </source>
     <php>

--- a/src/Handlers/CollectHandlers.php
+++ b/src/Handlers/CollectHandlers.php
@@ -6,11 +6,12 @@ namespace SergiX44\Nutgram\Handlers;
 use SergiX44\Nutgram\Exception\StatusFinalizedException;
 use SergiX44\Nutgram\Handlers\Listeners\MessageListeners;
 use SergiX44\Nutgram\Handlers\Listeners\UpdateListeners;
+use SergiX44\Nutgram\Support\HasThrottle;
 use SergiX44\Nutgram\Telegram\Properties\UpdateType;
 
 abstract class CollectHandlers
 {
-    use UpdateListeners, MessageListeners;
+    use UpdateListeners, MessageListeners, HasThrottle;
 
     protected const FALLBACK = 'FALLBACK';
     protected const EXCEPTION = 'EXCEPTION';
@@ -174,5 +175,10 @@ abstract class CollectHandlers
     private function checkFinalized(): void
     {
         !$this->finalized ?: throw new StatusFinalizedException();
+    }
+
+    public function getThrottleHash(): string
+    {
+        return 'global';
     }
 }

--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -8,9 +8,12 @@ use Psr\Container\NotFoundExceptionInterface;
 use SergiX44\Nutgram\Middleware\Link;
 use SergiX44\Nutgram\Middleware\MiddlewareChain;
 use SergiX44\Nutgram\Nutgram;
+use SergiX44\Nutgram\Support\HasThrottle;
 
 class Handler extends MiddlewareChain
 {
+    use HasThrottle;
+
     /**
      * regular expression to capture named parameters but not quantifiers
      * captures {name}, but not {1}, {1,}, or {1,2}.

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -11,6 +11,7 @@ use SergiX44\Nutgram\Cache\UserCache;
 use SergiX44\Nutgram\Configuration;
 use SergiX44\Nutgram\Conversations\Conversation;
 use SergiX44\Nutgram\Handlers\Type\Command;
+use SergiX44\Nutgram\Middleware\ThrottleMiddleware;
 use SergiX44\Nutgram\Proxies\UpdateProxy;
 use SergiX44\Nutgram\Telegram\Properties\MessageType;
 use SergiX44\Nutgram\Telegram\Properties\UpdateType;
@@ -187,6 +188,8 @@ abstract class ResolveHandlers extends CollectHandlers
      */
     protected function applyGlobalMiddlewareTo(Handler $handler): void
     {
+        $handler->middleware(ThrottleMiddleware::class);
+
         $skippedGlobalMiddlewares = $handler->getSkippedGlobalMiddlewares();
 
         if ($handler->isSkippingGlobalMiddlewares() && empty($skippedGlobalMiddlewares)) {

--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace SergiX44\Nutgram\Middleware;
+
+use Psr\SimpleCache\CacheInterface;
+use SergiX44\Nutgram\Nutgram;
+use SergiX44\Nutgram\Support\RateLimiter;
+
+class ThrottleMiddleware
+{
+    protected const CACHE_KEY = '__throttle';
+
+    public function __invoke(Nutgram $bot, $next)
+    {
+        // if user is not set, skip this middleware
+        if ($bot->userId() === null) {
+            $next($bot);
+
+            return;
+        }
+
+        //get throttle object
+        $currentHandler = $bot->currentHandler();
+        $throttle = $currentHandler?->getThrottle() ?? $bot->getThrottle();
+
+        // if throttle is disabled, skip this middleware
+        if ($throttle === null) {
+            $next($bot);
+
+            return;
+        }
+
+        // get throttle key
+        $key = $currentHandler?->getThrottle() !== null ? $currentHandler?->getThrottleHash() : $bot->getThrottleHash();
+
+        // get the rate limit key
+        $rateLimitKey = $this->getRateLimitKey($key, $bot->userId());
+
+        // init rate limiter
+        /** @var CacheInterface $cache */
+        $cache = $bot->getContainer()->get(CacheInterface::class);
+        $rateLimiter = new RateLimiter($cache);
+
+        // use the rate limiter
+        $executed = $rateLimiter->attempt(
+            key: $rateLimitKey,
+            maxAttempts: $throttle->getAttempts(),
+            callback: fn () => $next($bot),
+            decaySeconds: $throttle->getDecay(),
+        );
+
+        // if the rate limit is not exceeded, remove the cache key
+        if ($executed) {
+            $cache->delete($rateLimitKey.':exceeded');
+        }
+
+        // if the rate limit is exceeded, send a message to the user only once
+        if (!$executed && !$cache->has($rateLimitKey.':exceeded')) {
+            // get the number of seconds until the rate limit is reset
+            $seconds = $rateLimiter->availableIn($rateLimitKey);
+
+            // if the message is a callback query, answer it
+            if ($bot->isCallbackQuery()) {
+                $bot->answerCallbackQuery();
+            }
+
+            // call throttle message closure
+            $throttleMessageClosure = $bot::$throttleMessageClosure;
+
+            // send a message to the user
+            if ($throttleMessageClosure !== null) {
+                $throttleMessageClosure($bot, $seconds);
+            } else {
+                $bot->sendMessage("Too many messages sent!\nYou may try again in $seconds seconds.");
+            }
+
+            // set the cache key to prevent sending the message again
+            $cache->set($rateLimitKey.':exceeded', 1);
+        }
+    }
+
+    protected function getRateLimitKey(string $key, int|string $userID): string
+    {
+        return sprintf("%s:%s:%d", self::CACHE_KEY, $key, $userID);
+    }
+}

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -3,6 +3,7 @@
 
 namespace SergiX44\Nutgram;
 
+use Closure;
 use GuzzleHttp\Client as Guzzle;
 use InvalidArgumentException;
 use Laravel\SerializableClosure\SerializableClosure;
@@ -71,6 +72,8 @@ class Nutgram extends ResolveHandlers
 
     protected ?Handler $currentHandler = null;
 
+    public static ?Closure $throttleMessageClosure = null;
+
     /**
      * Nutgram constructor.
      * @param string $token
@@ -112,7 +115,7 @@ class Nutgram extends ResolveHandlers
             '%s/bot%s/%s',
             $config->apiUrl,
             $this->token,
-            $config->testEnv ?? false ? 'test/' : ''
+                $config->testEnv ?? false ? 'test/' : ''
         );
 
         $this->http = new Guzzle([
@@ -376,6 +379,15 @@ class Nutgram extends ResolveHandlers
      */
     public function currentParameters(): array
     {
-        return $this->currentHandler?->getParameters() ?? [];
+        return $this->currentHandler()?->getParameters() ?? [];
+    }
+
+    /**
+     * Returns the current handler being executed
+     * @return Handler|null
+     */
+    public function currentHandler(): ?Handler
+    {
+        return $this->currentHandler;
     }
 }

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -19,6 +19,7 @@ use SergiX44\Nutgram\Cache\GlobalCache;
 use SergiX44\Nutgram\Cache\UserCache;
 use SergiX44\Nutgram\Conversations\Conversation;
 use SergiX44\Nutgram\Handlers\FireHandlers;
+use SergiX44\Nutgram\Handlers\Handler;
 use SergiX44\Nutgram\Handlers\ResolveHandlers;
 use SergiX44\Nutgram\Handlers\Type\Command;
 use SergiX44\Nutgram\Hydrator\Hydrator;

--- a/src/Support/HasThrottle.php
+++ b/src/Support/HasThrottle.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SergiX44\Nutgram\Support;
+
+trait HasThrottle
+{
+    protected ?Throttle $throttle = null;
+
+    public function throttle(int $attempts = 5, int $decay = 1): self
+    {
+        $this->throttle = new Throttle($attempts, $decay);
+        return $this;
+    }
+
+    public function getThrottle(): ?Throttle
+    {
+        return $this->throttle;
+    }
+
+    public function getThrottleHash(): string
+    {
+        return crc32(serialize(get_object_vars($this)));
+    }
+}

--- a/src/Support/HasThrottle.php
+++ b/src/Support/HasThrottle.php
@@ -19,6 +19,6 @@ trait HasThrottle
 
     public function getThrottleHash(): string
     {
-        return crc32(serialize(get_object_vars($this)));
+        return spl_object_hash($this);
     }
 }

--- a/src/Support/RateLimiter.php
+++ b/src/Support/RateLimiter.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace SergiX44\Nutgram\Support;
+
+use Closure;
+use DateInterval;
+use DateTime;
+use DateTimeInterface;
+use Psr\SimpleCache\CacheInterface;
+
+class RateLimiter
+{
+    protected CacheInterface $cache;
+
+    protected array $limiters = [];
+
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Register a named limiter configuration.
+     * @param string $name
+     * @param Closure $callback
+     * @return $this
+     */
+    public function for(string $name, Closure $callback): self
+    {
+        $this->limiters[$name] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Get the given named rate limiter.
+     * @param string $name
+     * @return Closure|null
+     */
+    public function limiter(string $name): ?Closure
+    {
+        return $this->limiters[$name] ?? null;
+    }
+
+    /**
+     * Clean the rate limiter key from unicode characters.
+     * @param string $key
+     * @return string
+     */
+    public function cleanRateLimiterKey(string $key): string
+    {
+        return preg_replace('/&([a-z])[a-z]+;/i', '$1', htmlentities($key));
+    }
+
+    /**
+     * Get the number of attempts for the given key.
+     * @param string $key
+     * @return mixed
+     */
+    public function attempts(string $key): mixed
+    {
+        $key = $this->cleanRateLimiterKey($key);
+
+        return $this->cache->get($key, 0);
+    }
+
+    /**
+     * Reset the number of attempts for the given key.
+     * @param string $key
+     * @return bool
+     */
+    public function resetAttempts(string $key): bool
+    {
+        $key = $this->cleanRateLimiterKey($key);
+
+        return $this->cache->delete($key);
+    }
+
+    /**
+     * Determine if the given key has been "accessed" too many times.
+     * @param string $key
+     * @param int $maxAttempts
+     * @return bool
+     */
+    public function tooManyAttempts(string $key, int $maxAttempts): bool
+    {
+        if ($this->attempts($key) >= $maxAttempts) {
+            if ($this->cache->has($this->cleanRateLimiterKey($key).':timer')) {
+                return true;
+            }
+
+            $this->resetAttempts($key);
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the number of seconds until the given DateTime.
+     * @param DateTimeInterface|DateInterval|int $delay
+     * @return int
+     */
+    protected function secondsUntil(DateTimeInterface|DateInterval|int $delay): int
+    {
+        $delay = $this->parseDateInterval($delay);
+
+        return $delay instanceof DateTimeInterface
+            ? max(0, $delay->getTimestamp() - $this->currentTime())
+            : (int)$delay;
+    }
+
+    /**
+     * Get the "available at" UNIX timestamp.
+     * @param DateTimeInterface|DateInterval|int $delay
+     * @return int
+     */
+    protected function availableAt(DateTimeInterface|DateInterval|int $delay = 0): int
+    {
+        $delay = $this->parseDateInterval($delay);
+
+        if ($delay instanceof DateTimeInterface) {
+            return $delay->getTimestamp();
+        }
+
+        if (is_int($delay)) {
+            $delay = new DateInterval("PT{$delay}S");
+        }
+
+        return (new DateTime())->add($delay)->getTimestamp();
+    }
+
+    /**
+     * If the given value is an interval, convert it to a DateTime instance.
+     * @param DateTimeInterface|DateInterval|int $delay
+     * @return DateTimeInterface|int
+     */
+    protected function parseDateInterval(DateTimeInterface|DateInterval|int $delay): DateTimeInterface|int
+    {
+        if ($delay instanceof DateInterval) {
+            $delay = (new DateTime())->add($delay);
+        }
+
+        return $delay;
+    }
+
+    /**
+     * Get the current system time as a UNIX timestamp.
+     *
+     * @return int
+     */
+    protected function currentTime(): int
+    {
+        return (new DateTime())->getTimestamp();
+    }
+
+    /**
+     * Increment the counter for a given key for a given decay time.
+     *
+     * @param string $key
+     * @param int $decaySeconds
+     * @return int
+     */
+    public function hit(string $key, int $decaySeconds = 60): int
+    {
+        $key = $this->cleanRateLimiterKey($key);
+
+        $this->cacheAdd($key.':timer', $this->availableAt($decaySeconds), $decaySeconds);
+
+        $added = $this->cacheAdd($key, 0, $decaySeconds);
+
+        $hits = $this->cacheIncrement($key);
+
+        if (!$added && $hits == 1) {
+            $this->cache->set($key, 1, $decaySeconds);
+        }
+
+        return $hits;
+    }
+
+    protected function cacheAdd(string $key, int $value, int $seconds): bool
+    {
+        if ($this->cache->has($key)) {
+            return false;
+        }
+
+        return $this->cache->set($key, $value, $seconds);
+    }
+
+    protected function cacheIncrement(string $key, int $value = 1): int
+    {
+        if (!$this->cache->has($key)) {
+            $this->cache->set($key, 0);
+        }
+
+        $currentValue = (int)$this->cache->get($key);
+        $newValue = $currentValue + $value;
+
+        $this->cache->set($key, $newValue);
+
+        return $newValue;
+    }
+
+    /**
+     * Attempts to execute a callback if it's not limited.
+     * @param string $key
+     * @param int $maxAttempts
+     * @param \Closure $callback
+     * @param int $decaySeconds
+     * @return mixed
+     */
+    public function attempt(string $key, int $maxAttempts, Closure $callback, int $decaySeconds = 60): mixed
+    {
+        if ($this->tooManyAttempts($key, $maxAttempts)) {
+            return false;
+        }
+
+        $result = $callback() ?: true;
+
+        $this->hit($key, $decaySeconds);
+
+        return $result;
+    }
+
+    /**
+     * Get the number of retries left for the given key.
+     * @param string $key
+     * @param int $maxAttempts
+     * @return int
+     */
+    public function remaining(string $key, int $maxAttempts): int
+    {
+        $key = $this->cleanRateLimiterKey($key);
+
+        $attempts = $this->attempts($key);
+
+        return $maxAttempts - $attempts;
+    }
+
+    /**
+     * Get the number of retries left for the given key.
+     * @param string $key
+     * @param int $maxAttempts
+     * @return int
+     */
+    public function retriesLeft(string $key, int $maxAttempts): int
+    {
+        return $this->remaining($key, $maxAttempts);
+    }
+
+    /**
+     * Clear the hits and lockout timer for the given key.
+     * @param string $key
+     * @return void
+     */
+    public function clear(string $key): void
+    {
+        $key = $this->cleanRateLimiterKey($key);
+
+        $this->resetAttempts($key);
+
+        $this->cache->delete($key.':timer');
+    }
+
+    /**
+     * Get the number of seconds until the "key" is accessible again.
+     * @param string $key
+     * @return int
+     */
+    public function availableIn(string $key): int
+    {
+        $key = $this->cleanRateLimiterKey($key);
+
+        return max(0, $this->cache->get($key.':timer') - $this->currentTime());
+    }
+}

--- a/src/Support/RateLimiter.php
+++ b/src/Support/RateLimiter.php
@@ -126,7 +126,7 @@ class RateLimiter
             $delay = new DateInterval("PT{$delay}S");
         }
 
-        return (new DateTime())->add($delay)->getTimestamp();
+        return $this->getNow()->add($delay)->getTimestamp();
     }
 
     /**
@@ -137,7 +137,7 @@ class RateLimiter
     protected function parseDateInterval(DateTimeInterface|DateInterval|int $delay): DateTimeInterface|int
     {
         if ($delay instanceof DateInterval) {
-            $delay = (new DateTime())->add($delay);
+            $delay = $this->getNow()->add($delay);
         }
 
         return $delay;
@@ -150,7 +150,7 @@ class RateLimiter
      */
     protected function currentTime(): int
     {
-        return (new DateTime())->getTimestamp();
+        return $this->getNow()->getTimestamp();
     }
 
     /**
@@ -271,5 +271,10 @@ class RateLimiter
         $key = $this->cleanRateLimiterKey($key);
 
         return max(0, $this->cache->get($key.':timer') - $this->currentTime());
+    }
+
+    protected function getNow(): DateTime
+    {
+        return new DateTime();
     }
 }

--- a/src/Support/Throttle.php
+++ b/src/Support/Throttle.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\Support;
+
+class Throttle
+{
+    protected int $attempts;
+    protected int $decay;
+
+    public function __construct(int $attempts = 5, int $decay = 1)
+    {
+        $this->attempts = $attempts;
+        $this->decay = $decay;
+    }
+
+    public function getAttempts(): int
+    {
+        return $this->attempts;
+    }
+
+    public function getDecay(): int
+    {
+        return $this->decay;
+    }
+}

--- a/tests/Feature/ThrottleTest.php
+++ b/tests/Feature/ThrottleTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use SergiX44\Nutgram\Nutgram;
+use SergiX44\Nutgram\Telegram\Types\User\User;
+
+beforeEach(function () {
+    $this->user = User::make(
+        id: 123456,
+        is_bot: false,
+        first_name: 'John',
+        last_name: 'Doe',
+        username: 'johndoe',
+        language_code: 'en'
+    );
+});
+
+it('can throttle global handlers', function () {
+    $bot = Nutgram::fake();
+    $bot->throttle(1, 10);
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('Hello');
+    });
+
+    $bot->setCommonUser($this->user);
+
+    $bot->hearText('/start')->reply()->assertReplyText('Hello');
+    $bot->hearText('/start')->reply()->assertReplyText("Too many messages sent!\nYou may try again in 10 seconds.");
+});
+
+it('can throttle specific handlers', function () {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('Hello');
+    })->throttle(1, 10);
+
+    $bot->setCommonUser($this->user);
+
+    $bot->hearText('/start')->reply()->assertReplyText('Hello');
+    $bot->hearText('/start')->reply()->assertReplyText("Too many messages sent!\nYou may try again in 10 seconds.");
+});
+
+it('can throttle using different message', function () {
+    Nutgram::$throttleMessageClosure = function (Nutgram $bot, int $seconds) {
+        $bot->sendMessage("Retry again in $seconds seconds.");
+    };
+
+    $bot = Nutgram::fake();
+    $bot->throttle(1, 10);
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('Hello');
+    });
+
+    $bot->setCommonUser($this->user);
+
+    $bot->hearText('/start')->reply()->assertReplyText('Hello');
+    $bot->hearText('/start')->reply()->assertReplyText("Retry again in 10 seconds.");
+});


### PR DESCRIPTION
# Throttle System

This PR introduces the "Throttle System" for Nutgram.
This feature allows you to control the rate of requests per user, avoiding the 429 error. 
Activate it globally or for specific handlers, set requests per second, cooldown time, and error text.

### Enable throttle globally
```php
$bot = new Nutgram('token');
$bot->throttle(attempts: 10, decay: 5);

$bot->onCommand('start', StartCommand::class);
$bot->onCommand('help', StartCommand::class);
$bot->onCommand('about', StartCommand::class);

$bot->run();
```

### Enable throttle for a specific handler
```php
$bot = new Nutgram('token');

$bot->onCommand('start', StartCommand::class)->throttle(attempts: 10, decay: 5);
$bot->onCommand('help', StartCommand::class);
$bot->onCommand('about', StartCommand::class);

$bot->run();
```

### Enable throttle globally and override it for a specific handler
```php
$bot = new Nutgram('token');
$bot->throttle(attempts: 10, decay: 5);

$bot->onCommand('start', StartCommand::class)->throttle(attempts: 2, decay: 5);
$bot->onCommand('help', StartCommand::class);
$bot->onCommand('about', StartCommand::class);

$bot->run();
```

### Use different error text
If the user exceeds the limit, the bot will send the error text once and will not execute the handler.

Default action:
```php
$bot->sendMessage("Too many messages sent!\nYou may try again in $seconds seconds.");
```

To change the error text, you can override the static `throttleMessageCallback` property:
```php
Nutgram::$throttleMessageCallback = function(Nutgram $bot, int $seconds){
    $bot->sendMessage("Too many request sent! Retry in $seconds seconds.");
});
```