### PR TITLE
Add support for explicit binding of pattern parameters

### DIFF
--- a/src/Handlers/ResolveParameters.php
+++ b/src/Handlers/ResolveParameters.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\Handlers;
+
+trait ResolveParameters
+{
+    protected array $parametersResolvers = [];
+
+    public function bindParameter(string $name, callable $resolver): void
+    {
+
+        $this->parametersResolvers[$name] = $resolver;
+    }
+
+    public function resolveParameters(array $parameters): array
+    {
+        foreach ($parameters as $name => $value) {
+            if (isset($this->parametersResolvers[$name])) {
+                $parameters[$name] = $this->parametersResolvers[$name]($value);
+            }
+        }
+
+        return $parameters;
+    }
+}

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -19,6 +19,7 @@ use SergiX44\Nutgram\Cache\UserCache;
 use SergiX44\Nutgram\Conversations\Conversation;
 use SergiX44\Nutgram\Handlers\FireHandlers;
 use SergiX44\Nutgram\Handlers\ResolveHandlers;
+use SergiX44\Nutgram\Handlers\ResolveParameters;
 use SergiX44\Nutgram\Handlers\Type\Command;
 use SergiX44\Nutgram\Hydrator\Hydrator;
 use SergiX44\Nutgram\Proxies\GlobalCacheProxy;
@@ -36,7 +37,9 @@ use Throwable;
 
 class Nutgram extends ResolveHandlers
 {
-    use Client, UpdateDataProxy, GlobalCacheProxy, UserCacheProxy, FireHandlers, ValidatesWebData, HandleLogging;
+    use Client, HandleLogging;
+    use UpdateDataProxy, GlobalCacheProxy, UserCacheProxy;
+    use FireHandlers, ValidatesWebData, ResolveParameters;
 
     /**
      * @var string

--- a/tests/Feature/DependencyInjectionTest.php
+++ b/tests/Feature/DependencyInjectionTest.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+
 use SergiX44\Container\Container;
 use SergiX44\Container\Exception\ContainerException;
 use SergiX44\Nutgram\Configuration;

--- a/tests/Feature/DependencyInjectionTest.php
+++ b/tests/Feature/DependencyInjectionTest.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 use SergiX44\Container\Container;
 use SergiX44\Container\Exception\ContainerException;
 use SergiX44\Nutgram\Configuration;
@@ -11,6 +11,7 @@ use SergiX44\Nutgram\Tests\Fixtures\DI\MiddlewareCallable;
 use SergiX44\Nutgram\Tests\Fixtures\DI\StartCommandCallable;
 use SergiX44\Nutgram\Tests\Fixtures\DI\StartCommandClass;
 use SergiX44\Nutgram\Tests\Fixtures\DI\TextHandlerCallable;
+use SergiX44\Nutgram\Tests\Fixtures\DI\WrapperData;
 use SergiX44\Nutgram\Tests\Fixtures\MyService;
 use SergiX44\Nutgram\Tests\Fixtures\ServiceHandler;
 
@@ -140,4 +141,20 @@ describe('DI in Conversation', function () {
 
         Conversation::refreshOnDeserialize(false);
     });
+});
+
+it('resolves a parameter with custom resolution logic', function () {
+    $bot = Nutgram::fake();
+    $bot->bindParameter('value', function(string $value){
+        return new WrapperData($value);
+    });
+
+    $bot->onCommand('start {value} (y|n) {cat}', function (Nutgram $bot, WrapperData $value) {
+        expect($value)
+            ->toBeInstanceOf(WrapperData::class)
+            ->getValue()
+            ->toBe('wrapped:123');
+    });
+
+    $bot->hearText('/start 123 y aaa')->reply();
 });

--- a/tests/Fixtures/DI/WrapperData.php
+++ b/tests/Fixtures/DI/WrapperData.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SergiX44\Nutgram\Tests\Fixtures\DI;
+
+class WrapperData
+{
+    protected string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = 'wrapped:'.$value;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}


### PR DESCRIPTION
This PR adds support for explicit binding of pattern parameters.
This is useful when you want to customize the resolution logic of a pattern parameter.

If you wish to define your own resolution logic for a pattern parameter, 
you may use the `bindParameter` method of the `Nutgram` class.
The closure you pass to the `bindParameter` method will receive the value of the parameter and 
should return the resolved value that should be injected into the handler.

### Before this PR:
```php
$bot = new Nutgram('your-token');

$bot->onCommand('ban {user}', function(Nutgram $bot, string $value){
   $user = User::find($value);
   $user->ban();
});

$bot->run();
```

### After this PR:
```php
$bot = new Nutgram('your-token');

$bot->bindParameter('user', function(string $value){
    return User::find($value);
});

$bot->onCommand('ban {user}', function(Nutgram $bot, ?User $user){
    $user?->ban();
});

$bot->run();
```

Inspired by https://laravel.com/docs/11.x/routing#customizing-the-resolution-logic