### PR TITLE
Update bot api to 7.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 [![Total Downloads](http://poser.pugx.org/nutgram/nutgram/downloads)](https://packagist.org/packages/nutgram/nutgram)
 ![GitHub](https://img.shields.io/github/license/nutgram/nutgram)
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.6%09--%20July%2001,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.7%09--%20July%2007,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
 
 [![Test Suite](https://github.com/nutgram/nutgram/actions/workflows/php.yml/badge.svg)](https://github.com/nutgram/nutgram/actions/workflows/php.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/86c4ca3dae8f64db80f7/maintainability)](https://codeclimate.com/github/nutgram/nutgram/maintainability)

--- a/src/Handlers/Listeners/MessageListeners.php
+++ b/src/Handlers/Listeners/MessageListeners.php
@@ -388,6 +388,30 @@ trait MessageListeners
      * @param $callable
      * @return Handler
      */
+    public function onRefundedPayment($callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::REFUNDED_PAYMENT->value][] = new Handler($callable);
+    }
+
+    /**
+     * @param string $pattern
+     * @param $callable
+     * @return Handler
+     */
+    public function onRefundedPaymentPayload(string $pattern, $callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::REFUNDED_PAYMENT->value][$pattern] = new Handler(
+            $callable,
+            $pattern
+        );
+    }
+
+    /**
+     * @param $callable
+     * @return Handler
+     */
     public function onUsersShared($callable): Handler
     {
         $this->checkFinalized();

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -85,6 +85,9 @@ abstract class ResolveHandlers extends CollectHandlers
             } elseif ($messageType === MessageType::SUCCESSFUL_PAYMENT) {
                 $data = $this->update->getMessage()->successful_payment?->invoice_payload;
                 $this->addHandlersBy($resolvedHandlers, $updateType->value, $messageType->value, $data);
+            } elseif ($messageType === MessageType::REFUNDED_PAYMENT) {
+                $data = $this->update->getMessage()->refunded_payment?->invoice_payload;
+                $this->addHandlersBy($resolvedHandlers, $updateType->value, $messageType->value, $data);
             }
 
             if (count($resolvedHandlers) === 0) {

--- a/src/Telegram/Properties/MessageType.php
+++ b/src/Telegram/Properties/MessageType.php
@@ -34,6 +34,7 @@ enum MessageType: string
     case PINNED_MESSAGE = 'pinned_message';
     case INVOICE = 'invoice';
     case SUCCESSFUL_PAYMENT = 'successful_payment';
+    case REFUNDED_PAYMENT = 'refunded_payment';
     case USERS_SHARED = 'users_shared';
     case CHAT_SHARED = 'chat_shared';
     case CONNECTED_WEBSITE = 'connected_website';

--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -41,6 +41,7 @@ use SergiX44\Nutgram\Telegram\Types\Media\Voice;
 use SergiX44\Nutgram\Telegram\Types\Passport\PassportData;
 use SergiX44\Nutgram\Telegram\Types\Payment\Invoice;
 use SergiX44\Nutgram\Telegram\Types\Payment\PaidMediaInfo;
+use SergiX44\Nutgram\Telegram\Types\Payment\RefundedPayment;
 use SergiX44\Nutgram\Telegram\Types\Payment\SuccessfulPayment;
 use SergiX44\Nutgram\Telegram\Types\Poll\Poll;
 use SergiX44\Nutgram\Telegram\Types\Reaction\ReactionType;
@@ -478,6 +479,8 @@ class Message extends BaseType
      * {@see https://core.telegram.org/bots/api#payments More about payments »}
      */
     public ?SuccessfulPayment $successful_payment = null;
+
+    public ?RefundedPayment $refunded_payment = null;
 
     /**
      * Optional.

--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -694,6 +694,7 @@ class Message extends BaseType
             $this->pinned_message !== null => MessageType::PINNED_MESSAGE,
             $this->invoice !== null => MessageType::INVOICE,
             $this->successful_payment !== null => MessageType::SUCCESSFUL_PAYMENT,
+            $this->refunded_payment !== null => MessageType::REFUNDED_PAYMENT,
             $this->users_shared !== null => MessageType::USERS_SHARED,
             $this->chat_shared !== null => MessageType::CHAT_SHARED,
             $this->message_auto_delete_timer_changed !== null => MessageType::MESSAGE_AUTO_DELETE_TIMER_CHANGED,

--- a/src/Telegram/Types/Payment/RefundedPayment.php
+++ b/src/Telegram/Types/Payment/RefundedPayment.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object contains basic information about a refunded payment.
+ * @see https://core.telegram.org/bots/api#refundedpayment
+ */
+class RefundedPayment extends BaseType
+{
+    /**
+     * Three-letter ISO 4217 {@see https://core.telegram.org/bots/payments#supported-currencies currency} code,
+     * or “XTR” for payments in {@see https://t.me/BotNews/90 Telegram Stars}.
+     */
+    public string $currency;
+
+    /**
+     * Total price in the smallest units of the currency (integer, not float/double).
+     * For example, for a price of US$ 1.45 pass amount = 145.
+     * See the exp parameter in {@see https://core.telegram.org/bots/payments/currencies.json currencies.json},
+     * it shows the number of digits past the decimal point for each currency (2 for the majority of currencies).
+     */
+    public int $total_amount;
+
+    /**
+     * Bot-specified invoice payload
+     */
+    public string $invoice_payload;
+
+    /**
+     * Telegram payment identifier
+     */
+    public string $telegram_payment_charge_id;
+
+    /**
+     * Optional. Provider payment identifier
+     */
+    public string $provider_payment_charge_id;
+}

--- a/tests/Datasets/refunded_payment.php
+++ b/tests/Datasets/refunded_payment.php
@@ -1,0 +1,7 @@
+<?php
+
+dataset('refunded_payment', function () {
+    $file = file_get_contents(__DIR__.'/../Fixtures/Updates/refunded_payment.json');
+
+    return [json_decode($file)];
+});

--- a/tests/Feature/Listeners/MessageListenersTest.php
+++ b/tests/Feature/Listeners/MessageListenersTest.php
@@ -382,6 +382,30 @@ it('calls onSuccessfulPaymentPayload() handler', function ($update) {
     expect($bot->get('called'))->toBeTrue();
 })->with('successful_payment');
 
+it('calls onRefundedPayment() handler', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onRefundedPayment(function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called'))->toBeTrue();
+})->with('refunded_payment');
+
+it('calls onRefundedPaymentPayload() handler', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onRefundedPaymentPayload('thedata', function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called'))->toBeTrue();
+})->with('refunded_payment');
+
 it('calls onUsersShared() handler', function ($update) {
     $bot = Nutgram::fake($update);
 

--- a/tests/Fixtures/Updates/refunded_payment.json
+++ b/tests/Fixtures/Updates/refunded_payment.json
@@ -1,0 +1,27 @@
+{
+  "update_id": 1,
+  "message": {
+    "message_id": 123,
+    "from": {
+      "id": 456,
+      "is_bot": false,
+      "first_name": "Mario",
+      "username": "Bros",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 456,
+      "first_name": "Mario",
+      "username": "Bros",
+      "type": "private"
+    },
+    "date": 1684984664,
+    "refunded_payment": {
+      "currency": "USD",
+      "total_amount": 100,
+      "invoice_payload": "thedata",
+      "telegram_payment_charge_id": "thepaymentid",
+      "provider_payment_charge_id": "theproviderid"
+    }
+  }
+}


### PR DESCRIPTION
# https://core.telegram.org/bots/api#july-7-2024

#### July 7, 2024

**Bot API 7.7**

-   Added the class [RefundedPayment](https://core.telegram.org/bots/api#july-7-2024#refundedpayment), containing information about a refunded payment.
-   Added the field _refunded\_payment_ to the class [Message](https://core.telegram.org/bots/api#july-7-2024#message), describing a service message about a refunded payment.
-   Added the field _isVerticalSwipesEnabled_ and the methods _enableVerticalSwipes_, _disableVerticalSwipes_ to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
-   Added the [event](https://core.telegram.org/bots/webapps#events-available-for-mini-apps) _scanQrPopupClosed_ for Mini Apps.