### PR TITLE
Fix regex for named parameters

### DIFF
--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -17,10 +17,21 @@ class Handler extends MiddlewareChain
     use Taggable, Macroable, Disable;
 
     /**
-     * regular expression to capture named parameters but not quantifiers
-     * captures {name}, but not {1}, {1,}, or {1,2}.
+     * Regex to capture named parameters.
+     *
+     * Valid:
+     * - {name}
+     * - {name1}
+     * - {firstName}
+     * - {n123}
+     *
+     * Invalid:
+     * - {1} (reserved for quantifiers)
+     * - {1,} (reserved for quantifiers)
+     * - {1,2} (reserved for quantifiers)
+     * - {1name} (must start with a letter)
      */
-    protected const PARAM_NAME_REGEX = '/{((?:(?!\d+,?\d?+)\w)+?)}/';
+    protected const PARAM_NAME_REGEX = '/{((?:[a-zA-Z](?:(?!\d+,?\d?+\w)\w)*)+)}/';
 
     /**
      * @var string|null

--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -31,7 +31,7 @@ class Handler extends MiddlewareChain
      * - {1,2} (reserved for quantifiers)
      * - {1name} (must start with a letter)
      */
-    protected const PARAM_NAME_REGEX = '/{((?:[a-zA-Z](?:(?!\d+,?\d?+\w)\w)*)+)}/';
+    protected const PARAM_NAME_REGEX = '/{([a-zA-Z][a-zA-Z\d]*)}/';
 
     /**
      * @var string|null

--- a/tests/Feature/PatternsTest.php
+++ b/tests/Feature/PatternsTest.php
@@ -286,3 +286,16 @@ it('calls handler with optional named parameters', function (string $hear, bool 
     'valid' => ['/start luke 4316', true],
     'invalid' => ['/start 4316 luke', false],
 ]);
+
+it('calls handler on callback query data', function () {
+    $bot = Nutgram::fake();
+
+    $bot->onCallbackQueryData('{id1}-{yn}-{id2}', function (Nutgram $bot, $id1, $yn, $id2) {
+        $bot->sendMessage('called');
+    });
+
+    $bot
+        ->hearCallbackQueryData('2098495358-y-1707982893')
+        ->reply()
+        ->assertReplyText('called');
+});

--- a/tests/Feature/PatternsTest.php
+++ b/tests/Feature/PatternsTest.php
@@ -299,3 +299,28 @@ it('calls handler on callback query data', function () {
         ->reply()
         ->assertReplyText('called');
 });
+
+it('uses valid named parameters', function ($hearParameter, $expected) {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand(sprintf("start {%s}", $hearParameter), function (Nutgram $bot, $value) {
+        $bot->sendMessage('called');
+    });
+
+    $bot->hearText("/start 123")->reply();
+
+    if ($expected) {
+        $bot->assertCalled('sendMessage');
+    } else {
+        $bot->assertNoReply();
+    }
+})->with([
+    ['name', true],
+    ['name1', true],
+    ['n1255', true],
+    ['1name', false],
+    ['123e', false],
+    ['1', false],
+    ['1,', false],
+    ['1,1', false],
+]);


### PR DESCRIPTION
This PR fixes the regex for named parameters. It now matches the following patterns:

| Patterns     | BEFORE THE PR                          | AFTER THE PR                           |
|--------------|----------------------------------------|----------------------------------------|
| {name}       | ✅ match                                | ✅ match                                |
| {name1}      | ❌ no match                             | ✅ match                                |
| {1name}      | no match (it must start with a letter) | no match (it must start with a letter) |
| {1} or {1,1} | no match (reserved for regex)          | no match (reserved for regex)          |