### PR TITLE
fix optional parameter in RefundedPayment

### DIFF
--- a/src/Telegram/Types/Payment/RefundedPayment.php
+++ b/src/Telegram/Types/Payment/RefundedPayment.php
@@ -37,5 +37,5 @@ class RefundedPayment extends BaseType
     /**
      * Optional. Provider payment identifier
      */
-    public string $provider_payment_charge_id;
+    public ?string $provider_payment_charge_id = null;
 }


### PR DESCRIPTION
`SergiX44\Hydrator\Exception\MissingRequiredValueException: The RefundedPayment.provider_payment_charge_id property is required.`

Request from botapi webhook after refund:
```
{
  "message": {
    ...
    "refunded_payment": {
      "currency": "XTR",
      "invoice_payload": "<text>",
      "telegram_payment_charge_id": "<payment_id>",
      "total_amount": 1
    }
  },
  "update_id": 902183544
}
```