### PR TITLE
Update to Bot API 7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 [![Total Downloads](http://poser.pugx.org/nutgram/nutgram/downloads)](https://packagist.org/packages/nutgram/nutgram)
 ![GitHub](https://img.shields.io/github/license/nutgram/nutgram)
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.2%09--%20March%2031,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.3%09--%20May%2006,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
 
 [![Test Suite](https://github.com/nutgram/nutgram/actions/workflows/php.yml/badge.svg)](https://github.com/nutgram/nutgram/actions/workflows/php.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/86c4ca3dae8f64db80f7/maintainability)](https://codeclimate.com/github/nutgram/nutgram/maintainability)

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -38,6 +38,7 @@ use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageId;
 use SergiX44\Nutgram\Telegram\Types\Message\ReplyParameters;
+use SergiX44\Nutgram\Telegram\Types\Poll\InputPollOption;
 use SergiX44\Nutgram\Telegram\Types\Reaction\ReactionType;
 use SergiX44\Nutgram\Telegram\Types\Sticker\Sticker;
 use SergiX44\Nutgram\Telegram\Types\User\User;
@@ -650,7 +651,7 @@ trait AvailableMethods
 
     /**
      * Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
-     * For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as {@see https://core.telegram.org/bots/api#audio Audio} or {@see https://core.telegram.org/bots/api#document Document}).
+     * For this to work, your audio must be in an .OGG file encoded with OPUS, or in .MP3 format, or in .M4A format (other formats may be sent as {@see https://core.telegram.org/bots/api#audio Audio} or {@see https://core.telegram.org/bots/api#document Document}).
      * On success, the sent {@see https://core.telegram.org/bots/api#message Message} is returned.
      * Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
      * @see https://core.telegram.org/bots/api#sendvoice
@@ -825,7 +826,7 @@ trait AvailableMethods
      * @param int|string|null $chat_id Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
      * @param int|null $message_thread_id Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
      * @param float|null $horizontal_accuracy The radius of uncertainty for the location, measured in meters; 0-1500
-     * @param int|null $live_period Period in seconds for which the location will be updated (see {@see https://telegram.org/blog/live-locations Live Locations}, should be between 60 and 86400.
+     * @param int|null $live_period Period in seconds for which the location will be updated (see {@see https://telegram.org/blog/live-locations Live Locations}, should be between 60 and 86400, or 0x7FFFFFFF for live locations that can be edited indefinitely.
      * @param int|null $heading For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
      * @param int|null $proximity_alert_radius For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
      * @param bool|null $disable_notification Sends the message {@see https://telegram.org/blog/channels-2-0#silent-messages silently}. Users will receive a notification with no sound.
@@ -891,6 +892,7 @@ trait AvailableMethods
      * @param int|null $heading Direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
      * @param int|null $proximity_alert_radius The maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for a new {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}.
+     * @param int|null $live_period New period in seconds during which the location can be updated, starting from the message send date. If 0x7FFFFFFF is specified, then the location can be updated forever. Otherwise, the new value must not exceed the current live_period by more than a day, and the live location expiration date must remain within the next 90 days. If not specified, then live_period remains unchanged
      * @return Message|bool|null
      */
     public function editMessageLiveLocation(
@@ -903,6 +905,7 @@ trait AvailableMethods
         ?int $heading = null,
         ?int $proximity_alert_radius = null,
         ?InlineKeyboardMarkup $reply_markup = null,
+        ?int $live_period = null,
     ): Message|bool|null {
         $parameters = compact(
             'chat_id',
@@ -913,7 +916,8 @@ trait AvailableMethods
             'horizontal_accuracy',
             'heading',
             'proximity_alert_radius',
-            'reply_markup'
+            'reply_markup',
+            'live_period',
         );
 
         $this->setChatMessageOrInlineMessageId($parameters);
@@ -1074,7 +1078,7 @@ trait AvailableMethods
      * On success, the sent {@see https://core.telegram.org/bots/api#message Message} is returned.
      * @see https://core.telegram.org/bots/api#sendpoll
      * @param string $question Poll question, 1-300 characters
-     * @param string[] $options A JSON-serialized list of answer options, 2-10 strings 1-100 characters each
+     * @param InputPollOption[]|string[] $options A JSON-serialized list of answer options, 2-10 strings 1-100 characters each
      * @param int|string|null $chat_id Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
      * @param int|null $message_thread_id Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
      * @param bool|null $is_anonymous True, if the poll needs to be anonymous, defaults to True
@@ -1094,6 +1098,8 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param ParseMode|string|null $question_parse_mode Mode for parsing entities in the question. See {@see https://core.telegram.org/bots/api#formatting-options formatting options} for more details. Currently, only custom emoji entities are allowed.
+     * @param MessageEntity[]|null $question_entities A JSON-serialized list of special entities that appear in the poll question. It can be specified instead of question_parse_mode
      * @return Message|null
      */
     public function sendPoll(
@@ -1118,6 +1124,8 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ParseMode|string|null $question_parse_mode = null,
+        ?array $question_entities = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -1143,6 +1151,8 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'question_parse_mode',
+            'question_entities',
         );
         return $this->requestJson(__FUNCTION__, [
             'options' => json_encode($options, JSON_THROW_ON_ERROR),

--- a/src/Telegram/Properties/BackgroundFillType.php
+++ b/src/Telegram/Properties/BackgroundFillType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum BackgroundFillType: string
+{
+    case SOLID = 'solid';
+    case GRADIENT = 'gradient';
+    case FREEFORM_GRADIENT = 'freeform_gradient';
+}

--- a/src/Telegram/Properties/BackgroundTypeType.php
+++ b/src/Telegram/Properties/BackgroundTypeType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum BackgroundTypeType: string
+{
+    case FILL = 'fill';
+    case WALLPAPER = 'wallpaper';
+    case PATTERN = 'pattern';
+    case CHAT_THEME = 'chat_theme';
+}

--- a/src/Telegram/Types/Chat/Chat.php
+++ b/src/Telegram/Types/Chat/Chat.php
@@ -26,7 +26,7 @@ class Chat extends BaseType
      */
     public int $id;
 
-    /** Type of chat, can be either “private”, “group”, “supergroup” or “channel” */
+    /** Type of the chat, can be either “private”, “group”, “supergroup” or “channel” */
     #[EnumOrScalar]
     public ChatType|string $type;
 
@@ -43,14 +43,12 @@ class Chat extends BaseType
     public ?string $username = null;
 
     /**
-     * Optional.
-     * First name of the other party in a private chat
+     * Optional. First name of the other party in a private chat
      */
     public ?string $first_name = null;
 
     /**
-     * Optional.
-     * Last name of the other party in a private chat
+     * Optional. Last name of the other party in a private chat
      */
     public ?string $last_name = null;
 
@@ -59,6 +57,36 @@ class Chat extends BaseType
      * True, if the supergroup chat is a forum (has {@see https://telegram.org/blog/topics-in-groups-collectible-usernames#topics-in-groups topics} enabled)
      */
     public ?bool $is_forum = null;
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | ChatFullInfo Properties
+    |--------------------------------------------------------------------------
+    |
+    | https://core.telegram.org/bots/api#chatfullinfo
+    |
+    | The following properties are only returned by getChat method.
+    | https://core.telegram.org/bots/api#getchat
+    |
+    | To not make breaking changes, we will split this class in the next major version.
+    | @deprecated <= Bookmark this line for Nutgram 5.0.0
+    |
+    */
+
+    /**
+     * Optional.
+     * Identifier of the accent color for the chat name and backgrounds of the chat photo, reply header, and link preview.
+     * See {@see https://core.telegram.org/bots/api#accent-colors accent colors} for more details.
+     * Returned only in {@see https://core.telegram.org/bots/api#getchat getChat}.
+     * Always returned in getChat.
+     */
+    public ?int $accent_color_id = null;
+
+    /**
+     * The maximum number of reactions that can be set on a message in the chat
+     */
+    public ?int $max_reaction_count = null;
 
     /**
      * Optional.
@@ -117,15 +145,6 @@ class Chat extends BaseType
      */
     #[ArrayType(ReactionType::class)]
     public ?array $available_reactions = null;
-
-    /**
-     * Optional.
-     * Identifier of the accent color for the chat name and backgrounds of the chat photo, reply header, and link preview.
-     * See {@see https://core.telegram.org/bots/api#accent-colors accent colors} for more details.
-     * Returned only in {@see https://core.telegram.org/bots/api#getchat getChat}.
-     * Always returned in getChat.
-     */
-    public ?int $accent_color_id = null;
 
     /**
      * Optional.

--- a/src/Telegram/Types/Chat/ChatMemberUpdated.php
+++ b/src/Telegram/Types/Chat/ChatMemberUpdated.php
@@ -34,6 +34,11 @@ class ChatMemberUpdated extends BaseType
     public ?ChatInviteLink $invite_link = null;
 
     /**
+     * Optional. True, if the user joined the chat after sending a direct join request and being approved by an administrator
+     */
+    public ?bool $via_join_request = null;
+
+    /**
      * Optional.
      * True, if the user joined the chat via a chat folder invite link
      */

--- a/src/Telegram/Types/Inline/InlineQueryResultLocation.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultLocation.php
@@ -40,8 +40,7 @@ class InlineQueryResultLocation extends InlineQueryResult
     public ?float $horizontal_accuracy = null;
 
     /**
-     * Optional.
-     * Period in seconds for which the location can be updated, should be between 60 and 86400.
+     * Optional. Period in seconds during which the location can be updated, should be between 60 and 86400, or 0x7FFFFFFF for live locations that can be edited indefinitely.
      */
     public ?int $live_period = null;
 

--- a/src/Telegram/Types/Input/InputLocationMessageContent.php
+++ b/src/Telegram/Types/Input/InputLocationMessageContent.php
@@ -24,8 +24,7 @@ class InputLocationMessageContent extends InputMessageContent
     public ?float $horizontal_accuracy = null;
 
     /**
-     * Optional.
-     * Period in seconds for which the location can be updated, should be between 60 and 86400.
+     * Optional. Period in seconds during which the location can be updated, should be between 60 and 86400, or 0x7FFFFFFF for live locations that can be edited indefinitely.
      */
     public ?int $live_period = null;
 

--- a/src/Telegram/Types/Message/BackgroundFill.php
+++ b/src/Telegram/Types/Message/BackgroundFill.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\BackgroundFillType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object describes the way a background is filled based on the selected colors. Currently, it can be one of
+ * - {@see BackgroundFillSolid}
+ * - {@see BackgroundFillGradient}
+ * - {@see BackgroundFillFreeformGradient}
+ * @see https://core.telegram.org/bots/api#backgroundfill
+ */
+abstract class BackgroundFill extends BaseType
+{
+    /**
+     * Type of the background fill
+     */
+    #[EnumOrScalar]
+    public BackgroundFillType|string $type;
+}

--- a/src/Telegram/Types/Message/BackgroundFillFreeformGradient.php
+++ b/src/Telegram/Types/Message/BackgroundFillFreeformGradient.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\BackgroundFillType;
+
+class BackgroundFillFreeformGradient extends BackgroundFill
+{
+    /**
+     * Type of the background fill, always “freeform_gradient”
+     */
+    #[EnumOrScalar]
+    public BackgroundFillType|string $type = BackgroundFillType::FREEFORM_GRADIENT;
+
+    /**
+     * A list of the 3 or 4 base colors that are used to generate the freeform gradient in the RGB24 format
+     * @var int[]
+     */
+    public array $colors;
+}

--- a/src/Telegram/Types/Message/BackgroundFillGradient.php
+++ b/src/Telegram/Types/Message/BackgroundFillGradient.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\BackgroundFillType;
+
+/**
+ * The background is a gradient fill.
+ * @see https://core.telegram.org/bots/api#backgroundfillgradient
+ */
+class BackgroundFillGradient extends BackgroundFill
+{
+    /**
+     * Type of the background fill, always “gradient”
+     */
+    #[EnumOrScalar]
+    public BackgroundFillType|string $type = BackgroundFillType::GRADIENT;
+
+    /**
+     * Top color of the gradient in the RGB24 format
+     */
+    public int $top_color;
+
+    /**
+     * Bottom color of the gradient in the RGB24 format
+     */
+    public int $bottom_color;
+
+    /**
+     * Clockwise rotation angle of the background fill in degrees; 0-359
+     */
+    public int $rotation_angle;
+}

--- a/src/Telegram/Types/Message/BackgroundFillResolver.php
+++ b/src/Telegram/Types/Message/BackgroundFillResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use Attribute;
+use InvalidArgumentException;
+use SergiX44\Nutgram\Telegram\Properties\BackgroundFillType;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class BackgroundFillResolver
+{
+    public function concreteFor(array $data): ?string
+    {
+        $type = $data['type'] ?? throw new InvalidArgumentException('Type must be defined');
+
+        return match ($type) {
+            BackgroundFillType::SOLID->value => BackgroundFillSolid::class,
+            BackgroundFillType::GRADIENT->value => BackgroundFillGradient::class,
+            BackgroundFillType::FREEFORM_GRADIENT->value => BackgroundFillFreeformGradient::class,
+            default => (new class extends BackgroundFill {
+            })::class,
+        };
+    }
+}

--- a/src/Telegram/Types/Message/BackgroundFillSolid.php
+++ b/src/Telegram/Types/Message/BackgroundFillSolid.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\BackgroundFillType;
+
+/**
+ * The background is filled using the selected color.
+ * @see https://core.telegram.org/bots/api#backgroundfillsolid
+ */
+class BackgroundFillSolid extends BackgroundFill
+{
+    /**
+     * Type of the background fill, always “solid”
+     */
+    #[EnumOrScalar]
+    public BackgroundFillType|string $type = BackgroundFillType::SOLID;
+
+    /**
+     * The color of the background fill in the RGB24 format
+     */
+    public int $color;
+}

--- a/src/Telegram/Types/Message/BackgroundType.php
+++ b/src/Telegram/Types/Message/BackgroundType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\BackgroundTypeType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object describes the type of a background. Currently, it can be one of
+ * - {@see BackgroundTypeFill}
+ * - {@see BackgroundTypeWallpaper}
+ * - {@see BackgroundTypePattern}
+ * - {@see BackgroundTypeChatTheme}
+ * @see https://core.telegram.org/bots/api#backgroundtype
+ */
+#[BackgroundTypeResolver]
+abstract class BackgroundType extends BaseType
+{
+    /**
+     * Type of the background
+     */
+    #[EnumOrScalar]
+    public BackgroundTypeType|string $type;
+}

--- a/src/Telegram/Types/Message/BackgroundTypeChatTheme.php
+++ b/src/Telegram/Types/Message/BackgroundTypeChatTheme.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\BackgroundTypeType;
+
+/**
+ * The background is taken directly from a built-in chat theme.
+ * @see https://core.telegram.org/bots/api#backgroundtypechattheme
+ */
+class BackgroundTypeChatTheme extends BackgroundType
+{
+    /**
+     * Type of the background, always “chat_theme”
+     */
+    #[EnumOrScalar]
+    public BackgroundTypeType|string $type = BackgroundTypeType::CHAT_THEME;
+
+    /**
+     * Name of the chat theme, which is usually an emoji
+     */
+    public string $theme_name;
+}

--- a/src/Telegram/Types/Message/BackgroundTypeFill.php
+++ b/src/Telegram/Types/Message/BackgroundTypeFill.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\BackgroundTypeType;
+
+/**
+ * The background is automatically filled based on the selected colors.
+ * @see https://core.telegram.org/bots/api#backgroundtypefill
+ */
+class BackgroundTypeFill extends BackgroundType
+{
+    /**
+     * Type of the background, always “fill”
+     */
+    #[EnumOrScalar]
+    public BackgroundTypeType|string $type = BackgroundTypeType::FILL;
+
+    /**
+     * The background fill
+     */
+    public BackgroundFill $fill;
+
+    /**
+     * Dimming of the background in dark themes, as a percentage; 0-100
+     */
+    public int $dark_theme_dimming;
+}

--- a/src/Telegram/Types/Message/BackgroundTypePattern.php
+++ b/src/Telegram/Types/Message/BackgroundTypePattern.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\BackgroundTypeType;
+use SergiX44\Nutgram\Telegram\Types\Media\Document;
+
+/**
+ * The background is a PNG or TGV (gzipped subset of SVG with MIME type “application/x-tgwallpattern”)
+ * pattern to be combined with the background fill chosen by the user.
+ * @see https://core.telegram.org/bots/api#backgroundtypepattern
+ */
+class BackgroundTypePattern extends BackgroundType
+{
+    /**
+     * Type of the background, always “pattern”
+     */
+    #[EnumOrScalar]
+    public BackgroundTypeType|string $type = BackgroundTypeType::PATTERN;
+
+    /**
+     * Document with the pattern
+     */
+    public Document $document;
+
+    /**
+     * The background fill that is combined with the pattern
+     */
+    public BackgroundFill $fill;
+
+    /**
+     * Intensity of the pattern when it is shown above the filled background; 0-100
+     */
+    public int $intensity;
+
+    /**
+     * Optional. True, if the background fill must be applied only to the pattern itself.
+     * All other pixels are black in this case. For dark themes only
+     */
+    public ?bool $is_inverted = null;
+
+    /**
+     * Optional. True, if the background moves slightly when the device is tilted
+     */
+    public ?bool $is_moving = null;
+}

--- a/src/Telegram/Types/Message/BackgroundTypeResolver.php
+++ b/src/Telegram/Types/Message/BackgroundTypeResolver.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use Attribute;
+use InvalidArgumentException;
+use SergiX44\Hydrator\Annotation\ConcreteResolver;
+use SergiX44\Nutgram\Telegram\Properties\BackgroundTypeType;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class BackgroundTypeResolver extends ConcreteResolver
+{
+    public function concreteFor(array $data): ?string
+    {
+        $type = $data['type'] ?? throw new InvalidArgumentException('Type must be defined');
+
+        return match ($type) {
+            BackgroundTypeType::FILL->value => BackgroundTypeFill::class,
+            BackgroundTypeType::WALLPAPER->value => BackgroundTypeWallpaper::class,
+            BackgroundTypeType::PATTERN->value => BackgroundTypePattern::class,
+            BackgroundTypeType::CHAT_THEME->value => BackgroundTypeChatTheme::class,
+            default => (new class extends BackgroundType {
+            })::class,
+        };
+    }
+}

--- a/src/Telegram/Types/Message/BackgroundTypeWallpaper.php
+++ b/src/Telegram/Types/Message/BackgroundTypeWallpaper.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\BackgroundTypeType;
+use SergiX44\Nutgram\Telegram\Types\Media\Document;
+
+/**
+ * /**
+ * The background is a wallpaper in the JPEG format.
+ * @see https://core.telegram.org/bots/api#backgroundtypewallpaper
+ */
+class BackgroundTypeWallpaper extends BackgroundType
+{
+    /**
+     * Type of the background, always “wallpaper”
+     */
+    #[EnumOrScalar]
+    public BackgroundTypeType|string $type = BackgroundTypeType::WALLPAPER;
+
+    /**
+     * Document with the wallpaper
+     */
+    public Document $document;
+
+    /**
+     * Dimming of the background in dark themes, as a percentage; 0-100
+     */
+    public int $dark_theme_dimming;
+
+    /**
+     * Optional. True, if the wallpaper is downscaled to fit in a 450x450 square and then box-blurred with radius 12
+     */
+    public ?bool $is_blurred = null;
+
+    /**
+     * Optional. True, if the background moves slightly when the device is tilted
+     */
+    public ?bool $is_moving = null;
+}

--- a/src/Telegram/Types/Message/ChatBackground.php
+++ b/src/Telegram/Types/Message/ChatBackground.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object represents a chat background.
+ * @see https://core.telegram.org/bots/api#chatbackground
+ */
+class ChatBackground extends BaseType
+{
+    /**
+     * Type of the background
+     */
+    public BackgroundType $type;
+}

--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -515,6 +515,11 @@ class Message extends BaseType
     public ?ChatBoostAdded $boost_added = null;
 
     /**
+     * Optional. Service message: chat background set
+     */
+    public ?ChatBackground $chat_background_set = null;
+
+    /**
      * Optional.
      * Service message: forum topic created
      */

--- a/src/Telegram/Types/Poll/InputPollOption.php
+++ b/src/Telegram/Types/Poll/InputPollOption.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Poll;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\ParseMode;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
+
+/**
+ * This object contains information about one answer option in a poll to send.
+ * @see https://core.telegram.org/bots/api#inputpolloption
+ */
+class InputPollOption extends BaseType
+{
+    /** Option text, 1-100 characters */
+    public string $text;
+
+    /**
+     * Optional. Mode for parsing entities in the option text.
+     * See {@see https://core.telegram.org/bots/api#formatting-options formatting options} for more details.
+     * Currently, only custom emoji entities are allowed
+     */
+    #[EnumOrScalar]
+    public ParseMode|string|null $text_parse_mode = null;
+
+    /**
+     * Optional. Special entities that appear in the option text. Currently, only custom emoji entities are allowed in poll option texts
+     */
+    #[ArrayType(MessageEntity::class)]
+    public ?array $text_entities = null;
+}

--- a/src/Telegram/Types/Poll/Poll.php
+++ b/src/Telegram/Types/Poll/Poll.php
@@ -21,6 +21,12 @@ class Poll extends BaseType
     public string $question;
 
     /**
+     * Optional. Special entities that appear in the question. Currently, only custom emoji entities are allowed in poll questions
+     */
+    #[ArrayType(MessageEntity::class)]
+    public ?array $question_entities = null;
+
+    /**
      * List of poll options
      * @var PollOption[] $options
      */

--- a/src/Telegram/Types/Poll/PollOption.php
+++ b/src/Telegram/Types/Poll/PollOption.php
@@ -2,7 +2,9 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Poll;
 
+use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
 
 /**
  * This object contains information about one answer option in a poll.
@@ -12,6 +14,12 @@ class PollOption extends BaseType
 {
     /** Option text, 1-100 characters */
     public string $text;
+
+    /**
+     * Optional. Special entities that appear in the option text. Currently, only custom emoji entities are allowed in poll option texts
+     */
+    #[ArrayType(MessageEntity::class)]
+    public ?array $text_entities = null;
 
     /** Number of users that voted for this option */
     public int $voter_count;


### PR DESCRIPTION
https://core.telegram.org/bots/api-changelog#may-6-2024

### Tasks:

- [x] Update badge
- [x] Added support for [InlineKeyboardMarkup](https://core.telegram.org/bots/api#inlinekeyboardmarkup) with url, login_url, and callback_game buttons for messages sent on behalf of a business account.
- [x] Added the field via_join_request to the class [ChatMemberUpdated](https://core.telegram.org/bots/api#chatmemberupdated).
- [x] Added support for live locations that can be edited indefinitely, allowing 0x7FFFFFFF to be used as live_period.
- [x] Added the parameter live_period to the method [editMessageLiveLocation](https://core.telegram.org/bots/api#editmessagelivelocation).
- [x] Added the field question_entities to the class [Poll](https://core.telegram.org/bots/api#poll).
- [x] Added the field text_entities to the class [PollOption](https://core.telegram.org/bots/api#polloption).
- [x] Added the parameters question_parse_mode and question_entities to the method [sendPoll](https://core.telegram.org/bots/api#sendpoll).
- [x] Added the class [InputPollOption](https://core.telegram.org/bots/api#inputpolloption) and changed the type of the parameter options in the method [sendPoll](https://core.telegram.org/bots/api#sendpoll) to Array of [InputPollOption](https://core.telegram.org/bots/api#inputpolloption).
- [x] Added the classes [ChatBackground](https://core.telegram.org/bots/api#chatbackground), [BackgroundType](https://core.telegram.org/bots/api#backgroundtype), [BackgroundFill](https://core.telegram.org/bots/api#backgroundfill) and the field chat_background_set of type [ChatBackground](https://core.telegram.org/bots/api#chatbackground) to the class [Message](https://core.telegram.org/bots/api#message), describing service messages about background changes.
- [x] Split out the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo) from the class [Chat](https://core.telegram.org/bots/api#chat) and changed the return type of the method [getChat](https://core.telegram.org/bots/api#getchat) to [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).
- [x] Added the field max_reaction_count to the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).
- [x] Documented that .MP3 and .M4A files can be used as voice messages.