### PR TITLE
Fix wrong regex capture group

### DIFF
--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -72,7 +72,7 @@ class Handler extends MiddlewareChain
         $pattern = str_replace('/', '\/', $this->pattern);
 
         // replace named parameters with regex
-        $regex = '/^'.preg_replace(self::PARAM_NAME_REGEX, '(?<$1>.*)', $pattern).'?$/mUu';
+        $regex = '/^'.preg_replace(self::PARAM_NAME_REGEX, '(?<$1>.*?)', $pattern).'?$/mu';
 
         // match + return only named parameters
         $regexMatched = (bool)preg_match($regex, $value, $matches, PREG_UNMATCHED_AS_NULL);

--- a/tests/Feature/PatternsTest.php
+++ b/tests/Feature/PatternsTest.php
@@ -209,3 +209,16 @@ it('calls handler with different pattern cases', function ($pattern, $input, $pa
     'cyrillic-upper-lower' => ['ПРИМЕР', 'пример', false],
     'cyrillic-upper-upper' => ['ПРИМЕР', 'ПРИМЕР', true],
 ]);
+
+it('calls handler with optional regex group', function (string $hear, ?string $expected) {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('start ?(.*)?', function (Nutgram $bot, ?string $param) use ($expected) {
+        expect($param)->toBe($expected);
+    });
+
+    $bot->hearText($hear)->reply();
+})->with([
+    'without-param' => ['/start', null],
+    'with-param' => ['/start foo', 'foo'],
+]);


### PR DESCRIPTION
# Fix wrong regex capture group
This PR fixes a bug in the regex capture group.
See below for more details.

### Use Case

#### Pattern
```php
$bot->onCommand('start ?(.*)?', function (Nutgram $bot, ?string $param) {
    echo $param;
});
```

#### Inputs
1. `/start`
2. `/start foo`

## `$param` value before this PR
1. `null` ✅ correct
2. `' foo'` ❌ wrong

## `$param` value after this PR
1. `null` ✅ correct
2. `'foo'` ✅ correct