### PR TITLE
Add ability to manually pass additional parameters to conversations + Resolve parameters in the default conversation step

### DIFF
--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -35,11 +35,6 @@ abstract class Conversation
         return $instance;
     }
 
-    public function start(Nutgram $bot)
-    {
-        throw new RuntimeException('Attempt to start an empty conversation.');
-    }
-
     /**
      * @return bool
      */

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -21,7 +21,7 @@ abstract class Conversation
     private ?int $userId = null;
     private ?int $chatId = null;
 
-    public static function begin(Nutgram $bot, ?int $userId = null, ?int $chatId = null): self
+    public static function begin(Nutgram $bot, ?int $userId = null, ?int $chatId = null, array $data = []): self
     {
         if ($userId xor $chatId) {
             throw new \InvalidArgumentException('You need to provide both userId and chatId.');
@@ -30,7 +30,7 @@ abstract class Conversation
         $instance = $bot->getContainer()->get(static::class);
         $instance->userId = $userId;
         $instance->chatId = $chatId;
-        $instance($bot);
+        $instance($bot, ...$data);
 
         return $instance;
     }

--- a/tests/Feature/ConversationTest.php
+++ b/tests/Feature/ConversationTest.php
@@ -14,6 +14,7 @@ use SergiX44\Nutgram\Tests\Fixtures\Conversations\ConversationWithSkipHandlersMu
 use SergiX44\Nutgram\Tests\Fixtures\Conversations\ConversationWithSkipMiddlewareMultipleSteps;
 use SergiX44\Nutgram\Tests\Fixtures\Conversations\NonSerializableConversation;
 use SergiX44\Nutgram\Tests\Fixtures\Conversations\OneStepNotCompletedConversation;
+use SergiX44\Nutgram\Tests\Fixtures\Conversations\SurveyConversation;
 use SergiX44\Nutgram\Tests\Fixtures\Conversations\TwoStepConversation;
 use SergiX44\Nutgram\Tests\Fixtures\CustomService;
 
@@ -256,3 +257,24 @@ it('fails to start manually for a specific user/chat', function () {
     $bot = Nutgram::fake();
     TwoStepConversation::begin($bot, 123, null);
 })->throws(InvalidArgumentException::class, 'You need to provide both userId and chatId.');
+
+it('starts manually with additional data', function () {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('survey-66', function (Nutgram $bot) {
+        SurveyConversation::begin($bot, data: [
+            'surveyID' => 66,
+        ]);
+    });
+
+    $bot
+        ->willStartConversation()
+        ->hearText('/survey-66')
+        ->reply()
+        ->assertActiveConversation()
+        ->hearText('wow')
+        ->reply()
+        ->assertNoConversation();
+
+    expect($bot->get('test'))->toBe(66);
+});

--- a/tests/Feature/ConversationTest.php
+++ b/tests/Feature/ConversationTest.php
@@ -202,7 +202,7 @@ it('does not work with empty conversation class', function ($update) {
     $bot->onMessage(ConversationEmpty::class);
 
     $bot->run();
-})->with('message')->throws(RuntimeException::class, 'Attempt to start an empty conversation.');
+})->with('message')->throws(RuntimeException::class, "Conversation step 'start' not found.");
 
 it('does not work with missing step', function ($update) {
     $bot = Nutgram::fake($update);

--- a/tests/Fixtures/Conversations/SurveyConversation.php
+++ b/tests/Fixtures/Conversations/SurveyConversation.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace SergiX44\Nutgram\Tests\Fixtures\Conversations;
+
+use SergiX44\Nutgram\Conversations\Conversation;
+use SergiX44\Nutgram\Nutgram;
+
+class SurveyConversation extends Conversation
+{
+    protected int $surveyID;
+
+    public function start(Nutgram $bot, int $surveyID)
+    {
+        $this->surveyID = $surveyID;
+        $this->next('secondStep');
+    }
+
+    public function secondStep(Nutgram $bot)
+    {
+        $bot->set('test', $this->surveyID);
+        $this->end();
+    }
+}


### PR DESCRIPTION
# Ability to manually pass additional parameters

### Conversation example
```php
class SurveyConversation extends Conversation
{
    protected int $surveyID;

    public function start(Nutgram $bot, int $surveyID)
    {
        $this->surveyID = $surveyID;
        $this->next('secondStep');
    }

    public function secondStep(Nutgram $bot)
    {
        // I can use "$this->surveyID" here too!
        $this->end();
    }
}
``` 

## Before this PR
```php
// you can't do it manually but you can do this instead:

$bot->onCommand('survey {surveyID}',  SurveyConversation::class);
``` 

## After this PR
```php
$bot->onCommand('survey-66', function (Nutgram $bot) {
    SurveyConversation::begin($bot, data: [
        'surveyID' => 66,
    ]);
});
``` 

---------------------

# Resolve parameters in the default conversation step

### Handler example
```php
$bot->onCommand('add {name} {address}', AddConversation::class);
```

## Before this PR
```php
class AddConversation extends Conversation
{
    protected ?string $step = 'first';

    public function first(Nutgram $bot, string $name, string $address)
    {
        $bot->sendMessage("$name | $address");
        $this->end();
    }
}
``` 

## After this PR
```php
class AddConversation extends Conversation
{
    public function start(Nutgram $bot, string $name, string $address)
    {
        $bot->sendMessage("$name | $address");
        $this->end();
    }
}
``` 
