### PR TITLE
Add the ability to disable handler registration

### DIFF
--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -9,11 +9,12 @@ use Psr\Container\NotFoundExceptionInterface;
 use SergiX44\Nutgram\Middleware\Link;
 use SergiX44\Nutgram\Middleware\MiddlewareChain;
 use SergiX44\Nutgram\Nutgram;
+use SergiX44\Nutgram\Support\Disable;
 use SergiX44\Nutgram\Support\Taggable;
 
 class Handler extends MiddlewareChain
 {
-    use Taggable, Macroable;
+    use Taggable, Macroable, Disable;
 
     /**
      * regular expression to capture named parameters but not quantifiers

--- a/src/Handlers/HandlerGroup.php
+++ b/src/Handlers/HandlerGroup.php
@@ -4,12 +4,13 @@ namespace SergiX44\Nutgram\Handlers;
 
 use Closure;
 use Illuminate\Support\Traits\Macroable;
+use SergiX44\Nutgram\Support\Disable;
 use SergiX44\Nutgram\Support\Taggable;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScope;
 
 class HandlerGroup
 {
-    use Taggable, Macroable;
+    use Taggable, Macroable, Disable;
 
     protected array $middlewares = [];
 

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -120,9 +120,10 @@ abstract class ResolveHandlers extends CollectHandlers
 
         /** @var Handler|array $handler */
         foreach ($typedHandlers as $handler) {
-            if (is_array($handler)) {
+            if (is_array($handler) || $handler->isDisabled()) {
                 continue;
             }
+
             if (
                 ($subType !== null && $handler->getPattern() === $subType) ||
                 ($value === null && $handler->getPattern() === null) ||
@@ -270,7 +271,7 @@ abstract class ResolveHandlers extends CollectHandlers
             ($group->groupCallable)($this);
 
             // apply the middleware stack to the current registered group handlers
-            array_walk_recursive($this->groupHandlers, function ($leaf) use ($tags, $middlewares, $scopes) {
+            array_walk_recursive($this->groupHandlers, function ($leaf) use ($tags, $middlewares, $scopes, $group) {
                 if ($leaf instanceof Handler) {
                     foreach ($middlewares as $middleware) {
                         $leaf->middleware($middleware);
@@ -279,6 +280,7 @@ abstract class ResolveHandlers extends CollectHandlers
                         $leaf->scope($scopes);
                     }
                     $leaf->tags([...$leaf->getTags(), ...$tags]);
+                    $leaf->disable($group->isDisabled());
                 }
             });
 

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -280,7 +280,7 @@ abstract class ResolveHandlers extends CollectHandlers
                         $leaf->scope($scopes);
                     }
                     $leaf->tags([...$leaf->getTags(), ...$tags]);
-                    $leaf->disable($group->isDisabled());
+                    $leaf->unless($group->isDisabled());
                 }
             });
 

--- a/src/Support/Disable.php
+++ b/src/Support/Disable.php
@@ -6,7 +6,7 @@ trait Disable
 {
     protected bool $disabled = false;
 
-    public function disable(bool $condition = true): self
+    public function unless(bool $condition): self
     {
         $this->disabled = $condition;
         return $this;

--- a/src/Support/Disable.php
+++ b/src/Support/Disable.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SergiX44\Nutgram\Support;
+
+trait Disable
+{
+    protected bool $disabled = false;
+
+    public function disable(bool $condition = true): self
+    {
+        $this->disabled = $condition;
+        return $this;
+    }
+
+    public function isDisabled(): bool
+    {
+        return $this->disabled;
+    }
+}

--- a/tests/Feature/DisabledHandlerTest.php
+++ b/tests/Feature/DisabledHandlerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use SergiX44\Nutgram\Nutgram;
+
+it('does not disable handler', function () {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('hello');
+    })->disable(false);
+
+    $bot->hearText('/start')
+        ->reply()
+        ->assertReplyText('hello');
+});
+
+it('does not run disabled handler', function () {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('hello');
+    })->disable();
+
+    $bot->hearText('/start')
+        ->reply()
+        ->assertNoReply();
+});
+
+it('does not run disabled handler inside group', function () {
+    $bot = Nutgram::fake();
+
+    $bot->group(function (Nutgram $bot) {
+        $bot->onCommand('start', function (Nutgram $bot) {
+            $bot->sendMessage('hello');
+        });
+    })->disable();
+
+    $bot->hearText('/start')
+        ->reply()
+        ->assertNoReply();
+});

--- a/tests/Feature/DisabledHandlerTest.php
+++ b/tests/Feature/DisabledHandlerTest.php
@@ -7,7 +7,7 @@ it('does not disable handler', function () {
 
     $bot->onCommand('start', function (Nutgram $bot) {
         $bot->sendMessage('hello');
-    })->disable(false);
+    })->unless(false);
 
     $bot->hearText('/start')
         ->reply()
@@ -19,7 +19,7 @@ it('does not run disabled handler', function () {
 
     $bot->onCommand('start', function (Nutgram $bot) {
         $bot->sendMessage('hello');
-    })->disable();
+    })->unless(true);
 
     $bot->hearText('/start')
         ->reply()
@@ -33,7 +33,7 @@ it('does not run disabled handler inside group', function () {
         $bot->onCommand('start', function (Nutgram $bot) {
             $bot->sendMessage('hello');
         });
-    })->disable();
+    })->unless(true);
 
     $bot->hearText('/start')
         ->reply()


### PR DESCRIPTION
This PR adds the ability to disable handler registration.
This is useful when you want register handlers under certain conditions, e.g. when a certain property is set to true/false.

### Before this PR

```php
if (config('donation.enabled')) {
    $bot->onCommand('donate', DonateConversation::class);
    $bot->onCommand('start donate', DonateConversation::class);
    $bot->onPreCheckoutQuery(PreCheckoutQueryHandler::class);
    $bot->onSuccessfulPayment(SuccessfulPaymentHandler::class);
}
```

### After this PR

```php

$bot->onCommand('donate', DonateConversation::class)->unless(!config('donation.enabled'));
$bot->onCommand('start donate', DonateConversation::class)->unless(!config('donation.enabled'));
$bot->onPreCheckoutQuery(PreCheckoutQueryHandler::class)->unless(!config('donation.enabled'));
$bot->onSuccessfulPayment(SuccessfulPaymentHandler::class)->unless(!config('donation.enabled'));

// or

$bot->group(function(){
    $bot->onCommand('donate', DonateConversation::class);
    $bot->onCommand('start donate', DonateConversation::class);
    $bot->onPreCheckoutQuery(PreCheckoutQueryHandler::class);
    $bot->onSuccessfulPayment(SuccessfulPaymentHandler::class);
})->unless(!config('donation.enabled'));

```