### PR TITLE
Update to Bot API 7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 [![Total Downloads](http://poser.pugx.org/nutgram/nutgram/downloads)](https://packagist.org/packages/nutgram/nutgram)
 ![GitHub](https://img.shields.io/github/license/nutgram/nutgram)
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.5%09--%20June%2018,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.6%09--%20July%2001,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
 
 [![Test Suite](https://github.com/nutgram/nutgram/actions/workflows/php.yml/badge.svg)](https://github.com/nutgram/nutgram/actions/workflows/php.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/86c4ca3dae8f64db80f7/maintainability)](https://codeclimate.com/github/nutgram/nutgram/maintainability)

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -26,6 +26,7 @@ use SergiX44\Nutgram\Telegram\Types\Input\InputMediaAudio;
 use SergiX44\Nutgram\Telegram\Types\Input\InputMediaDocument;
 use SergiX44\Nutgram\Telegram\Types\Input\InputMediaPhoto;
 use SergiX44\Nutgram\Telegram\Types\Input\InputMediaVideo;
+use SergiX44\Nutgram\Telegram\Types\Input\InputPaidMedia;
 use SergiX44\Nutgram\Telegram\Types\Internal\InputFile;
 use SergiX44\Nutgram\Telegram\Types\Internal\UploadableArray;
 use SergiX44\Nutgram\Telegram\Types\Keyboard\ForceReply;
@@ -219,7 +220,7 @@ trait AvailableMethods
 
     /**
      * Use this method to copy messages of any kind.
-     * Service messages and invoice messages can't be copied.
+     * Service messages, paid media messages, giveaway messages, giveaway winners messages, and invoice messages can't be copied.
      * A quiz {@see https://core.telegram.org/bots/api#poll poll} can be copied only if the value of the field correct_option_id is known to the bot.
      * The method is analogous to the method {@see https://core.telegram.org/bots/api#forwardmessage forwardMessage}, but the copied message doesn't have a link to the original message.
      * Returns the {@see https://core.telegram.org/bots/api#messageid MessageId} of the sent message on success.
@@ -277,7 +278,7 @@ trait AvailableMethods
     /**
      * Use this method to copy messages of any kind.
      * If some of the specified messages can't be found or copied, they are skipped.
-     * Service messages, giveaway messages, giveaway winners messages, and invoice messages can't be copied.
+     * Service messages, paid media messages, giveaway messages, giveaway winners messages, and invoice messages can't be copied.
      * A quiz {@see https://core.telegram.org/bots/api#poll poll} can be copied only if the value of the field correct_option_id is known to the bot.
      * The method is analogous to the method {@see https://core.telegram.org/bots/api#forwardmessages forwardMessages}, but the copied messages don't have a link to the original message.
      * Album grouping is kept for copied messages.
@@ -803,6 +804,56 @@ trait AvailableMethods
         );
 
         return $this->sendAttachment(__FUNCTION__, 'video_note', $video_note, $opt, $clientOpt);
+    }
+
+    /**
+     * Use this method to send paid media to channel chats.
+     * On success, the sent {@see https://core.telegram.org/bots/api#message Message} is returned.
+     * @see https://core.telegram.org/bots/api#sendpaidmedia
+     * @param int $star_count The number of Telegram Stars that must be paid to buy access to the media
+     * @param InputPaidMedia[] $media A JSON-serialized array describing the media to be sent; up to 10 items
+     * @param int|string|null $chat_id Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
+     * @param string|null $caption Media caption, 0-1024 characters after entities parsing
+     * @param ParseMode|string|null $parse_mode Mode for parsing entities in the voice message caption. See {@see https://core.telegram.org/bots/api#formatting-options formatting options} for more details.
+     * @param array|null $caption_entities A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+     * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
+     * @param bool|null $disable_notification Sends the message {@see https://telegram.org/blog/channels-2-0#silent-messages silently}. Users will receive a notification with no sound.
+     * @param bool|null $protect_content Protects the contents of the sent message from forwarding and saving
+     * @param ReplyParameters|null $reply_parameters Description of the message to reply to
+     * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
+     * @param array $clientOpt Client options
+     * @return Message|null
+     */
+    public function sendPaidMedia(
+        int $star_count,
+        array $media,
+        int|string|null $chat_id = null,
+        ?string $caption = null,
+        ParseMode|string|null $parse_mode = null,
+        ?array $caption_entities = null,
+        ?bool $show_caption_above_media = null,
+        ?bool $disable_notification = null,
+        ?bool $protect_content = null,
+        ?ReplyParameters $reply_parameters = null,
+        InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
+        array $clientOpt = [],
+    ): ?Message
+    {
+        $chat_id ??= $this->chatId();
+        $opt = compact(
+            'star_count',
+            'chat_id',
+            'caption',
+            'parse_mode',
+            'caption_entities',
+            'show_caption_above_media',
+            'disable_notification',
+            'protect_content',
+            'reply_parameters',
+            'reply_markup',
+        );
+
+        return $this->sendAttachment(__FUNCTION__, 'media', $media, $opt, $clientOpt);
     }
 
     /**

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -839,7 +839,7 @@ trait AvailableMethods
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
-        $opt = compact(
+        $params = compact(
             'star_count',
             'chat_id',
             'caption',
@@ -852,7 +852,10 @@ trait AvailableMethods
             'reply_markup',
         );
 
-        return $this->sendAttachment(__FUNCTION__, 'media', $media, $opt, $clientOpt);
+        return $this->requestMultipart(__FUNCTION__, [
+            'media' => new UploadableArray($media),
+            ...$params,
+        ], Message::class, $clientOpt);
     }
 
     /**

--- a/src/Telegram/Properties/InputPaidMediaType.php
+++ b/src/Telegram/Properties/InputPaidMediaType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum InputPaidMediaType: string
+{
+    case PHOTO = 'photo';
+    case VIDEO = 'video';
+}

--- a/src/Telegram/Properties/PaidMediaType.php
+++ b/src/Telegram/Properties/PaidMediaType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum PaidMediaType: string
+{
+    case PREVIEW = 'preview';
+    case PHOTO = 'photo';
+    case VIDEO = 'video';
+}

--- a/src/Telegram/Properties/TransactionPartnerType.php
+++ b/src/Telegram/Properties/TransactionPartnerType.php
@@ -6,5 +6,6 @@ enum TransactionPartnerType: string
 {
     case FRAGMENT = 'fragment';
     case USER = 'user';
+    case TELEGRAM_ADS = 'telegram_ads';
     case OTHER = 'other';
 }

--- a/src/Telegram/Types/Chat/Chat.php
+++ b/src/Telegram/Types/Chat/Chat.php
@@ -247,6 +247,13 @@ class Chat extends BaseType
 
     /**
      * Optional.
+     * True, if paid media messages can be sent or forwarded to the channel chat.
+     * The field is available only for channel chats.
+     */
+    public ?bool $can_send_paid_media = null;
+
+    /**
+     * Optional.
      * For supergroups, the minimum allowed delay between consecutive messages sent by each unpriviledged user;
      * in seconds.
      * Returned only in {@see https://core.telegram.org/bots/api#getchat getChat}.
@@ -365,6 +372,7 @@ class Chat extends BaseType
         ?bool $can_set_sticker_set = null,
         ?int $linked_chat_id = null,
         ?ChatLocation $location = null,
+        ?bool $can_send_paid_media = null,
     ): Chat {
         $chat = new self();
         $chat->id = $id;
@@ -395,6 +403,7 @@ class Chat extends BaseType
         $chat->can_set_sticker_set = $can_set_sticker_set;
         $chat->linked_chat_id = $linked_chat_id;
         $chat->location = $location;
+        $chat->can_send_paid_media = $can_send_paid_media;
         return $chat;
     }
 

--- a/src/Telegram/Types/Input/InputPaidMedia.php
+++ b/src/Telegram/Types/Input/InputPaidMedia.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace SergiX44\Nutgram\Telegram\Types\Input;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputPaidMediaType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Internal\InputFile;
+use SergiX44\Nutgram\Telegram\Types\Internal\Uploadable;
+
+/**
+ * This object describes the paid media to be sent. Currently, it can be one of
+ * - {@see InputPaidMediaPhoto}
+ * - {@see InputPaidMediaVideo}
+ */
+abstract class InputPaidMedia extends BaseType implements Uploadable
+{
+    /**
+     * Type of the media
+     */
+    #[EnumOrScalar]
+    public InputPaidMediaType|string $type;
+
+    /**
+     * File to send.
+     * Pass a file_id to send a file that exists on the Telegram servers (recommended),
+     * pass an HTTP URL for Telegram to get a file from the Internet,
+     * or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.
+     * {@see https://core.telegram.org/bots/api#sending-files More information on Sending Files »}
+     */
+    public InputFile|string $media;
+
+    public function isLocal(): bool
+    {
+        return $this->media instanceof InputFile;
+    }
+
+    public function getResource()
+    {
+        return $this->media->getResource();
+    }
+
+    public function getFilename(): string
+    {
+        return $this->media->getFilename();
+    }
+}

--- a/src/Telegram/Types/Input/InputPaidMediaPhoto.php
+++ b/src/Telegram/Types/Input/InputPaidMediaPhoto.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Input;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputPaidMediaType;
+use SergiX44\Nutgram\Telegram\Types\Internal\InputFile;
+use function SergiX44\Nutgram\Support\array_filter_null;
+
+/**
+ * The paid media to send is a photo.
+ * @see https://core.telegram.org/bots/api#inputpaidmediaphoto
+ */
+class InputPaidMediaPhoto extends InputPaidMedia implements JsonSerializable
+{
+    /**
+     * Type of the media, must be photo
+     */
+    #[EnumOrScalar]
+    public InputPaidMediaType|string $type = InputPaidMediaType::PHOTO;
+
+
+    public function __construct(
+        InputFile|string $media,
+    ) {
+        parent::__construct();
+        $this->media = $media;
+    }
+
+    public static function make(
+        InputFile|string $media,
+    ): self {
+        return new self(
+            media: $media,
+        );
+    }
+
+
+    public function jsonSerialize(): array
+    {
+        return array_filter_null([
+            'type' => $this->type->value,
+            'media' => $this->media,
+        ]);
+    }
+}

--- a/src/Telegram/Types/Input/InputPaidMediaVideo.php
+++ b/src/Telegram/Types/Input/InputPaidMediaVideo.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Input;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputPaidMediaType;
+use SergiX44\Nutgram\Telegram\Properties\ParseMode;
+use SergiX44\Nutgram\Telegram\Types\Internal\InputFile;
+use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
+use function SergiX44\Nutgram\Support\array_filter_null;
+
+/**
+ * The paid media to send is a video.
+ * @see https://core.telegram.org/bots/api#inputpaidmediavideo
+ */
+class InputPaidMediaVideo extends InputPaidMedia implements JsonSerializable
+{
+    /**
+     * Type of the media, must be video
+     */
+    #[EnumOrScalar]
+    public InputPaidMediaType|string $type = InputPaidMediaType::VIDEO;
+
+    /**
+     * Optional.
+     * Thumbnail of the file sent;
+     * can be ignored if thumbnail generation for the file is supported server-side.
+     * The thumbnail should be in JPEG format and less than 200 kB in size.
+     * A thumbnail's width and height should not exceed 320.
+     * Ignored if the file is not uploaded using multipart/form-data.
+     * Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>.
+     * {@see https://core.telegram.org/bots/api#sending-files More information on Sending Files »}
+     */
+    public InputFile|string|null $thumbnail = null;
+
+    /**
+     * Optional.
+     * Video width
+     */
+    public ?int $width = null;
+
+    /**
+     * Optional.
+     * Video height
+     */
+    public ?int $height = null;
+
+    /**
+     * Optional.
+     * Video duration in seconds
+     */
+    public ?int $duration = null;
+
+    /**
+     * Optional.
+     * Pass True if the uploaded video is suitable for streaming
+     */
+    public ?bool $supports_streaming = null;
+
+    public function __construct(
+        InputFile|string $media,
+        InputFile|string|null $thumbnail = null,
+        ?int $width = null,
+        ?int $height = null,
+        ?int $duration = null,
+        ?bool $supports_streaming = null,
+    ) {
+        parent::__construct();
+        $this->media = $media;
+        $this->thumbnail = $thumbnail;
+        $this->width = $width;
+        $this->height = $height;
+        $this->duration = $duration;
+        $this->supports_streaming = $supports_streaming;
+    }
+
+    public static function make(
+        InputFile|string $media,
+        InputFile|string|null $thumbnail = null,
+        ?int $width = null,
+        ?int $height = null,
+        ?int $duration = null,
+        ?bool $supports_streaming = null,
+    ): self {
+        return new self(
+            media: $media,
+            thumbnail: $thumbnail,
+            width: $width,
+            height: $height,
+            duration: $duration,
+            supports_streaming: $supports_streaming,
+        );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return array_filter_null([
+            'type' => $this->type,
+            'media' => $this->media,
+            'width' => $this->width,
+            'height' => $this->height,
+            'duration' => $this->duration,
+            'supports_streaming' => $this->supports_streaming,
+        ]);
+    }
+}

--- a/src/Telegram/Types/Keyboard/ExternalReplyInfo.php
+++ b/src/Telegram/Types/Keyboard/ExternalReplyInfo.php
@@ -23,6 +23,7 @@ use SergiX44\Nutgram\Telegram\Types\Media\Voice;
 use SergiX44\Nutgram\Telegram\Types\Message\LinkPreviewOptions;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageOrigin;
 use SergiX44\Nutgram\Telegram\Types\Payment\Invoice;
+use SergiX44\Nutgram\Telegram\Types\Payment\PaidMediaInfo;
 use SergiX44\Nutgram\Telegram\Types\Poll\Poll;
 use SergiX44\Nutgram\Telegram\Types\Sticker\Sticker;
 
@@ -73,6 +74,11 @@ class ExternalReplyInfo extends BaseType
      * @var Document|null
      */
     public ?Document $document = null;
+
+    /**
+     * Optional. Message contains paid media; information about the paid media
+     */
+    public ?PaidMediaInfo $paid_media = null;
 
     /**
      * Optional. Message is a photo, available sizes of the photo

--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -40,6 +40,7 @@ use SergiX44\Nutgram\Telegram\Types\Media\VideoNote;
 use SergiX44\Nutgram\Telegram\Types\Media\Voice;
 use SergiX44\Nutgram\Telegram\Types\Passport\PassportData;
 use SergiX44\Nutgram\Telegram\Types\Payment\Invoice;
+use SergiX44\Nutgram\Telegram\Types\Payment\PaidMediaInfo;
 use SergiX44\Nutgram\Telegram\Types\Payment\SuccessfulPayment;
 use SergiX44\Nutgram\Telegram\Types\Poll\Poll;
 use SergiX44\Nutgram\Telegram\Types\Reaction\ReactionType;
@@ -271,6 +272,11 @@ class Message extends BaseType
      * Message is a general file, information about the file
      */
     public ?Document $document = null;
+
+    /**
+     * Optional. Message contains paid media; information about the paid media
+     */
+    public ?PaidMediaInfo $paid_media = null;
 
     /**
      * Optional.

--- a/src/Telegram/Types/Payment/PaidMedia.php
+++ b/src/Telegram/Types/Payment/PaidMedia.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\PaidMediaType;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object describes paid media. Currently, it can be one of:
+ * - {@see PaidMediaPreview}
+ * - {@see PaidMediaPhoto}
+ * - {@see PaidMediaVideo}
+ * @see https://core.telegram.org/bots/api#paidmedia
+ */
+#[PaidMediaResolver]
+abstract class PaidMedia extends BaseType
+{
+    /**
+     * Type of the transaction partner, can be “preview”, “photo”, or “video”.
+     */
+    #[EnumOrScalar]
+    public PaidMediaType|string $type;
+}

--- a/src/Telegram/Types/Payment/PaidMediaInfo.php
+++ b/src/Telegram/Types/Payment/PaidMediaInfo.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * Describes the paid media added to a message.
+ * @see https://core.telegram.org/bots/api#paidmediainfo
+ */
+class PaidMediaInfo extends BaseType
+{
+    /**
+     * The number of Telegram Stars that must be paid to buy access to the media
+     */
+    public int $star_count;
+
+    /**
+     * Information about the paid media
+     */
+    #[ArrayType(PaidMedia::class)]
+    public array $paid_media;
+}

--- a/src/Telegram/Types/Payment/PaidMediaPhoto.php
+++ b/src/Telegram/Types/Payment/PaidMediaPhoto.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\PaidMediaType;
+use SergiX44\Nutgram\Telegram\Types\Media\PhotoSize;
+
+/**
+ * The paid media is a photo.
+ * @see https://core.telegram.org/bots/api#paidmediaphoto
+ */
+class PaidMediaPhoto extends PaidMedia
+{
+    /**
+     * Type of the paid media, always “photo”
+     */
+    #[EnumOrScalar]
+    public PaidMediaType|string $type = PaidMediaType::PHOTO;
+
+    /**
+     * The photo
+     * @var PhotoSize[]
+     */
+    #[ArrayType(PhotoSize::class)]
+    public array $photo;
+}

--- a/src/Telegram/Types/Payment/PaidMediaPreview.php
+++ b/src/Telegram/Types/Payment/PaidMediaPreview.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\PaidMediaType;
+
+/**
+ * The paid media isn't available before the payment.
+ * @see https://core.telegram.org/bots/api#paidmediapreview
+ */
+class PaidMediaPreview extends PaidMedia
+{
+    /**
+     * Type of the paid media, always “preview”
+     */
+    #[EnumOrScalar]
+    public PaidMediaType|string $type = PaidMediaType::PREVIEW;
+
+    /**
+     * Optional. Media width as defined by the sender
+     */
+    public ?int $width;
+
+    /**
+     * Optional. Media height as defined by the sender
+     */
+    public ?int $height;
+
+    /**
+     * Optional. Duration of the media in seconds as defined by the sender
+     */
+    public ?int $duration;
+}

--- a/src/Telegram/Types/Payment/PaidMediaResolver.php
+++ b/src/Telegram/Types/Payment/PaidMediaResolver.php
@@ -5,21 +5,21 @@ namespace SergiX44\Nutgram\Telegram\Types\Payment;
 use Attribute;
 use InvalidArgumentException;
 use SergiX44\Hydrator\Annotation\ConcreteResolver;
+use SergiX44\Nutgram\Telegram\Properties\PaidMediaType;
 use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-class TransactionPartnerResolver extends ConcreteResolver
+class PaidMediaResolver extends ConcreteResolver
 {
     public function concreteFor(array $data): ?string
     {
         $type = $data['type'] ?? throw new InvalidArgumentException('Type must be defined');
 
         return match ($type) {
-            TransactionPartnerType::FRAGMENT->value => TransactionPartnerFragment::class,
-            TransactionPartnerType::USER->value => TransactionPartnerUser::class,
-            TransactionPartnerType::TELEGRAM_ADS->value => TransactionPartnerTelegramAds::class,
-            TransactionPartnerType::OTHER->value => TransactionPartnerOther::class,
-            default => (new class extends TransactionPartner {
+            PaidMediaType::PREVIEW->value => PaidMediaPreview::class,
+            PaidMediaType::PHOTO->value => PaidMediaPhoto::class,
+            PaidMediaType::VIDEO->value => PaidMediaVideo::class,
+            default => (new class extends PaidMedia {
             })::class,
         };
     }

--- a/src/Telegram/Types/Payment/PaidMediaVideo.php
+++ b/src/Telegram/Types/Payment/PaidMediaVideo.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\PaidMediaType;
+use SergiX44\Nutgram\Telegram\Types\Media\PhotoSize;
+use SergiX44\Nutgram\Telegram\Types\Media\Video;
+
+/**
+ * The paid media is a video.
+ * @see https://core.telegram.org/bots/api#paidmediavideo
+ */
+class PaidMediaVideo extends PaidMedia
+{
+    /**
+     * Type of the paid media, always “video”
+     */
+    #[EnumOrScalar]
+    public PaidMediaType|string $type = PaidMediaType::VIDEO;
+
+    /**
+     * The video
+     */
+    public Video $video;
+}

--- a/src/Telegram/Types/Payment/TransactionPartner.php
+++ b/src/Telegram/Types/Payment/TransactionPartner.php
@@ -11,6 +11,7 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
  * Currently, it can be one of:
  * - {@see TransactionPartnerFragment}
  * - {@see TransactionPartnerUser}
+ * - {@see TransactionPartnerTelegramAds}
  * - {@see TransactionPartnerOther}
  * @see https://core.telegram.org/bots/api#transactionpartner
  */
@@ -18,7 +19,7 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
 abstract class TransactionPartner extends BaseType
 {
     /**
-     * Type of the transaction partner, can be “fragment”, “user” or “other”.
+     * Type of the transaction partner, can be “fragment”, “user”, “telegram_ads” or “other”.
      */
     #[EnumOrScalar]
     public TransactionPartnerType|string $type;

--- a/src/Telegram/Types/Payment/TransactionPartnerTelegramAds.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerTelegramAds.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+
+/**
+ * Describes a withdrawal transaction to the Telegram Ads platform.
+ * @see https://core.telegram.org/bots/api#transactionpartnertelegramads
+ */
+class TransactionPartnerTelegramAds extends TransactionPartner
+{
+    /**
+     * Type of the transaction partner, always “telegram_ads”
+     */
+    #[EnumOrScalar]
+    public TransactionPartnerType|string $type = TransactionPartnerType::TELEGRAM_ADS;
+}

--- a/src/Telegram/Types/Payment/TransactionPartnerUser.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerUser.php
@@ -22,4 +22,9 @@ class TransactionPartnerUser extends TransactionPartner
      * Information about the user
      */
     public User $user;
+
+    /**
+     * Optional. Bot-specified invoice payload
+     */
+    public ?string $invoice_payload = null;
 }


### PR DESCRIPTION
#### July 1, 2024

**Bot API 7.6**

- [x] Update badge
- [x] Added the classes [PaidMedia](https://core.telegram.org/bots/api#paidmedia), [PaidMediaInfo](https://core.telegram.org/bots/api#paidmediainfo), [PaidMediaPreview](https://core.telegram.org/bots/api#paidmediapreview), [PaidMediaPhoto](https://core.telegram.org/bots/api#paidmediaphoto) and [PaidMediaVideo](https://core.telegram.org/bots/api#paidmediavideo), containing information about paid media.
- [x] Added the method [sendPaidMedia](https://core.telegram.org/bots/api#sendpaidmedia) and the classes [InputPaidMedia](https://core.telegram.org/bots/api#inputpaidmedia), [InputPaidMediaPhoto](https://core.telegram.org/bots/api#inputpaidmediaphoto) and [InputPaidMediaVideo](https://core.telegram.org/bots/api#inputpaidmediavideo), to support sending paid media.
- [x] Documented that the methods [copyMessage](https://core.telegram.org/bots/api#copymessage) and [copyMessages](https://core.telegram.org/bots/api#copymessages) cannot be used to copy paid media.
- [x] Added the field _can\_send\_paid\_media_ to the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).
- [x] Added the field _paid\_media_ to the classes [Message](https://core.telegram.org/bots/api#message) and [ExternalReplyInfo](https://core.telegram.org/bots/api#externalreplyinfo).
- [x] Added the class [TransactionPartnerTelegramAds](https://core.telegram.org/bots/api#transactionpartnertelegramads), containing information about Telegram Star transactions involving the Telegram Ads Platform.
- [x] Added the field _invoice\_payload_ to the class [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser), containing the bot-specified invoice payload.
- [x] Changed the default opening mode for [Direct Link Mini Apps](https://core.telegram.org/bots/webapps#direct-link-mini-apps).
- [x] Added support for launching Web Apps via `t.me` link in the class [MenuButtonWebApp](https://core.telegram.org/bots/api#menubuttonwebapp).
- [x] Added the field _section\_separator\_color_ to the class [ThemeParams](https://core.telegram.org/bots/webapps#themeparams).