### PR TITLE
Update to Bot API 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 [![Total Downloads](http://poser.pugx.org/nutgram/nutgram/downloads)](https://packagist.org/packages/nutgram/nutgram)
 ![GitHub](https://img.shields.io/github/license/nutgram/nutgram)
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.3%09--%20May%2006,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.4%09--%20May%2028,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
 
 [![Test Suite](https://github.com/nutgram/nutgram/actions/workflows/php.yml/badge.svg)](https://github.com/nutgram/nutgram/actions/workflows/php.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/86c4ca3dae8f64db80f7/maintainability)](https://codeclimate.com/github/nutgram/nutgram/maintainability)

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -109,6 +109,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @return Message|null
      */
     public function sendMessage(
@@ -126,6 +127,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -145,6 +147,7 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->requestJson(__FUNCTION__, $parameters, Message::class);
@@ -234,6 +237,7 @@ trait AvailableMethods
      * @param bool|null $allow_sending_without_reply Pass True if the message should be sent even if the specified replied-to message is not found
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
+     * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
      * @return MessageId|null
      */
     public function copyMessage(
@@ -250,6 +254,7 @@ trait AvailableMethods
         ?bool $allow_sending_without_reply = null,
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
+        ?bool $show_caption_above_media = null,
     ): ?MessageId {
         return $this->requestJson(__FUNCTION__, compact(
             'chat_id',
@@ -264,7 +269,8 @@ trait AvailableMethods
             'reply_to_message_id',
             'allow_sending_without_reply',
             'reply_parameters',
-            'reply_markup'
+            'reply_markup',
+            'show_caption_above_media',
         ), MessageId::class);
     }
 
@@ -323,6 +329,8 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -341,6 +349,8 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?bool $show_caption_above_media = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -360,6 +370,8 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'show_caption_above_media',
+            'message_effect_id',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'photo', $photo, $opt, $clientOpt);
@@ -388,6 +400,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -409,6 +422,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -431,6 +445,7 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'audio', $audio, $opt, $clientOpt);
@@ -456,6 +471,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -475,6 +491,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -495,6 +512,7 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'document', $document, $opt, $clientOpt);
@@ -524,6 +542,8 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -547,6 +567,8 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?bool $show_caption_above_media = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -571,6 +593,8 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'show_caption_above_media',
+            'message_effect_id',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'video', $video, $opt, $clientOpt);
@@ -599,6 +623,8 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -621,6 +647,8 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?bool $show_caption_above_media = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -644,6 +672,8 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'show_caption_above_media',
+            'message_effect_id',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'animation', $animation, $opt, $clientOpt);
@@ -669,6 +699,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -687,6 +718,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -706,6 +738,7 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'voice', $voice, $opt, $clientOpt);
@@ -729,6 +762,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -746,6 +780,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -764,6 +799,7 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'video_note', $video_note, $opt, $clientOpt);
@@ -783,6 +819,7 @@ trait AvailableMethods
      * @param bool|null $allow_sending_without_reply Pass True if the message should be sent even if the specified replied-to message is not found
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message[]|null
      */
@@ -796,6 +833,7 @@ trait AvailableMethods
         ?bool $allow_sending_without_reply = null,
         ?ReplyParameters $reply_parameters = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?array {
         $chat_id ??= $this->chatId();
@@ -813,6 +851,7 @@ trait AvailableMethods
                 'allow_sending_without_reply',
                 'reply_parameters',
                 'business_connection_id',
+                'message_effect_id',
             ),
         ], Message::class, $clientOpt);
     }
@@ -836,6 +875,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @return Message|null
      */
     public function sendLocation(
@@ -854,6 +894,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -875,6 +916,7 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         ), Message::class);
     }
 
@@ -972,6 +1014,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @return Message|null
      */
     public function sendVenue(
@@ -992,6 +1035,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -1015,6 +1059,7 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         ), Message::class);
     }
 
@@ -1035,6 +1080,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @return Message|null
      */
     public function sendContact(
@@ -1051,6 +1097,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -1070,6 +1117,7 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         ), Message::class);
     }
 
@@ -1100,6 +1148,7 @@ trait AvailableMethods
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param ParseMode|string|null $question_parse_mode Mode for parsing entities in the question. See {@see https://core.telegram.org/bots/api#formatting-options formatting options} for more details. Currently, only custom emoji entities are allowed.
      * @param MessageEntity[]|null $question_entities A JSON-serialized list of special entities that appear in the poll question. It can be specified instead of question_parse_mode
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @return Message|null
      */
     public function sendPoll(
@@ -1126,6 +1175,7 @@ trait AvailableMethods
         ?string $business_connection_id = null,
         ParseMode|string|null $question_parse_mode = null,
         ?array $question_entities = null,
+        ?string $message_effect_id = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -1153,6 +1203,7 @@ trait AvailableMethods
             'business_connection_id',
             'question_parse_mode',
             'question_entities',
+            'message_effect_id',
         );
         return $this->requestJson(__FUNCTION__, [
             'options' => json_encode($options, JSON_THROW_ON_ERROR),
@@ -1174,6 +1225,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @return Message|null
      */
     public function sendDice(
@@ -1187,6 +1239,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -1202,6 +1255,7 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         ), Message::class);
     }
 

--- a/src/Telegram/Endpoints/CustomEndpoints.php
+++ b/src/Telegram/Endpoints/CustomEndpoints.php
@@ -36,6 +36,7 @@ trait CustomEndpoints
      * @param bool|null $allow_sending_without_reply Pass True if the message should be sent even if the specified replied-to message is not found
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @return Message[]|null
      */
     public function sendChunkedMessage(
@@ -51,6 +52,7 @@ trait CustomEndpoints
         ?bool $allow_sending_without_reply = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
     ): ?array {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -68,6 +70,7 @@ trait CustomEndpoints
             'allow_sending_without_reply',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
         unset($parameters['text']);
 
@@ -113,6 +116,7 @@ trait CustomEndpoints
      * @param bool|null $allow_sending_without_reply Pass True if the message should be sent even if the specified replied-to message is not found
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message[]|null
      */
@@ -130,6 +134,7 @@ trait CustomEndpoints
         ?bool $allow_sending_without_reply = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?array {
         $chat_id ??= $this->chatId();
@@ -148,6 +153,7 @@ trait CustomEndpoints
             'allow_sending_without_reply',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
         return $this->sendChunkedMedia(
             endpoint: 'sendPhoto',
@@ -183,6 +189,7 @@ trait CustomEndpoints
      * @param bool|null $allow_sending_without_reply Pass True if the message should be sent even if the specified replied-to message is not found
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message[]|null
      */
@@ -203,6 +210,7 @@ trait CustomEndpoints
         ?bool $allow_sending_without_reply = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?array {
         $chat_id ??= $this->chatId();
@@ -224,6 +232,7 @@ trait CustomEndpoints
             'allow_sending_without_reply',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->sendChunkedMedia(
@@ -255,6 +264,7 @@ trait CustomEndpoints
      * @param bool|null $allow_sending_without_reply Pass True if the message should be sent even if the specified replied-to message is not found
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message[]|null
      */
@@ -273,6 +283,7 @@ trait CustomEndpoints
         ?bool $allow_sending_without_reply = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?array {
         $chat_id ??= $this->chatId();
@@ -292,6 +303,7 @@ trait CustomEndpoints
             'allow_sending_without_reply',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->sendChunkedMedia(
@@ -328,6 +340,7 @@ trait CustomEndpoints
      * @param bool|null $allow_sending_without_reply Pass True if the message should be sent even if the specified replied-to message is not found
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message[]|null
      */
@@ -350,6 +363,7 @@ trait CustomEndpoints
         ?bool $allow_sending_without_reply = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?array {
         $chat_id ??= $this->chatId();
@@ -373,6 +387,7 @@ trait CustomEndpoints
             'allow_sending_without_reply',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->sendChunkedMedia(
@@ -407,6 +422,7 @@ trait CustomEndpoints
      * @param bool|null $allow_sending_without_reply Pass True if the message should be sent even if the specified replied-to message is not found
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message[]|null
      */
@@ -428,6 +444,7 @@ trait CustomEndpoints
         ?bool $allow_sending_without_reply = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?array {
         $chat_id ??= $this->chatId();
@@ -450,6 +467,7 @@ trait CustomEndpoints
             'allow_sending_without_reply',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->sendChunkedMedia(
@@ -483,6 +501,7 @@ trait CustomEndpoints
      * @param bool|null $allow_sending_without_reply Pass True if the message should be sent even if the specified replied-to message is not found
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message[]|null
      */
@@ -500,6 +519,7 @@ trait CustomEndpoints
         ?bool $allow_sending_without_reply = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?array {
         $chat_id ??= $this->chatId();
@@ -518,6 +538,7 @@ trait CustomEndpoints
             'allow_sending_without_reply',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->sendChunkedMedia(

--- a/src/Telegram/Endpoints/Games.php
+++ b/src/Telegram/Endpoints/Games.php
@@ -29,6 +29,7 @@ trait Games
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @return Message|null
      */
     public function sendGame(
@@ -42,6 +43,7 @@ trait Games
         ?ReplyParameters $reply_parameters = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -57,6 +59,7 @@ trait Games
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->requestJson(__FUNCTION__, $parameters, Message::class);

--- a/src/Telegram/Endpoints/Payments.php
+++ b/src/Telegram/Endpoints/Payments.php
@@ -23,8 +23,8 @@ trait Payments
      * @param string $title Product name, 1-32 characters
      * @param string $description Product description, 1-255 characters
      * @param string $payload Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
-     * @param string $provider_token Payment provider token, obtained via {@see https://t.me/botfather @BotFather}
-     * @param string $currency Three-letter ISO 4217 currency code, see {@see https://core.telegram.org/bots/payments#supported-currencies more on currencies}
+     * @param string $provider_token Payment provider token, obtained via {@see https://t.me/botfather @BotFather}. Pass an empty string for payments in {@see https://t.me/BotNews/90 Telegram Stars}.
+     * @param string $currency Three-letter ISO 4217 currency code, see {@see https://core.telegram.org/bots/payments#supported-currencies more on currencies}. Pass “XTR” for payments in {@see https://t.me/BotNews/90 Telegram Stars}.
      * @param LabeledPrice[] $prices Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
      * @param int|string|null $chat_id Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
      * @param int|null $message_thread_id Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
@@ -49,6 +49,7 @@ trait Payments
      * @param bool|null $allow_sending_without_reply Pass True if the message should be sent even if the specified replied-to message is not found
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button.
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @return Message|null
      */
     public function sendInvoice(
@@ -81,6 +82,7 @@ trait Payments
         ?bool $allow_sending_without_reply = null,
         ?ReplyParameters $reply_parameters = null,
         ?InlineKeyboardMarkup $reply_markup = null,
+        ?string $message_effect_id = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -113,7 +115,8 @@ trait Payments
             'reply_to_message_id',
             'allow_sending_without_reply',
             'reply_parameters',
-            'reply_markup'
+            'reply_markup',
+            'message_effect_id',
         );
         $parameters['prices'] = json_encode($prices, JSON_THROW_ON_ERROR);
         return $this->requestJson(__FUNCTION__, $parameters, Message::class);
@@ -126,8 +129,8 @@ trait Payments
      * @param string $title Product name, 1-32 characters
      * @param string $description Product description, 1-255 characters
      * @param string $payload Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
-     * @param string $provider_token Payment provider token, obtained via {@see https://t.me/botfather BotFather}
-     * @param string $currency Three-letter ISO 4217 currency code, see {@see https://core.telegram.org/bots/payments#supported-currencies more on currencies}
+     * @param string $provider_token Payment provider token, obtained via {@see https://t.me/botfather BotFather}. Pass an empty string for payments in {@see https://t.me/BotNews/90 Telegram Stars}.
+     * @param string $currency Three-letter ISO 4217 currency code, see {@see https://core.telegram.org/bots/payments#supported-currencies more on currencies}. Pass “XTR” for payments in {@see https://t.me/BotNews/90 Telegram Stars}.
      * @param LabeledPrice[] $prices Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
      * @param int|null $max_tip_amount The maximum accepted amount for tips in the smallest units of the currency (integer, not float/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in {@see https://core.telegram.org/bots/payments/currencies.json currencies.json}, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0
      * @param int[]|null $suggested_tip_amounts A JSON-serialized array of suggested amounts of tips in the smallest units of the currency (integer, not float/double). At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed max_tip_amount.
@@ -233,6 +236,24 @@ trait Payments
     ): ?bool {
         $pre_checkout_query_id ??= $this->preCheckoutQuery()?->id;
         $parameters = compact('pre_checkout_query_id', 'ok', 'error_message');
+
+        return $this->requestJson(__FUNCTION__, $parameters);
+    }
+
+    /**
+     * Refunds a successful payment in {@see https://t.me/BotNews/90 Telegram Stars}.
+     * Returns True on success.
+     * @see https://core.telegram.org/bots/api#refundstarpayment
+     * @param int $user_id Identifier of the user whose payment will be refunded
+     * @param string $telegram_payment_charge_id Telegram payment identifier
+     * @return bool|null
+     */
+    public function refundStarPayment(
+        string $telegram_payment_charge_id,
+        ?int $user_id = null
+    ): ?bool {
+        $user_id ??= $this->userId();
+        $parameters = compact('user_id', 'telegram_payment_charge_id');
 
         return $this->requestJson(__FUNCTION__, $parameters);
     }

--- a/src/Telegram/Endpoints/Stickers.php
+++ b/src/Telegram/Endpoints/Stickers.php
@@ -41,6 +41,7 @@ trait Stickers
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -56,6 +57,7 @@ trait Stickers
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $message_effect_id = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -72,6 +74,7 @@ trait Stickers
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'message_effect_id',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'sticker', $sticker, $opt, $clientOpt);

--- a/src/Telegram/Endpoints/UpdatesMessages.php
+++ b/src/Telegram/Endpoints/UpdatesMessages.php
@@ -71,6 +71,7 @@ trait UpdatesMessages
      * @param ParseMode|string|null $parse_mode Mode for parsing entities in the message caption. See {@see https://core.telegram.org/bots/api#formatting-options formatting options} for more details.
      * @param MessageEntity[]|null $caption_entities A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}.
+     * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
      * @return Message|bool|null
      */
     public function editMessageCaption(
@@ -81,6 +82,7 @@ trait UpdatesMessages
         ParseMode|string|null $parse_mode = null,
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
+        ?bool $show_caption_above_media = null,
     ): Message|bool|null {
         $parameters = compact(
             'chat_id',
@@ -89,7 +91,8 @@ trait UpdatesMessages
             'caption',
             'parse_mode',
             'caption_entities',
-            'reply_markup'
+            'reply_markup',
+            'show_caption_above_media',
         );
         $this->setChatMessageOrInlineMessageId($parameters);
 

--- a/src/Telegram/Properties/MessageEntityType.php
+++ b/src/Telegram/Properties/MessageEntityType.php
@@ -17,6 +17,7 @@ enum MessageEntityType: string
     case STRIKETHROUGH = 'strikethrough';
     case SPOILER = 'spoiler';
     case BLOCKQUOTE = 'blockquote';
+    case EXPANDABLE_BLOCKQUOTE = 'expandable_blockquote';
     case CODE = 'code';
     case PRE = 'pre';
     case TEXT_LINK = 'text_link';

--- a/src/Telegram/Types/Inline/InlineQueryResultCachedGif.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultCachedGif.php
@@ -58,6 +58,11 @@ class InlineQueryResultCachedGif extends InlineQueryResult
     public ?array $caption_entities = null;
 
     /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
+
+    /**
      * Optional.
      * {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
      */
@@ -78,6 +83,7 @@ class InlineQueryResultCachedGif extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ) {
         parent::__construct();
         $this->id = $id;
@@ -88,6 +94,7 @@ class InlineQueryResultCachedGif extends InlineQueryResult
         $this->caption_entities = $caption_entities;
         $this->reply_markup = $reply_markup;
         $this->input_message_content = $input_message_content;
+        $this->show_caption_above_media = $show_caption_above_media;
     }
 
     public static function make(
@@ -99,6 +106,7 @@ class InlineQueryResultCachedGif extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ): self {
         return new self(
             id: $id,
@@ -109,6 +117,7 @@ class InlineQueryResultCachedGif extends InlineQueryResult
             caption_entities: $caption_entities,
             reply_markup: $reply_markup,
             input_message_content: $input_message_content,
+            show_caption_above_media: $show_caption_above_media,
         );
     }
 
@@ -124,6 +133,7 @@ class InlineQueryResultCachedGif extends InlineQueryResult
             'caption_entities' => $this->caption_entities,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
+            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultCachedMpeg4Gif.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultCachedMpeg4Gif.php
@@ -58,6 +58,11 @@ class InlineQueryResultCachedMpeg4Gif extends InlineQueryResult
     public ?array $caption_entities = null;
 
     /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
+
+    /**
      * Optional.
      * {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
      */
@@ -78,6 +83,7 @@ class InlineQueryResultCachedMpeg4Gif extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ) {
         parent::__construct();
         $this->id = $id;
@@ -88,6 +94,7 @@ class InlineQueryResultCachedMpeg4Gif extends InlineQueryResult
         $this->caption_entities = $caption_entities;
         $this->reply_markup = $reply_markup;
         $this->input_message_content = $input_message_content;
+        $this->show_caption_above_media = $show_caption_above_media;
     }
 
     public static function make(
@@ -99,6 +106,7 @@ class InlineQueryResultCachedMpeg4Gif extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ): self {
         return new self(
             id: $id,
@@ -109,6 +117,7 @@ class InlineQueryResultCachedMpeg4Gif extends InlineQueryResult
             caption_entities: $caption_entities,
             reply_markup: $reply_markup,
             input_message_content: $input_message_content,
+            show_caption_above_media: $show_caption_above_media,
         );
     }
 
@@ -124,6 +133,7 @@ class InlineQueryResultCachedMpeg4Gif extends InlineQueryResult
             'caption_entities' => $this->caption_entities,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
+            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultCachedPhoto.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultCachedPhoto.php
@@ -64,6 +64,11 @@ class InlineQueryResultCachedPhoto extends InlineQueryResult
     public ?array $caption_entities = null;
 
     /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
+
+    /**
      * Optional.
      * {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
      */
@@ -85,6 +90,7 @@ class InlineQueryResultCachedPhoto extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ) {
         parent::__construct();
         $this->id = $id;
@@ -96,6 +102,7 @@ class InlineQueryResultCachedPhoto extends InlineQueryResult
         $this->caption_entities = $caption_entities;
         $this->reply_markup = $reply_markup;
         $this->input_message_content = $input_message_content;
+        $this->show_caption_above_media = $show_caption_above_media;
     }
 
     public static function make(
@@ -108,6 +115,7 @@ class InlineQueryResultCachedPhoto extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ): self {
         return new self(
             id: $id,
@@ -119,6 +127,7 @@ class InlineQueryResultCachedPhoto extends InlineQueryResult
             caption_entities: $caption_entities,
             reply_markup: $reply_markup,
             input_message_content: $input_message_content,
+            show_caption_above_media: $show_caption_above_media,
         );
     }
 
@@ -135,6 +144,7 @@ class InlineQueryResultCachedPhoto extends InlineQueryResult
             'caption_entities' => $this->caption_entities,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
+            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultCachedVideo.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultCachedVideo.php
@@ -61,6 +61,11 @@ class InlineQueryResultCachedVideo extends InlineQueryResult
     public ?array $caption_entities = null;
 
     /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
+
+    /**
      * Optional.
      * {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
      */
@@ -82,6 +87,7 @@ class InlineQueryResultCachedVideo extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ) {
         parent::__construct();
         $this->id = $id;
@@ -93,6 +99,7 @@ class InlineQueryResultCachedVideo extends InlineQueryResult
         $this->caption_entities = $caption_entities;
         $this->reply_markup = $reply_markup;
         $this->input_message_content = $input_message_content;
+        $this->show_caption_above_media = $show_caption_above_media;
     }
 
     public static function make(
@@ -105,6 +112,7 @@ class InlineQueryResultCachedVideo extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ): self {
         return new self(
             id: $id,
@@ -116,6 +124,7 @@ class InlineQueryResultCachedVideo extends InlineQueryResult
             caption_entities: $caption_entities,
             reply_markup: $reply_markup,
             input_message_content: $input_message_content,
+            show_caption_above_media: $show_caption_above_media,
         );
     }
 
@@ -132,6 +141,7 @@ class InlineQueryResultCachedVideo extends InlineQueryResult
             'caption_entities' => $this->caption_entities,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
+            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultGif.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultGif.php
@@ -89,6 +89,11 @@ class InlineQueryResultGif extends InlineQueryResult
     public ?array $caption_entities = null;
 
     /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
+
+    /**
      * Optional.
      * {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
      */
@@ -114,6 +119,7 @@ class InlineQueryResultGif extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ) {
         parent::__construct();
         $this->id = $id;
@@ -129,6 +135,7 @@ class InlineQueryResultGif extends InlineQueryResult
         $this->caption_entities = $caption_entities;
         $this->reply_markup = $reply_markup;
         $this->input_message_content = $input_message_content;
+        $this->show_caption_above_media = $show_caption_above_media;
     }
 
     public static function make(
@@ -145,6 +152,7 @@ class InlineQueryResultGif extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ): self {
         return new self(
             id: $id,
@@ -160,6 +168,7 @@ class InlineQueryResultGif extends InlineQueryResult
             caption_entities: $caption_entities,
             reply_markup: $reply_markup,
             input_message_content: $input_message_content,
+            show_caption_above_media: $show_caption_above_media,
         );
     }
 
@@ -180,6 +189,7 @@ class InlineQueryResultGif extends InlineQueryResult
             'caption_entities' => $this->caption_entities,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
+            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultMpeg4Gif.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultMpeg4Gif.php
@@ -89,6 +89,11 @@ class InlineQueryResultMpeg4Gif extends InlineQueryResult
     public ?array $caption_entities = null;
 
     /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
+
+    /**
      * Optional.
      * {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
      */
@@ -114,6 +119,7 @@ class InlineQueryResultMpeg4Gif extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ) {
         parent::__construct();
         $this->id = $id;
@@ -129,6 +135,41 @@ class InlineQueryResultMpeg4Gif extends InlineQueryResult
         $this->caption_entities = $caption_entities;
         $this->reply_markup = $reply_markup;
         $this->input_message_content = $input_message_content;
+        $this->show_caption_above_media = $show_caption_above_media;
+    }
+
+    public static function make(
+        string $id,
+        string $mpeg4_url,
+        string $thumbnail_url,
+        ?int $mpeg4_width = null,
+        ?int $mpeg4_height = null,
+        ?int $mpeg4_duration = null,
+        ?string $thumbnail_mime_type = null,
+        ?string $title = null,
+        ?string $caption = null,
+        ?ParseMode $parse_mode = null,
+        ?array $caption_entities = null,
+        ?InlineKeyboardMarkup $reply_markup = null,
+        ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
+    ): self {
+        return new self(
+            id: $id,
+            mpeg4_url: $mpeg4_url,
+            thumbnail_url: $thumbnail_url,
+            mpeg4_width: $mpeg4_width,
+            mpeg4_height: $mpeg4_height,
+            mpeg4_duration: $mpeg4_duration,
+            thumbnail_mime_type: $thumbnail_mime_type,
+            title: $title,
+            caption: $caption,
+            parse_mode: $parse_mode,
+            caption_entities: $caption_entities,
+            reply_markup: $reply_markup,
+            input_message_content: $input_message_content,
+            show_caption_above_media: $show_caption_above_media,
+        );
     }
 
     public function jsonSerialize(): array
@@ -148,6 +189,7 @@ class InlineQueryResultMpeg4Gif extends InlineQueryResult
             'caption_entities' => $this->caption_entities,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
+            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultPhoto.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultPhoto.php
@@ -83,6 +83,11 @@ class InlineQueryResultPhoto extends InlineQueryResult
     public ?array $caption_entities = null;
 
     /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
+
+    /**
      * Optional.
      * {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
      */
@@ -107,6 +112,7 @@ class InlineQueryResultPhoto extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ) {
         parent::__construct();
         $this->id = $id;
@@ -121,6 +127,7 @@ class InlineQueryResultPhoto extends InlineQueryResult
         $this->caption_entities = $caption_entities;
         $this->reply_markup = $reply_markup;
         $this->input_message_content = $input_message_content;
+        $this->show_caption_above_media = $show_caption_above_media;
     }
 
     public static function make(
@@ -136,6 +143,7 @@ class InlineQueryResultPhoto extends InlineQueryResult
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ): self {
         return new self(
             id: $id,
@@ -150,6 +158,7 @@ class InlineQueryResultPhoto extends InlineQueryResult
             caption_entities: $caption_entities,
             reply_markup: $reply_markup,
             input_message_content: $input_message_content,
+            show_caption_above_media: $show_caption_above_media,
         );
     }
 
@@ -169,6 +178,7 @@ class InlineQueryResultPhoto extends InlineQueryResult
             'caption_entities' => $this->caption_entities,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
+            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultVideo.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultVideo.php
@@ -85,6 +85,11 @@ class InlineQueryResultVideo extends InlineQueryResult
     public ?string $description = null;
 
     /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
+
+    /**
      * Optional.
      * {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
      */
@@ -112,6 +117,7 @@ class InlineQueryResultVideo extends InlineQueryResult
         ?string $description = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ) {
         parent::__construct();
         $this->id = $id;
@@ -128,6 +134,7 @@ class InlineQueryResultVideo extends InlineQueryResult
         $this->description = $description;
         $this->reply_markup = $reply_markup;
         $this->input_message_content = $input_message_content;
+        $this->show_caption_above_media = $show_caption_above_media;
     }
 
     public static function make(
@@ -145,6 +152,7 @@ class InlineQueryResultVideo extends InlineQueryResult
         ?string $description = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?InputMessageContent $input_message_content = null,
+        ?bool $show_caption_above_media = null,
     ): self {
         return new self(
             id: $id,
@@ -161,6 +169,7 @@ class InlineQueryResultVideo extends InlineQueryResult
             description: $description,
             reply_markup: $reply_markup,
             input_message_content: $input_message_content,
+            show_caption_above_media: $show_caption_above_media,
         );
     }
 
@@ -182,6 +191,7 @@ class InlineQueryResultVideo extends InlineQueryResult
             'description' => $this->description,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
+            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Input/InputInvoiceMessageContent.php
+++ b/src/Telegram/Types/Input/InputInvoiceMessageContent.php
@@ -24,10 +24,17 @@ class InputInvoiceMessageContent extends InputMessageContent
      */
     public string $payload;
 
-    /** Payment provider token, obtained via {@see https://t.me/botfather @BotFather} */
-    public string $provider_token;
+    /**
+     * Optional.
+     * Payment provider token, obtained via {@see https://t.me/botfather @BotFather}.
+     * Pass an empty string for payments in {@see https://t.me/BotNews/90 Telegram Stars}.
+     */
+    public ?string $provider_token = null;
 
-    /** Three-letter ISO 4217 currency code, see {@see https://core.telegram.org/bots/payments#supported-currencies more on currencies} */
+    /**
+     * Three-letter ISO 4217 currency code, see {@see https://core.telegram.org/bots/payments#supported-currencies more on currencies}.
+     * Pass “XTR” for payments in {@see https://t.me/BotNews/90 Telegram Stars}.
+     */
     public string $currency;
 
     /**
@@ -227,7 +234,7 @@ class InputInvoiceMessageContent extends InputMessageContent
             'title' => $this->title,
             'description' => $this->description,
             'payload' => $this->payload,
-            'provider_token' => $this->provider_token,
+            'provider_token' => $this->provider_token ?: null,
             'currency' => $this->currency,
             'prices' => $this->prices,
             'max_tip_amount' => $this->max_tip_amount,

--- a/src/Telegram/Types/Input/InputMediaAnimation.php
+++ b/src/Telegram/Types/Input/InputMediaAnimation.php
@@ -56,6 +56,11 @@ class InputMediaAnimation extends InputMedia implements JsonSerializable
     public ?array $caption_entities = null;
 
     /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
+
+    /**
      * Optional.
      * Animation width
      */
@@ -81,14 +86,15 @@ class InputMediaAnimation extends InputMedia implements JsonSerializable
 
     public function __construct(
         InputFile|string $media,
-        InputFile|string|null $thumbnail,
-        ?string $caption,
-        ParseMode|string|null $parse_mode,
-        ?array $caption_entities,
-        ?int $width,
-        ?int $height,
-        ?int $duration,
-        ?bool $has_spoiler
+        InputFile|string|null $thumbnail = null,
+        ?string $caption = null,
+        ParseMode|string|null $parse_mode = null,
+        ?array $caption_entities = null,
+        ?int $width = null,
+        ?int $height = null,
+        ?int $duration = null,
+        ?bool $has_spoiler = null,
+        ?bool $show_caption_above_media = null,
     ) {
         parent::__construct();
         $this->media = $media;
@@ -100,6 +106,7 @@ class InputMediaAnimation extends InputMedia implements JsonSerializable
         $this->height = $height;
         $this->duration = $duration;
         $this->has_spoiler = $has_spoiler;
+        $this->show_caption_above_media = $show_caption_above_media;
     }
 
     public static function make(
@@ -111,7 +118,8 @@ class InputMediaAnimation extends InputMedia implements JsonSerializable
         ?int $width = null,
         ?int $height = null,
         ?int $duration = null,
-        ?bool $has_spoiler = null
+        ?bool $has_spoiler = null,
+        ?bool $show_caption_above_media = null,
     ): self {
         return new self(
             media: $media,
@@ -122,7 +130,8 @@ class InputMediaAnimation extends InputMedia implements JsonSerializable
             width: $width,
             height: $height,
             duration: $duration,
-            has_spoiler: $has_spoiler
+            has_spoiler: $has_spoiler,
+            show_caption_above_media: $show_caption_above_media,
         );
     }
 
@@ -139,6 +148,7 @@ class InputMediaAnimation extends InputMedia implements JsonSerializable
             'height' => $this->height,
             'duration' => $this->duration,
             'has_spoiler' => $this->has_spoiler,
+            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Input/InputMediaPhoto.php
+++ b/src/Telegram/Types/Input/InputMediaPhoto.php
@@ -44,6 +44,11 @@ class InputMediaPhoto extends InputMedia implements JsonSerializable
     public ?array $caption_entities = null;
 
     /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
+
+    /**
      * Optional.
      * Pass True if the photo needs to be covered with a spoiler animation
      */
@@ -51,10 +56,11 @@ class InputMediaPhoto extends InputMedia implements JsonSerializable
 
     public function __construct(
         InputFile|string $media,
-        ?string $caption,
-        ParseMode|string|null $parse_mode,
-        ?array $caption_entities,
-        ?bool $has_spoiler
+        ?string $caption = null,
+        ParseMode|string|null $parse_mode = null,
+        ?array $caption_entities = null,
+        ?bool $has_spoiler = null,
+        ?bool $show_caption_above_media = null,
     ) {
         parent::__construct();
         $this->media = $media;
@@ -62,6 +68,7 @@ class InputMediaPhoto extends InputMedia implements JsonSerializable
         $this->parse_mode = $parse_mode;
         $this->caption_entities = $caption_entities;
         $this->has_spoiler = $has_spoiler;
+        $this->show_caption_above_media = $show_caption_above_media;
     }
 
     public static function make(
@@ -69,14 +76,16 @@ class InputMediaPhoto extends InputMedia implements JsonSerializable
         ?string $caption = null,
         ?ParseMode $parse_mode = null,
         ?array $caption_entities = null,
-        ?bool $has_spoiler = null
+        ?bool $has_spoiler = null,
+        ?bool $show_caption_above_media = null,
     ): self {
         return new self(
             media: $media,
             caption: $caption,
             parse_mode: $parse_mode,
             caption_entities: $caption_entities,
-            has_spoiler: $has_spoiler
+            has_spoiler: $has_spoiler,
+            show_caption_above_media: $show_caption_above_media,
         );
     }
 
@@ -90,6 +99,7 @@ class InputMediaPhoto extends InputMedia implements JsonSerializable
             'parse_mode' => $this->parse_mode?->value,
             'caption_entities' => $this->caption_entities,
             'has_spoiler' => $this->has_spoiler,
+            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Input/InputMediaVideo.php
+++ b/src/Telegram/Types/Input/InputMediaVideo.php
@@ -56,6 +56,11 @@ class InputMediaVideo extends InputMedia implements JsonSerializable
     public ?array $caption_entities = null;
 
     /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
+
+    /**
      * Optional.
      * Video width
      */
@@ -87,15 +92,16 @@ class InputMediaVideo extends InputMedia implements JsonSerializable
 
     public function __construct(
         InputFile|string $media,
-        InputFile|string|null $thumbnail,
-        ?string $caption,
-        ParseMode|string|null $parse_mode,
-        ?array $caption_entities,
-        ?int $width,
-        ?int $height,
-        ?int $duration,
-        ?bool $supports_streaming,
-        ?bool $has_spoiler
+        InputFile|string|null $thumbnail = null,
+        ?string $caption = null,
+        ParseMode|string|null $parse_mode = null,
+        ?array $caption_entities = null,
+        ?int $width = null,
+        ?int $height = null,
+        ?int $duration = null,
+        ?bool $supports_streaming = null,
+        ?bool $has_spoiler = null,
+        ?bool $show_caption_above_media = null,
     ) {
         parent::__construct();
         $this->media = $media;
@@ -108,6 +114,7 @@ class InputMediaVideo extends InputMedia implements JsonSerializable
         $this->duration = $duration;
         $this->supports_streaming = $supports_streaming;
         $this->has_spoiler = $has_spoiler;
+        $this->show_caption_above_media = $show_caption_above_media;
     }
 
     public static function make(
@@ -120,19 +127,21 @@ class InputMediaVideo extends InputMedia implements JsonSerializable
         ?int $height = null,
         ?int $duration = null,
         ?bool $supports_streaming = null,
-        ?bool $has_spoiler = null
+        ?bool $has_spoiler = null,
+        ?bool $show_caption_above_media = null,
     ): self {
         return new self(
-            $media,
-            $thumbnail,
-            $caption,
-            $parse_mode,
-            $caption_entities,
-            $width,
-            $height,
-            $duration,
-            $supports_streaming,
-            $has_spoiler
+            media: $media,
+            thumbnail: $thumbnail,
+            caption: $caption,
+            parse_mode: $parse_mode,
+            caption_entities: $caption_entities,
+            width: $width,
+            height: $height,
+            duration: $duration,
+            supports_streaming: $supports_streaming,
+            has_spoiler: $has_spoiler,
+            show_caption_above_media: $show_caption_above_media,
         );
     }
 
@@ -149,6 +158,7 @@ class InputMediaVideo extends InputMedia implements JsonSerializable
             'duration' => $this->duration,
             'supports_streaming' => $this->supports_streaming,
             'has_spoiler' => $this->has_spoiler,
+            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Keyboard/InlineKeyboardButton.php
+++ b/src/Telegram/Types/Keyboard/InlineKeyboardButton.php
@@ -78,7 +78,9 @@ class InlineKeyboardButton extends BaseType implements JsonSerializable
 
     /**
      * Optional.
-     * Specify True, to send a {@see https://core.telegram.org/bots/api#payments Pay button}.NOTE: This type of button must always be the first button in the first row and can only be used in invoice messages.
+     * Specify True, to send a {@see https://core.telegram.org/bots/api#payments Pay button}.
+     * Substrings “⭐” and “XTR” in the buttons's text will be replaced with a Telegram Star icon.
+     * NOTE: This type of button must always be the first button in the first row and can only be used in invoice messages.
      */
     public ?bool $pay = null;
 

--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -250,6 +250,10 @@ class Message extends BaseType
     public ?LinkPreviewOptions $link_preview_options = null;
 
     /**
+     * Optional. Unique identifier of the message effect added to the message
+     */
+    public ?string $effect_id = null;
+    /**
      * Optional.
      * Message is an animation, information about the animation.
      * For backward compatibility, when this field is set, the document field will also be set
@@ -320,6 +324,11 @@ class Message extends BaseType
      */
     #[ArrayType(MessageEntity::class)]
     public ?array $caption_entities = null;
+
+    /**
+     * Optional. True, if the caption must be shown above the message media
+     */
+    public ?bool $show_caption_above_media = null;
 
     /**
      * Optional.

--- a/src/Telegram/Types/Payment/Invoice.php
+++ b/src/Telegram/Types/Payment/Invoice.php
@@ -19,7 +19,10 @@ class Invoice extends BaseType
     /** Unique bot deep-linking parameter that can be used to generate this invoice */
     public string $start_parameter;
 
-    /** Three-letter ISO 4217 {@see https://core.telegram.org/bots/payments#supported-currencies currency} code */
+    /**
+     * Three-letter ISO 4217 {@see https://core.telegram.org/bots/payments#supported-currencies currency} code,
+     * or “XTR” for payments in {@see https://t.me/BotNews/90 Telegram Stars}.
+     */
     public string $currency;
 
     /**

--- a/src/Telegram/Types/Payment/PreCheckoutQuery.php
+++ b/src/Telegram/Types/Payment/PreCheckoutQuery.php
@@ -17,7 +17,10 @@ class PreCheckoutQuery extends BaseType
     /** User who sent the query */
     public User $from;
 
-    /** Three-letter ISO 4217 {@see https://core.telegram.org/bots/payments#supported-currencies currency} code */
+    /**
+     * Three-letter ISO 4217 {@see https://core.telegram.org/bots/payments#supported-currencies currency} code,
+     * or “XTR” for payments in {@see https://t.me/BotNews/90 Telegram Stars}.
+     */
     public string $currency;
 
     /**

--- a/src/Telegram/Types/Payment/SuccessfulPayment.php
+++ b/src/Telegram/Types/Payment/SuccessfulPayment.php
@@ -10,7 +10,10 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
  */
 class SuccessfulPayment extends BaseType
 {
-    /** Three-letter ISO 4217 {@see https://core.telegram.org/bots/payments#supported-currencies currency} code */
+    /**
+     * Three-letter ISO 4217 {@see https://core.telegram.org/bots/payments#supported-currencies currency} code,
+     * or “XTR” for payments in {@see https://t.me/BotNews/90 Telegram Stars}.
+     */
     public string $currency;
 
     /**


### PR DESCRIPTION
### https://core.telegram.org/bots/api-changelog#may-28-2024

- [x] Updated badge
- [x] Added support for payments in [Telegram Stars](https://t.me/BotNews/90) by introducing the new currency “XTR”.
- [x] The parameter `provider_token` of the methods [sendInvoice](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendinvoice) and [createInvoiceLink](https://core.telegram.org/bots/api#inputinvoicemessagecontent#createinvoicelink) must be omitted for payments in [Telegram Stars](https://t.me/BotNews/90).
- [x] The field `provider_token` in the class [InputInvoiceMessageContent](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inputinvoicemessagecontent) must be omitted for payments in [Telegram Stars](https://t.me/BotNews/90).
- [x] Added the method [refundStarPayment](https://core.telegram.org/bots/api#inputinvoicemessagecontent#refundstarpayment).
- [x] Added the field `effect_id` to the class [Message](https://core.telegram.org/bots/api#inputinvoicemessagecontent#message).
- [x] Added the parameter `message_effect_id` to the methods [sendMessage](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendmessage), [sendPhoto](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendphoto), [sendVideo](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendvideo), [sendAnimation](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendanimation), [sendAudio](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendaudio), [sendDocument](https://core.telegram.org/bots/api#inputinvoicemessagecontent#senddocument), [sendSticker](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendsticker), [sendVideoNote](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendvideonote), [sendVoice](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendvoice), [sendLocation](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendlocation), [sendVenue](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendvenue), [sendContact](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendcontact), [sendPoll](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendpoll), [sendDice](https://core.telegram.org/bots/api#inputinvoicemessagecontent#senddice), [sendInvoice](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendinvoice), [sendGame](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendgame), and [sendMediaGroup](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendmediagroup).
- [x] Added the field `show_caption_above_media` to the classes [Message](https://core.telegram.org/bots/api#inputinvoicemessagecontent#message), [InputMediaAnimation](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inputmediaanimation), [InputMediaPhoto](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inputmediaphoto), [InputMediaVideo](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inputmediavideo), [InlineQueryResultGif](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inlinequeryresultgif), [InlineQueryResultMpeg4Gif](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inlinequeryresultmpeg4gif), [InlineQueryResultPhoto](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inlinequeryresultphoto), [InlineQueryResultVideo](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inlinequeryresultvideo), [InlineQueryResultCachedGif](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inlinequeryresultcachedgif), [InlineQueryResultCachedMpeg4Gif](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inlinequeryresultcachedmpeg4gif), [InlineQueryResultCachedPhoto](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inlinequeryresultcachedphoto), and [InlineQueryResultCachedVideo](https://core.telegram.org/bots/api#inputinvoicemessagecontent#inlinequeryresultcachedvideo).
- [x] Added the parameter `show_caption_above_media` to the methods [sendAnimation](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendanimation), [sendPhoto](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendphoto), [sendVideo](https://core.telegram.org/bots/api#inputinvoicemessagecontent#sendvideo), [copyMessage](https://core.telegram.org/bots/api#inputinvoicemessagecontent#copymessage), and [editMessageCaption](https://core.telegram.org/bots/api#inputinvoicemessagecontent#editmessagecaption).
- [x] Added support for “expandable_blockquote” entities in received messages.
- [x] Added support for “expandable_blockquote” entity parsing in “MarkdownV2” and “HTML” parse modes.
- [x] Allowed to explicitly specify “expandable_blockquote” entities in formatted texts.
