### PR TITLE
[4.x] Add onInlineQueryText handler

### DIFF
--- a/src/Handlers/Listeners/UpdateListeners.php
+++ b/src/Handlers/Listeners/UpdateListeners.php
@@ -74,6 +74,17 @@ trait UpdateListeners
     }
 
     /**
+     * @param string $pattern
+     * @param $callable
+     * @return Handler
+     */
+    public function onInlineQueryText(string $pattern, $callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::INLINE_QUERY->value][$pattern] = new Handler($callable, $pattern);
+    }
+
+    /**
      * @param $callable
      * @return Handler
      */

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -78,6 +78,9 @@ abstract class ResolveHandlers extends CollectHandlers
         } elseif ($updateType === UpdateType::PRE_CHECKOUT_QUERY) {
             $data = $this->update->pre_checkout_query?->invoice_payload;
             $this->addHandlersBy($resolvedHandlers, $updateType->value, value: $data);
+        } elseif ($updateType === UpdateType::INLINE_QUERY) {
+            $data = $this->update->inline_query?->query;
+            $this->addHandlersBy($resolvedHandlers, $updateType->value, value: $data);
         }
 
         if (empty($resolvedHandlers) && $updateType !== null) {

--- a/tests/Feature/Handlers/UpdateHandlersTest.php
+++ b/tests/Feature/Handlers/UpdateHandlersTest.php
@@ -75,6 +75,18 @@ it('calls onInlineQuery() handler', function ($update) {
     expect($bot->get('called'))->toBeTrue();
 })->with('inline_query');
 
+it('calls onInlineQueryText() handler', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onInlineQueryText('test', function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called'))->toBeTrue();
+})->with('inline_query');
+
 it('calls onChosenInlineResult() handler', function ($update) {
     $bot = Nutgram::fake($update);
 


### PR DESCRIPTION
# Before this PR
```php
$bot->onInlineQuery(function (Nutgram $bot) {
    $text = $bot->inlineQuery()->query;

    if($text === 'foo') {
        $bot->answerInlineQuery(
            results: [],
            button: InlineQueryResultsButton::make(
                text: 'This is a foo test',
                start_parameter: 'foo',
            )
        );
        return;
    }

	if($text === 'bar') {
        $bot->answerInlineQuery(
            results: [],
            button: InlineQueryResultsButton::make(
                text: 'This is a bar test',
                start_parameter: 'bar',
            )
        );
        return;
    }


    $bot->answerInlineQuery(
        results: [],
        button: InlineQueryResultsButton::make(
            text: 'Invalid value!',
            start_parameter: 'invalid_value',
        )
    );
});
```

# After this PR
```php
$bot->onInlineQueryText('foo', function (Nutgram $bot) {
        $bot->answerInlineQuery(
            results: [],
            button: InlineQueryResultsButton::make(
                text: 'This is a foo test',
                start_parameter: 'foo',
            )
        );
});

$bot->onInlineQueryText('bar', function (Nutgram $bot) {
    $bot->answerInlineQuery(
        results: [],
        button: InlineQueryResultsButton::make(
            text: 'This is a bar test',
            start_parameter: 'bar ',
        )
    );
});

$bot->onInlineQuery(function (Nutgram $bot) {
    $bot->answerInlineQuery(
        results: [],
        button: InlineQueryResultsButton::make(
            text: 'Invalid value!',
            start_parameter: 'invalid_value',
        )
    );
});
``` 