### PR TITLE
Update Bot API to 7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 [![Total Downloads](http://poser.pugx.org/nutgram/nutgram/downloads)](https://packagist.org/packages/nutgram/nutgram)
 ![GitHub](https://img.shields.io/github/license/nutgram/nutgram)
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.4%09--%20May%2028,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.5%09--%20June%2018,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
 
 [![Test Suite](https://github.com/nutgram/nutgram/actions/workflows/php.yml/badge.svg)](https://github.com/nutgram/nutgram/actions/workflows/php.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/86c4ca3dae8f64db80f7/maintainability)](https://codeclimate.com/github/nutgram/nutgram/maintainability)

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -921,52 +921,6 @@ trait AvailableMethods
     }
 
     /**
-     * Use this method to edit live location messages.
-     * A location can be edited until its live_period expires or editing is explicitly disabled by a call to {@see https://core.telegram.org/bots/api#stopmessagelivelocation stopMessageLiveLocation}telegram.org/bots/api#message Message}LiveLocation.
-     * On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
-     * @see https://core.telegram.org/bots/api#editmessagelivelocation
-     * @param float $latitude Latitude of new location
-     * @param float $longitude Longitude of new location
-     * @param int|string|null $chat_id Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
-     * @param int|null $message_id Required if inline_message_id is not specified. Identifier of the message to edit
-     * @param string|null $inline_message_id Required if chat_id and message_id are not specified. Identifier of the inline message
-     * @param float|null $horizontal_accuracy The radius of uncertainty for the location, measured in meters; 0-1500
-     * @param int|null $heading Direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
-     * @param int|null $proximity_alert_radius The maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
-     * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for a new {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}.
-     * @param int|null $live_period New period in seconds during which the location can be updated, starting from the message send date. If 0x7FFFFFFF is specified, then the location can be updated forever. Otherwise, the new value must not exceed the current live_period by more than a day, and the live location expiration date must remain within the next 90 days. If not specified, then live_period remains unchanged
-     * @return Message|bool|null
-     */
-    public function editMessageLiveLocation(
-        float $latitude,
-        float $longitude,
-        int|string|null $chat_id = null,
-        ?int $message_id = null,
-        ?string $inline_message_id = null,
-        ?float $horizontal_accuracy = null,
-        ?int $heading = null,
-        ?int $proximity_alert_radius = null,
-        ?InlineKeyboardMarkup $reply_markup = null,
-        ?int $live_period = null,
-    ): Message|bool|null {
-        $parameters = compact(
-            'chat_id',
-            'message_id',
-            'inline_message_id',
-            'latitude',
-            'longitude',
-            'horizontal_accuracy',
-            'heading',
-            'proximity_alert_radius',
-            'reply_markup',
-            'live_period',
-        );
-
-        $this->setChatMessageOrInlineMessageId($parameters);
-        return $this->requestJson(__FUNCTION__, $parameters, Message::class);
-    }
-
-    /**
      * Use this method to stop updating a live location message before live_period expires.
      * On success, if the message is not an inline message, the edited {@see https://core.telegram.org/bots/api#message Message} is returned, otherwise True is returned.
      * @see https://core.telegram.org/bots/api#stopmessagelivelocation
@@ -974,6 +928,7 @@ trait AvailableMethods
      * @param int|null $message_id Required if inline_message_id is not specified. Identifier of the message with live location to stop
      * @param string|null $inline_message_id Required if chat_id and message_id are not specified. Identifier of the inline message
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for a new {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}.
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message to be edited was sent
      * @return Message|bool|null
      */
     public function stopMessageLiveLocation(
@@ -981,12 +936,14 @@ trait AvailableMethods
         ?int $message_id = null,
         ?string $inline_message_id = null,
         ?InlineKeyboardMarkup $reply_markup = null,
+        ?string $business_connection_id = null,
     ): Message|bool|null {
         $parameters = compact(
             'chat_id',
             'message_id',
             'inline_message_id',
-            'reply_markup'
+            'reply_markup',
+            'business_connection_id',
         );
 
         $this->setChatMessageOrInlineMessageId($parameters);

--- a/src/Telegram/Endpoints/Payments.php
+++ b/src/Telegram/Endpoints/Payments.php
@@ -8,6 +8,7 @@ use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\Message\ReplyParameters;
 use SergiX44\Nutgram\Telegram\Types\Payment\LabeledPrice;
 use SergiX44\Nutgram\Telegram\Types\Payment\ShippingOption;
+use SergiX44\Nutgram\Telegram\Types\Payment\StarTransactions;
 
 /**
  * Trait Payments
@@ -238,6 +239,20 @@ trait Payments
         $parameters = compact('pre_checkout_query_id', 'ok', 'error_message');
 
         return $this->requestJson(__FUNCTION__, $parameters);
+    }
+
+    /**
+     * Returns the bot's Telegram Star transactions in chronological order.
+     * On success, returns a {@see https://core.telegram.org/bots/api#startransactions StarTransactions} object.
+     * @param int|null $offset Number of transactions to skip in the response
+     * @param int|null $limit The maximum number of transactions to be retrieved. Values between 1-100 are accepted. Defaults to 100.
+     * @return StarTransactions[]|null
+     */
+    public function getStarTransactions(?int $offset = null, ?int $limit = null): ?array
+    {
+        $parameters = compact('offset', 'limit');
+
+        return $this->requestJson(__FUNCTION__, $parameters, StarTransactions::class);
     }
 
     /**

--- a/src/Telegram/Endpoints/UpdatesMessages.php
+++ b/src/Telegram/Endpoints/UpdatesMessages.php
@@ -31,6 +31,7 @@ trait UpdatesMessages
      * @param bool|null $disable_web_page_preview Disables link previews for links in this message
      * @param LinkPreviewOptions|null $link_preview_options Link preview generation options for the message
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}.
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message to be edited was sent
      * @return Message|bool|null
      */
     public function editMessageText(
@@ -43,6 +44,7 @@ trait UpdatesMessages
         ?bool $disable_web_page_preview = null,
         ?LinkPreviewOptions $link_preview_options = null,
         ?InlineKeyboardMarkup $reply_markup = null,
+        ?string $business_connection_id = null,
     ): Message|bool|null {
         $parameters = compact(
             'chat_id',
@@ -53,7 +55,8 @@ trait UpdatesMessages
             'entities',
             'disable_web_page_preview',
             'link_preview_options',
-            'reply_markup'
+            'reply_markup',
+            'business_connection_id',
         );
         $this->setChatMessageOrInlineMessageId($parameters);
 
@@ -72,6 +75,7 @@ trait UpdatesMessages
      * @param MessageEntity[]|null $caption_entities A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}.
      * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message to be edited was sent
      * @return Message|bool|null
      */
     public function editMessageCaption(
@@ -83,6 +87,7 @@ trait UpdatesMessages
         ?array $caption_entities = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?bool $show_caption_above_media = null,
+        ?string $business_connection_id = null,
     ): Message|bool|null {
         $parameters = compact(
             'chat_id',
@@ -93,6 +98,7 @@ trait UpdatesMessages
             'caption_entities',
             'reply_markup',
             'show_caption_above_media',
+            'business_connection_id',
         );
         $this->setChatMessageOrInlineMessageId($parameters);
 
@@ -112,6 +118,7 @@ trait UpdatesMessages
      * @param string|null $inline_message_id Required if chat_id and message_id are not specified. Identifier of the inline message
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for a new {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}.
      * @param array $clientOpt Client options
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message to be edited was sent
      * @return Message|bool|null
      */
     public function editMessageMedia(
@@ -120,6 +127,7 @@ trait UpdatesMessages
         ?int $message_id = null,
         ?string $inline_message_id = null,
         ?InlineKeyboardMarkup $reply_markup = null,
+        ?string $business_connection_id = null,
         array $clientOpt = [],
     ): Message|bool|null {
         $parameters = compact(
@@ -128,11 +136,60 @@ trait UpdatesMessages
             'inline_message_id',
             'media',
             'reply_markup',
-            'clientOpt'
+            'business_connection_id',
         );
         $this->setChatMessageOrInlineMessageId($parameters);
 
         return $this->requestMultipart(__FUNCTION__, $parameters, Message::class, $clientOpt);
+    }
+
+    /**
+     * Use this method to edit live location messages.
+     * A location can be edited until its live_period expires or editing is explicitly disabled by a call to {@see https://core.telegram.org/bots/api#stopmessagelivelocation stopMessageLiveLocation}telegram.org/bots/api#message Message}LiveLocation.
+     * On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
+     * @see https://core.telegram.org/bots/api#editmessagelivelocation
+     * @param float $latitude Latitude of new location
+     * @param float $longitude Longitude of new location
+     * @param int|string|null $chat_id Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
+     * @param int|null $message_id Required if inline_message_id is not specified. Identifier of the message to edit
+     * @param string|null $inline_message_id Required if chat_id and message_id are not specified. Identifier of the inline message
+     * @param float|null $horizontal_accuracy The radius of uncertainty for the location, measured in meters; 0-1500
+     * @param int|null $heading Direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
+     * @param int|null $proximity_alert_radius The maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
+     * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for a new {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}.
+     * @param int|null $live_period New period in seconds during which the location can be updated, starting from the message send date. If 0x7FFFFFFF is specified, then the location can be updated forever. Otherwise, the new value must not exceed the current live_period by more than a day, and the live location expiration date must remain within the next 90 days. If not specified, then live_period remains unchanged
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message to be edited was sent
+     * @return Message|bool|null
+     */
+    public function editMessageLiveLocation(
+        float $latitude,
+        float $longitude,
+        int|string|null $chat_id = null,
+        ?int $message_id = null,
+        ?string $inline_message_id = null,
+        ?float $horizontal_accuracy = null,
+        ?int $heading = null,
+        ?int $proximity_alert_radius = null,
+        ?InlineKeyboardMarkup $reply_markup = null,
+        ?int $live_period = null,
+        ?string $business_connection_id = null,
+    ): Message|bool|null {
+        $parameters = compact(
+            'chat_id',
+            'message_id',
+            'inline_message_id',
+            'latitude',
+            'longitude',
+            'horizontal_accuracy',
+            'heading',
+            'proximity_alert_radius',
+            'reply_markup',
+            'live_period',
+            'business_connection_id',
+        );
+
+        $this->setChatMessageOrInlineMessageId($parameters);
+        return $this->requestJson(__FUNCTION__, $parameters, Message::class);
     }
 
     /**
@@ -143,6 +200,7 @@ trait UpdatesMessages
      * @param int|null $message_id Required if inline_message_id is not specified. Identifier of the message to edit
      * @param string|null $inline_message_id Required if chat_id and message_id are not specified. Identifier of the inline message
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}.
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message to be edited was sent
      * @return Message|bool|null
      */
     public function editMessageReplyMarkup(
@@ -150,12 +208,14 @@ trait UpdatesMessages
         ?int $message_id = null,
         ?string $inline_message_id = null,
         ?InlineKeyboardMarkup $reply_markup = null,
+        ?string $business_connection_id = null,
     ): Message|bool|null {
         $parameters = compact(
             'chat_id',
             'message_id',
             'inline_message_id',
-            'reply_markup'
+            'reply_markup',
+            'business_connection_id',
         );
         $this->setChatMessageOrInlineMessageId($parameters);
 
@@ -169,11 +229,23 @@ trait UpdatesMessages
      * @param int|string $chat_id Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
      * @param int $message_id Identifier of the original message with the poll
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for a new message {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}.
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message to be edited was sent
      * @return Poll|null
      */
-    public function stopPoll(int|string $chat_id, int $message_id, ?InlineKeyboardMarkup $reply_markup = null): ?Poll
+    public function stopPoll(
+        int|string $chat_id,
+        int $message_id,
+        ?InlineKeyboardMarkup $reply_markup = null,
+        ?string $business_connection_id = null,
+    ): ?Poll
     {
-        $parameters = compact('chat_id', 'message_id', 'reply_markup');
+        $parameters = compact(
+            'chat_id',
+            'message_id',
+            'reply_markup',
+            'business_connection_id',
+        );
+
         return $this->requestJson(__FUNCTION__, $parameters, Poll::class);
     }
 

--- a/src/Telegram/Properties/RevenueWithdrawalStateType.php
+++ b/src/Telegram/Properties/RevenueWithdrawalStateType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum RevenueWithdrawalStateType: string
+{
+    case PENDING = 'pending';
+    Case SUCCEEDED = 'succeeded';
+    case FAILED = 'failed';
+}

--- a/src/Telegram/Properties/TransactionPartnerType.php
+++ b/src/Telegram/Properties/TransactionPartnerType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum TransactionPartnerType: string
+{
+    case FRAGMENT = 'fragment';
+    case USER = 'user';
+    case OTHER = 'other';
+}

--- a/src/Telegram/Types/Payment/RevenueWithdrawalState.php
+++ b/src/Telegram/Types/Payment/RevenueWithdrawalState.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RevenueWithdrawalStateType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object describes the state of a revenue withdrawal operation.
+ * Currently, it can be one of
+ * - {@see RevenueWithdrawalStatePending}
+ * - {@see RevenueWithdrawalStateSucceeded}
+ * - {@see RevenueWithdrawalStateFailed}
+ * @see https://core.telegram.org/bots/api#revenuewithdrawalstate
+ */
+#[RevenueWithdrawalStateResolver]
+abstract class RevenueWithdrawalState extends BaseType
+{
+    /**
+     * Type of the state, can be “pending”, “succeeded” or “failed”.
+     */
+    #[EnumOrScalar]
+    public RevenueWithdrawalStateType|string $type;
+}

--- a/src/Telegram/Types/Payment/RevenueWithdrawalStateFailed.php
+++ b/src/Telegram/Types/Payment/RevenueWithdrawalStateFailed.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RevenueWithdrawalStateType;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+
+/**
+ * The withdrawal failed and the transaction was refunded.
+ * @see https://core.telegram.org/bots/api#revenuewithdrawalstatefailed
+ */
+class RevenueWithdrawalStateFailed extends RevenueWithdrawalState
+{
+    /**
+     * Type of the state, always “failed”
+     */
+    #[EnumOrScalar]
+    public RevenueWithdrawalStateType|string $type = RevenueWithdrawalStateType::FAILED;
+}

--- a/src/Telegram/Types/Payment/RevenueWithdrawalStatePending.php
+++ b/src/Telegram/Types/Payment/RevenueWithdrawalStatePending.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RevenueWithdrawalStateType;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+
+/**
+ * The withdrawal is in progress.
+ * @see https://core.telegram.org/bots/api#revenuewithdrawalstatepending
+ */
+class RevenueWithdrawalStatePending extends RevenueWithdrawalState
+{
+    /**
+     * Type of the state, always “pending”
+     */
+    #[EnumOrScalar]
+    public RevenueWithdrawalStateType|string $type = RevenueWithdrawalStateType::PENDING;
+}

--- a/src/Telegram/Types/Payment/RevenueWithdrawalStateResolver.php
+++ b/src/Telegram/Types/Payment/RevenueWithdrawalStateResolver.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use Attribute;
+use InvalidArgumentException;
+use SergiX44\Hydrator\Annotation\ConcreteResolver;
+use SergiX44\Nutgram\Telegram\Properties\RevenueWithdrawalStateType;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class RevenueWithdrawalStateResolver extends ConcreteResolver
+{
+
+    public function concreteFor(array $data): ?string
+    {
+        $type = $data['type'] ?? throw new InvalidArgumentException('Type must be defined');
+
+        return match ($type) {
+            RevenueWithdrawalStateType::PENDING->value => RevenueWithdrawalStatePending::class,
+            RevenueWithdrawalStateType::SUCCEEDED->value => RevenueWithdrawalStateSucceeded::class,
+            RevenueWithdrawalStateType::FAILED->value => RevenueWithdrawalStateFailed::class,
+            default => (new class extends RevenueWithdrawalState {
+            })::class,
+        };
+    }
+}

--- a/src/Telegram/Types/Payment/RevenueWithdrawalStateSucceeded.php
+++ b/src/Telegram/Types/Payment/RevenueWithdrawalStateSucceeded.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RevenueWithdrawalStateType;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+
+/**
+ * The withdrawal succeeded.
+ * @see https://core.telegram.org/bots/api#revenuewithdrawalstatesucceeded
+ */
+class RevenueWithdrawalStateSucceeded extends RevenueWithdrawalState
+{
+    /**
+     * Type of the state, always “succeeded”
+     */
+    #[EnumOrScalar]
+    public RevenueWithdrawalStateType|string $type = RevenueWithdrawalStateType::SUCCEEDED;
+
+    /**
+     * Date the withdrawal was completed in Unix time
+     */
+    public int $date;
+
+    /**
+     * An HTTPS URL that can be used to see transaction details
+     */
+    public string $url;
+}

--- a/src/Telegram/Types/Payment/StarTransaction.php
+++ b/src/Telegram/Types/Payment/StarTransaction.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use JsonSerializable;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use function SergiX44\Nutgram\Support\array_filter_null;
+
+/**
+ * Describes a Telegram Star transaction.
+ * @see https://core.telegram.org/bots/api#startransaction
+ */
+class StarTransaction extends BaseType implements JsonSerializable
+{
+    /**
+     * Unique identifier of the transaction.
+     * Coincides with the identifer of the original transaction for refund transactions.
+     * Coincides with SuccessfulPayment.telegram_payment_charge_id for successful incoming payments from users.
+     */
+    public string $id;
+
+    /**
+     * Number of Telegram Stars transferred by the transaction
+     */
+    public int $amount;
+
+    /**
+     * Date the transaction was created in Unix time
+     */
+    public int $date;
+
+    /**
+     * Optional.
+     * Source of an incoming transaction (e.g., a user purchasing goods or services, Fragment refunding a failed withdrawal).
+     * Only for incoming transactions
+     */
+    public ?TransactionPartner $source = null;
+
+    /**
+     * Optional.
+     * Receiver of an outgoing transaction (e.g., a user for a purchase refund, Fragment for a withdrawal).
+     * Only for outgoing transactions
+     */
+    public ?TransactionPartner $receiver = null;
+
+    public function jsonSerialize(): array
+    {
+        return array_filter_null([
+            'id' => $this->id,
+            'amount' => $this->amount,
+            'date' => $this->date,
+            'source' => $this->source,
+            'receiver' => $this->receiver,
+        ]);
+    }
+}

--- a/src/Telegram/Types/Payment/StarTransactions.php
+++ b/src/Telegram/Types/Payment/StarTransactions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * Contains a list of Telegram Star transactions.
+ * @see https://core.telegram.org/bots/api#startransactions
+ */
+class StarTransactions extends BaseType
+{
+    /**
+     * The list of transactions
+     * @var StarTransaction[] $transactions
+     */
+    #[ArrayType(StarTransaction::class)]
+    public array $transactions;
+}

--- a/src/Telegram/Types/Payment/TransactionPartner.php
+++ b/src/Telegram/Types/Payment/TransactionPartner.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object describes the source of a transaction, or its recipient for outgoing transactions.
+ * Currently, it can be one of:
+ * - {@see TransactionPartnerFragment}
+ * - {@see TransactionPartnerUser}
+ * - {@see TransactionPartnerOther}
+ * @see https://core.telegram.org/bots/api#transactionpartner
+ */
+#[TransactionPartnerResolver]
+abstract class TransactionPartner extends BaseType
+{
+    /**
+     * Type of the transaction partner, can be “fragment”, “user” or “other”.
+     */
+    #[EnumOrScalar]
+    public TransactionPartnerType|string $type;
+}

--- a/src/Telegram/Types/Payment/TransactionPartnerFragment.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerFragment.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+use function SergiX44\Nutgram\Support\array_filter_null;
+
+/**
+ * Describes a withdrawal transaction with Fragment.
+ * @see https://core.telegram.org/bots/api#transactionpartnerfragment
+ */
+class TransactionPartnerFragment extends TransactionPartner implements JsonSerializable
+{
+    /**
+     * Type of the transaction partner, always “fragment”
+     */
+    #[EnumOrScalar]
+    public TransactionPartnerType|string $type = TransactionPartnerType::FRAGMENT;
+
+    /**
+     * Optional. State of the transaction if the transaction is outgoing
+     */
+    public ?RevenueWithdrawalState $withdrawal_state = null;
+
+    public function jsonSerialize(): array
+    {
+        return array_filter_null([
+            'type' => $this->type->value,
+            'withdrawal_state' => $this->withdrawal_state,
+        ]);
+    }
+}

--- a/src/Telegram/Types/Payment/TransactionPartnerOther.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerOther.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+
+/**
+ * Describes a transaction with an unknown source or recipient.
+ * @see https://core.telegram.org/bots/api#transactionpartnerother
+ */
+class TransactionPartnerOther extends TransactionPartner
+{
+    /**
+     * Type of the transaction partner, always “other”
+     */
+    #[EnumOrScalar]
+    public TransactionPartnerType|string $type = TransactionPartnerType::OTHER;
+}

--- a/src/Telegram/Types/Payment/TransactionPartnerResolver.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerResolver.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use Attribute;
+use InvalidArgumentException;
+use SergiX44\Hydrator\Annotation\ConcreteResolver;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class TransactionPartnerResolver extends ConcreteResolver
+{
+
+    public function concreteFor(array $data): ?string
+    {
+        $type = $data['type'] ?? throw new InvalidArgumentException('Type must be defined');
+
+        return match ($type) {
+            TransactionPartnerType::FRAGMENT->value => TransactionPartnerFragment::class,
+            TransactionPartnerType::USER->value => TransactionPartnerUser::class,
+            TransactionPartnerType::OTHER->value => TransactionPartnerOther::class,
+            default => (new class extends TransactionPartner {
+            })::class,
+        };
+    }
+}

--- a/src/Telegram/Types/Payment/TransactionPartnerUser.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerUser.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+use SergiX44\Nutgram\Telegram\Types\User\User;
+
+/**
+ * Describes a transaction with a user.
+ * @see https://core.telegram.org/bots/api#transactionpartneruser
+ */
+class TransactionPartnerUser extends TransactionPartner
+{
+    /**
+     * Type of the transaction partner, always “user”
+     */
+    #[EnumOrScalar]
+    public TransactionPartnerType|string $type = TransactionPartnerType::USER;
+
+    /**
+     * Information about the user
+     */
+    public User $user;
+}


### PR DESCRIPTION
## https://core.telegram.org/bots/api-changelog#june-18-2024

### Tasks
- [x] Update badge
- [x]  Added the classes [StarTransactions](https://core.telegram.org/bots/api#startransactions), [StarTransaction](https://core.telegram.org/bots/api#startransaction), [TransactionPartner](https://core.telegram.org/bots/api#transactionpartner) and [RevenueWithdrawalState](https://core.telegram.org/bots/api#revenuewithdrawalstate), containing information about Telegram Star transactions involving the bot.
- [x]   Added the method [getStarTransactions](https://core.telegram.org/bots/api#getstartransactions) that can be used to get the list of all Telegram Star transactions for the bot.
- [x]   Added support for _callback_ buttons in [InlineKeyboardMarkup](https://core.telegram.org/bots/api#inlinekeyboardmarkup) for messages sent on behalf of a business account.
- [x]   Added support for callback queries originating from a message sent on behalf of a business account.
- [x]   Added the parameter _business\_connection\_id_ to the methods [editMessageText](https://core.telegram.org/bots/api#editmessagetext), [editMessageMedia](https://core.telegram.org/bots/api#editmessagemedia), [editMessageCaption](https://core.telegram.org/bots/api#editmessagecaption), [editMessageLiveLocation](https://core.telegram.org/bots/api#editmessagelivelocation), [stopMessageLiveLocation](https://core.telegram.org/bots/api#stopmessagelivelocation) and [editMessageReplyMarkup](https://core.telegram.org/bots/api#editmessagereplymarkup), allowing the bot to edit business messages.
- [x]   Added the parameter _business\_connection\_id_ to the method [stopPoll](https://core.telegram.org/bots/api#stoppoll), allowing the bot to stop polls it sent on behalf of a business account.