### PR TITLE
Add new where constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `nutgram` will be documented in this file.
 
+## 4.12.1 - 2023-12-01
+
+### What's Changed
+
+* Fix missing onUpdate handler + refactor handler structure by @Lukasss93 in https://github.com/nutgram/nutgram/pull/621
+
+**Full Changelog**: https://github.com/nutgram/nutgram/compare/4.12.0...4.12.1
+
 ## 4.12.0 - 2023-11-30
 
 ### What's Changed

--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -9,12 +9,13 @@ use Psr\Container\NotFoundExceptionInterface;
 use SergiX44\Nutgram\Middleware\Link;
 use SergiX44\Nutgram\Middleware\MiddlewareChain;
 use SergiX44\Nutgram\Nutgram;
+use SergiX44\Nutgram\Support\Constraints;
 use SergiX44\Nutgram\Support\Disable;
 use SergiX44\Nutgram\Support\Taggable;
 
 class Handler extends MiddlewareChain
 {
-    use Taggable, Macroable, Disable;
+    use Taggable, Macroable, Disable, Constraints;
 
     /**
      * regular expression to capture named parameters but not quantifiers
@@ -27,10 +28,6 @@ class Handler extends MiddlewareChain
      */
     protected ?string $pattern;
 
-    /**
-     * @var array<string, string>
-     */
-    protected array $constraints = [];
 
     /**
      * @var array
@@ -173,18 +170,5 @@ class Handler extends MiddlewareChain
     public function getPattern(): ?string
     {
         return $this->pattern;
-    }
-
-    public function where(array|string $parameter, ?string $constraint = null): Handler
-    {
-        if (!is_array($parameter)) {
-            $constraints = [$parameter => $constraint];
-        } else {
-            $constraints = $parameter;
-        }
-
-        $this->constraints = [...$this->constraints, ...$constraints];
-
-        return $this;
     }
 }

--- a/src/Handlers/HandlerGroup.php
+++ b/src/Handlers/HandlerGroup.php
@@ -4,13 +4,14 @@ namespace SergiX44\Nutgram\Handlers;
 
 use Closure;
 use Illuminate\Support\Traits\Macroable;
+use SergiX44\Nutgram\Support\Constraints;
 use SergiX44\Nutgram\Support\Disable;
 use SergiX44\Nutgram\Support\Taggable;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScope;
 
 class HandlerGroup
 {
-    use Taggable, Macroable, Disable;
+    use Taggable, Macroable, Disable, Constraints;
 
     protected array $middlewares = [];
 

--- a/src/Support/Constraints.php
+++ b/src/Support/Constraints.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SergiX44\Nutgram\Support;
+
+trait Constraints
+{
+    protected array $constraints = [];
+
+    public function where(array|string $parameter, ?string $constraint = null): self
+    {
+        if (!is_array($parameter)) {
+            $constraints = [$parameter => $constraint];
+        } else {
+            $constraints = $parameter;
+        }
+
+        $this->constraints = [...$this->constraints, ...$constraints];
+
+        return $this;
+    }
+
+    public function whereIn(string $parameter, array $values): self
+    {
+        $this->constraints[$parameter] = implode('|', $values);
+
+        return $this;
+    }
+
+    public function whereAlpha(string $parameter): self
+    {
+        $this->constraints[$parameter] = '[a-zA-Z]+';
+
+        return $this;
+    }
+
+    public function whereNumber(string $parameter): self
+    {
+        $this->constraints[$parameter] = '[0-9]+';
+
+        return $this;
+    }
+
+    public function whereAlphaNumeric(string $parameter): self
+    {
+        $this->constraints[$parameter] = '[a-zA-Z0-9]+';
+
+        return $this;
+    }
+
+    public function getConstraints(): array
+    {
+        return $this->constraints;
+    }
+}

--- a/tests/Feature/PatternsTest.php
+++ b/tests/Feature/PatternsTest.php
@@ -286,3 +286,110 @@ it('calls handler with optional named parameters', function (string $hear, bool 
     'valid' => ['/start luke 4316', true],
     'invalid' => ['/start 4316 luke', false],
 ]);
+
+it('uses where constraint via group method', function () {
+    $bot = Nutgram::fake();
+
+    $bot->group(function (Nutgram $bot) {
+        $bot->onCommand('start {age}', function (Nutgram $bot, $age) {
+            $bot->sendMessage("You're $age");
+        });
+
+        $bot->onCommand('hello {age}', function (Nutgram $bot, $age) {
+            $bot->sendMessage("You're $age");
+        });
+    })->where('age', '\d+');
+
+    $bot->hearText('/start 18')
+        ->reply()
+        ->assertReplyText('You\'re 18');
+
+    $bot->hearText('/hello 18')
+        ->reply()
+        ->assertReplyText('You\'re 18');
+});
+
+it('uses whereIn constraints', function ($hearValue, $expected) {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('start {value}', function (Nutgram $bot, $value) {
+        $bot->sendMessage('called');
+    })->whereIn('value', ['y', 'n']);
+
+    $bot->hearText("/start $hearValue")->reply();
+
+    if ($expected) {
+        $bot->assertCalled('sendMessage');
+    } else {
+        $bot->assertNoReply();
+    }
+})->with([
+    ['y', true],
+    ['n', true],
+    ['yn', false],
+]);
+
+it('uses whereAlpha constraint', function ($hearValue, $expected) {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('start {value}', function (Nutgram $bot, $value) {
+        $bot->sendMessage('called');
+    })->whereAlpha('value');
+
+    $bot->hearText("/start $hearValue")->reply();
+
+    if ($expected) {
+        $bot->assertCalled('sendMessage');
+    } else {
+        $bot->assertNoReply();
+    }
+})->with([
+    ['y', true],
+    ['n', true],
+    ['yn', true],
+    ['123', false],
+]);
+
+it('uses whereNumber constraint', function ($hearValue, $expected) {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('start {value}', function (Nutgram $bot, $value) {
+        $bot->sendMessage('called');
+    })->whereNumber('value');
+
+    $bot->hearText("/start $hearValue")->reply();
+
+    if ($expected) {
+        $bot->assertCalled('sendMessage');
+    } else {
+        $bot->assertNoReply();
+    }
+})->with([
+    ['abc', false],
+    ['123a', false],
+    ['123', true],
+    ['1', true],
+]);
+
+it('uses whereAlphaNumeric constraint', function ($hearValue, $expected) {
+    $bot = Nutgram::fake();
+
+    $bot->onCommand('start {value}', function (Nutgram $bot, $value) {
+        $bot->sendMessage('called');
+    })->whereAlphaNumeric('value');
+
+    $bot->hearText("/start $hearValue")->reply();
+
+    if ($expected) {
+        $bot->assertCalled('sendMessage');
+    } else {
+        $bot->assertNoReply();
+    }
+})->with([
+    ['abc', true],
+    ['123a', true],
+    ['123', true],
+    ['1', true],
+    ['abc13', true],
+    ['abc123!', false],
+]);


### PR DESCRIPTION
This PR adds support for new where constraints. 
It now supports the following constraints:
- whereIn(string $parameter, array $values)
- whereAlpha(string $parameter)
- whereNumber(string $parameter)
- whereAlphaNumeric(string $parameter)

It also adds support to use the where constraints with the `group` method.