### PR TITLE
Add throwable api error

### DIFF
--- a/src/Exception/ThrowableApiError.php
+++ b/src/Exception/ThrowableApiError.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SergiX44\Nutgram\Exception;
+
+use Exception;
+
+abstract class ThrowableApiError extends Exception
+{
+    abstract public static function pattern(): string;
+}

--- a/tests/Feature/ApiErrorTest.php
+++ b/tests/Feature/ApiErrorTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Response;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Exceptions\TelegramException;
 use SergiX44\Nutgram\Testing\FakeNutgram;
+use SergiX44\Nutgram\Tests\Fixtures\Exceptions\UserDeactivatedException;
 
 it('calls the api error handler', function ($responseBody) {
     $bot = Nutgram::fake(responses: [
@@ -117,3 +118,13 @@ it('redacts bot token when there is a connectexception', function () {
         expect($e->getMessage())->not->toContain(FakeNutgram::TOKEN);
     }
 });
+
+it('calls the specific api error handler using ThrowableApiError', function ($responseBody) {
+    $bot = Nutgram::fake(responses: [
+        new Response(403, body: $responseBody),
+    ]);
+
+    $bot->onApiError(UserDeactivatedException::class);
+
+    $bot->sendMessage('hi');
+})->with('response_user_deactivated')->throws(UserDeactivatedException::class);

--- a/tests/Fixtures/Exceptions/UserDeactivatedException.php
+++ b/tests/Fixtures/Exceptions/UserDeactivatedException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SergiX44\Nutgram\Tests\Fixtures\Exceptions;
+
+use SergiX44\Nutgram\Exception\ThrowableApiError;
+
+class UserDeactivatedException extends ThrowableApiError
+{
+    public static function pattern(): string
+    {
+        return '.*deactivated.*';
+    }
+}


### PR DESCRIPTION
## Description
This PR implements the ability to automatically throw exceptions based on the error message returned by the Telegram API.

## Use Case
In your code:
```php
$bot->sendMessage('hi'); // example: telegram will return an error 403 Forbidden: user is deactivated
```

## Before this PR
Registered handler:
```php
$bot->onApiError('.*deactivated.*', function (Nutgram $bot, $e) {
    throw new UserDeactivatedException($e->getMessage());
});
```
Exception file:
```php
class UserDeactivatedException extends Exception
{

}
```

## After this PR
Registered handler:
```php
$bot->onApiError(UserDeactivatedException::class);
```
Exception file:
```php
class UserDeactivatedException extends TelegramApiError
{
    public static function pattern(): string
    {
        return '.*deactivated.*';
    }
}
```


## Example
#### Before
```php
$bot->onApiError('.*bot was blocked by the user.*', function(Nutgram $bot, TelegramException $e){
    throw new TelegramUserBlockedException($e->getMessage());
});
$bot->onApiError('.*user is deactivated.*', function(Nutgram $bot, TelegramException $e){
    throw new TelegramUserDeactivatedException($e->getMessage());
});
$bot->onApiError('.*specified new message content and reply markup are exactly the same.*', function(Nutgram $bot, TelegramException $e){
    throw new TelegramMessageNotModifiedException($e->getMessage());
});
$bot->onApiError('.*message to edit not found.*', function(Nutgram $bot, TelegramException $e){
    throw new TelegramMessageToEditNotFoundException($e->getMessage());
});
$bot->onApiError('.*message to delete not found.*', function(Nutgram $bot, TelegramException $e){
    throw new TelegramMessageToDeleteNotFoundException($e->getMessage());
});
$bot->onApiError('.*wrong file_id or the file is temporarily unavailable.*', function(Nutgram $bot, TelegramException $e){
    throw new TelegramWrongFileIdException($e->getMessage());
});
```

#### After
```php
$bot->onApiError(TelegramUserBlockedException::class);
$bot->onApiError(TelegramUserDeactivatedException::class);
$bot->onApiError(TelegramMessageNotModifiedException::class);
$bot->onApiError(TelegramMessageToEditNotFoundException::class);
$bot->onApiError(TelegramMessageToDeleteNotFoundException::class);
$bot->onApiError(TelegramWrongFileIdException::class);
```