### PR TITLE
Add Update Once Method

### DIFF
--- a/src/Handlers/CollectHandlers.php
+++ b/src/Handlers/CollectHandlers.php
@@ -53,6 +53,20 @@ abstract class CollectHandlers
     }
 
     /**
+     * @return $this
+     */
+    public function reset(): static
+    {
+        $this->handlers = [];
+        $this->groups = [];
+        $this->globalMiddlewares = [];
+        $this->groupHandlers = [];
+        $this->target = 'handlers';
+
+        return $this;
+    }
+
+    /**
      * @param Array<callable|callable-string|array> $callable
      */
     public function middlewares($callable): void

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -202,6 +202,16 @@ class Nutgram extends ResolveHandlers
     }
 
     /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function once(): void
+    {
+        $this->preflight();
+        $this->container->get(RunningMode::class)->processUpdate($this);
+    }
+
+    /**
      * @param Update $update
      * @throws Throwable
      * @throws \Psr\SimpleCache\InvalidArgumentException

--- a/src/RunningMode/Polling.php
+++ b/src/RunningMode/Polling.php
@@ -37,8 +37,7 @@ class Polling implements RunningMode
         $this->listenForSignals();
         print("Listening...\n");
         while (self::$FOREVER) {
-
-             $this->processUpdate($bot);
+            $this->processUpdate($bot);
         }
     }
 

--- a/src/RunningMode/Polling.php
+++ b/src/RunningMode/Polling.php
@@ -37,6 +37,7 @@ class Polling implements RunningMode
         $this->listenForSignals();
         print("Listening...\n");
         while (self::$FOREVER) {
+
              $this->processUpdate($bot);
         }
     }


### PR DESCRIPTION
This PR adds abbility to implement `nutgram:listen` as mentioned in #710 and #711 . 
In order to add the command to Nutgrams Laravel repository, Firstly we need to be able to process one update in pulling mode and clear the Handler collector. After merging this PR I will follow up with another PR to Nutgram/Laravel adding this command:


```php
class ListenCommand extends Command
{
    protected $signature = 'nutgram:listen';

    protected $description = 'Start the bot in long polling mode';

    /**
     * @throws ContainerExceptionInterface
     * @throws NotFoundExceptionInterface
     */
    public function handle(Nutgram $bot): void
    {
        while (true) {
            $bot->once();                                              // process one update
            $bot->reset();                                             //clear handlers
            require app()->basePath('routes/telegram.php');            // register handlers again
        }
    }
}
```