### PR TITLE
Fix missing DI in Command class

### DIFF
--- a/src/Handlers/Type/Command.php
+++ b/src/Handlers/Type/Command.php
@@ -4,7 +4,6 @@ namespace SergiX44\Nutgram\Handlers\Type;
 
 use RuntimeException;
 use SergiX44\Nutgram\Handlers\Handler;
-use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommand;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScope;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScopeDefault;
@@ -24,7 +23,17 @@ class Command extends Handler
     public function __construct($callable = null, ?string $command = null)
     {
         $command = $command ?? $this->command;
-        parent::__construct($callable ?? [$this, 'handle'], "/{$command}");
+
+        if ($callable !== null) {
+            parent::__construct($callable, "/{$command}");
+            return;
+        }
+
+        if (!method_exists($this, 'handle')) {
+            throw new RuntimeException('The handle method must be extended!');
+        }
+
+        parent::__construct([$this, 'handle'], "/{$command}");
     }
 
     /**
@@ -90,10 +99,5 @@ class Command extends Handler
     public function toBotCommand(): BotCommand
     {
         return new BotCommand($this->getName(), $this->getDescription());
-    }
-
-    public function handle(Nutgram $bot): void
-    {
-        throw new RuntimeException('The handle method must be extended!');
     }
 }

--- a/src/Handlers/Type/Command.php
+++ b/src/Handlers/Type/Command.php
@@ -30,7 +30,7 @@ class Command extends Handler
         }
 
         if (!method_exists($this, 'handle')) {
-            throw new RuntimeException('The handle method must be extended!');
+            throw new RuntimeException('The handle method must be implemented!');
         }
 
         parent::__construct([$this, 'handle'], "/{$command}");

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -12,7 +12,9 @@ use SergiX44\Nutgram\Telegram\Types\Command\BotCommand;
 use SergiX44\Nutgram\Telegram\Types\Internal\InputFile;
 use SergiX44\Nutgram\Telegram\Types\Keyboard\ReplyKeyboardRemove;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
+use SergiX44\Nutgram\Tests\Fixtures\ComplexCommand;
 use SergiX44\Nutgram\Tests\Fixtures\HelloHandler;
+use SergiX44\Nutgram\Tests\Fixtures\InvalidCommand;
 use SergiX44\Nutgram\Tests\Fixtures\TestStartCommand;
 
 it('calls the message handler', function ($update) {
@@ -204,6 +206,28 @@ it('allows defining commands with classes', function ($update) {
 
     expect($bot->get('called'))->toBeTrue();
 })->with('command_message');
+
+it('allows defining commands with classes with missing handle method', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->set('called', false);
+    $bot->registerCommand(InvalidCommand::class);
+
+    $bot->run();
+
+    expect($bot->get('called'))->toBeFalse();
+})->with('command_message')->throws(RuntimeException::class, 'The handle method must be extended!');
+
+it('allows defining commands with classes with parameter', function () {
+    $bot = Nutgram::fake();
+
+    $bot->set('called', false);
+    $bot->registerCommand(ComplexCommand::class);
+
+    $bot->hearText('/start test')->reply();
+
+    expect($bot->get('called'))->toBeTrue();
+});
 
 it('throws an error if not when not specifying a callable', function ($update) {
     $bot = Nutgram::fake($update);

--- a/tests/Feature/HandlerTest.php
+++ b/tests/Feature/HandlerTest.php
@@ -216,7 +216,7 @@ it('allows defining commands with classes with missing handle method', function 
     $bot->run();
 
     expect($bot->get('called'))->toBeFalse();
-})->with('command_message')->throws(RuntimeException::class, 'The handle method must be extended!');
+})->with('command_message')->throws(RuntimeException::class, 'The handle method must be implemented!');
 
 it('allows defining commands with classes with parameter', function () {
     $bot = Nutgram::fake();

--- a/tests/Fixtures/ComplexCommand.php
+++ b/tests/Fixtures/ComplexCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SergiX44\Nutgram\Tests\Fixtures;
+
+use SergiX44\Nutgram\Handlers\Type\Command;
+use SergiX44\Nutgram\Nutgram;
+
+class ComplexCommand extends Command
+{
+    protected string $command = 'start {value}';
+
+    protected ?string $description = 'A lovely description';
+
+    public function handle(Nutgram $bot, string $value): void
+    {
+        expect($bot->get('called'))->toBeFalse();
+        $bot->set('called', true);
+        expect($value)->toBe('test');
+    }
+}

--- a/tests/Fixtures/InvalidCommand.php
+++ b/tests/Fixtures/InvalidCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SergiX44\Nutgram\Tests\Fixtures;
+
+use SergiX44\Nutgram\Handlers\Type\Command;
+use SergiX44\Nutgram\Nutgram;
+
+class InvalidCommand extends Command
+{
+    protected string $command = 'test';
+
+    public function missing(Nutgram $bot): void
+    {
+        expect($bot->get('called'))->toBeFalse();
+        $bot->set('called', true);
+    }
+}


### PR DESCRIPTION
# Fix missing DI in Command class
This PR fixes the missing DI in the Command class.

## Use Case
```php
class AgeCommand extends Command
{
    protected string $command = 'age {value}';

    public function handle(Nutgram $bot, string $value)
    {
        //...
    }
}
```

## Before this PR

❌ Error: Declaration must be compatible with Command->handle(bot: \SergiX44\Nutgram\Nutgram)

The developer should use $bot->onCommand instead of $bot->registerCommand to avoid this error.

## After this PR

✅ No error.
