### PR TITLE
Update to Bot API 7.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://i.imgur.com/yrd8jr2.png" width="400px">
 </p>
 
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.7%09--%20July%2007,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.8%09--%20July%2031,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nutgram/nutgram.svg?label=composer&logo=composer)](https://packagist.org/packages/nutgram/nutgram)
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 ![License](https://img.shields.io/github/license/nutgram/nutgram)

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -1769,11 +1769,18 @@ trait AvailableMethods
      * @param int|string $chat_id Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
      * @param int $message_id Identifier of a message to pin
      * @param bool|null $disable_notification Pass True if it is not necessary to send a notification to all chat members about the new pinned message. Notifications are always disabled in channels and private chats.
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be pinned
      * @return bool|null
      */
-    public function pinChatMessage(int|string $chat_id, int $message_id, ?bool $disable_notification = null): ?bool
+    public function pinChatMessage(
+        int|string $chat_id,
+        int $message_id,
+        ?bool $disable_notification = null,
+        ?string $business_connection_id = null,
+    ): ?bool
     {
-        return $this->requestJson(__FUNCTION__, compact('chat_id', 'message_id', 'disable_notification'));
+        $business_connection_id ??= $this->businessConnectionId();
+        return $this->requestJson(__FUNCTION__, compact('chat_id', 'message_id', 'disable_notification', 'business_connection_id'));
     }
 
     /**
@@ -1783,11 +1790,17 @@ trait AvailableMethods
      * @see https://core.telegram.org/bots/api#unpinchatmessage
      * @param int|string $chat_id Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
      * @param int|null $message_id Identifier of a message to unpin. If not specified, the most recent pinned message (by sending date) will be unpinned.
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be pinned
      * @return bool|null
      */
-    public function unpinChatMessage(int|string $chat_id, ?int $message_id = null): ?bool
+    public function unpinChatMessage(
+        int|string $chat_id,
+        ?int $message_id = null,
+        ?string $business_connection_id = null,
+    ): ?bool
     {
-        return $this->requestJson(__FUNCTION__, compact('chat_id', 'message_id'));
+        $business_connection_id ??= $this->businessConnectionId();
+        return $this->requestJson(__FUNCTION__, compact('chat_id', 'message_id', 'business_connection_id'));
     }
 
     /**

--- a/src/Telegram/Types/User/User.php
+++ b/src/Telegram/Types/User/User.php
@@ -101,6 +101,7 @@ class User extends BaseType
         ?bool $can_read_all_group_messages = null,
         ?bool $supports_inline_queries = null,
         ?bool $can_connect_to_business = null,
+        ?bool $has_main_web_app = null,
     ): User {
         $user = new self();
         $user->id = $id;
@@ -115,6 +116,7 @@ class User extends BaseType
         $user->can_read_all_group_messages = $can_read_all_group_messages;
         $user->supports_inline_queries = $supports_inline_queries;
         $user->can_connect_to_business = $can_connect_to_business;
+        $user->has_main_web_app = $has_main_web_app;
         return $user;
     }
 }

--- a/src/Telegram/Types/User/User.php
+++ b/src/Telegram/Types/User/User.php
@@ -81,6 +81,13 @@ class User extends BaseType
      */
     public ?bool $can_connect_to_business = null;
 
+    /**
+     * Optional.
+     * True, if the bot has a main Web App.
+     * Returned only in {@see https://core.telegram.org/bots/api#getme getMe}.
+     */
+    public ?bool $has_main_web_app = null;
+
     public static function make(
         int $id,
         bool $is_bot,


### PR DESCRIPTION
#### [July 31, 2024](https://core.telegram.org/bots/api-changelog#july-31-2024)

**Bot API 7.8**

- [x] Update badge
- [x] Added the option for bots to set a [Main Mini App](https://core.telegram.org/bots/webapps#launching-the-main-mini-app), which can be previewed and launched directly from a button in the bot's profile or a link.
- [x] Added the method _shareToStory_ to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
- [x] Added the field _has\_main\_web\_app_ to the class [User](https://core.telegram.org/bots/api#user), which is returned in the response to [getMe](https://core.telegram.org/bots/api#getme).
- [x] Added the parameter _business\_connection\_id_ to the methods [pinChatMessage](https://core.telegram.org/bots/api#pinchatmessage) and [unpinChatMessage](https://core.telegram.org/bots/api#unpinchatmessage), allowing bots to manage pinned messages on behalf of a business account.