### PR TITLE
Update bot api to 7.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://i.imgur.com/yrd8jr2.png" width="400px">
 </p>
 
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.8%09--%20July%2031,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.9%09--%20August%2014,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nutgram/nutgram.svg?label=composer&logo=composer)](https://packagist.org/packages/nutgram/nutgram)
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 ![License](https://img.shields.io/github/license/nutgram/nutgram)

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -821,6 +821,7 @@ trait AvailableMethods
      * @param bool|null $protect_content Protects the contents of the sent message from forwarding and saving
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -836,9 +837,11 @@ trait AvailableMethods
         ?bool $protect_content = null,
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
+        ?string $business_connection_id = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
+        $business_connection_id ??= $this->businessConnectionId();
         $params = compact(
             'star_count',
             'chat_id',
@@ -850,6 +853,7 @@ trait AvailableMethods
             'protect_content',
             'reply_parameters',
             'reply_markup',
+            'business_connection_id',
         );
 
         return $this->requestMultipart(__FUNCTION__, [
@@ -1656,6 +1660,58 @@ trait AvailableMethods
             'expire_date',
             'member_limit',
             'creates_join_request'
+        ), ChatInviteLink::class);
+    }
+
+    /**
+     * Use this method to create a
+     * {@see https://telegram.org/blog/superchannels-star-reactions-subscriptions#star-subscriptions subscription invite link}
+     * for a channel chat.
+     * The bot must have the can_invite_users administrator rights.
+     * The link can be edited using the method
+     * {@see https://core.telegram.org/bots/api#editchatsubscriptioninvitelink editChatSubscriptionInviteLink}
+     * or revoked using the method {@see https://core.telegram.org/bots/api#revokechatinvitelink revokeChatInviteLink}.
+     * Returns the new invite link as a {@see https://core.telegram.org/bots/api#chatinvitelink ChatInviteLink} object.
+     * @see https://core.telegram.org/bots/api#createchatsubscriptioninvitelink
+     * @param string|int $chat_id Unique identifier for the target channel chat or username of the target channel (in the format &#64;channelusername)
+     * @param int $subscription_period The number of seconds the subscription will be active for before the next payment. Currently, it must always be 2592000 (30 days).
+     * @param int $subscription_price The amount of Telegram Stars a user must pay initially and after each subsequent subscription period to be a member of the chat; 1-2500
+     * @param string|null $name Invite link name; 0-32 characters
+     * @return ChatInviteLink|null
+     */
+    public function createChatSubscriptionInviteLink(
+        string|int $chat_id,
+        int $subscription_period,
+        int $subscription_price,
+        ?string $name = null,
+    ): ?ChatInviteLink {
+        return $this->requestJson(__FUNCTION__, compact(
+            'chat_id',
+            'subscription_period',
+            'subscription_price',
+            'name',
+        ), ChatInviteLink::class);
+    }
+
+    /**
+     * Use this method to edit a subscription invite link created by the bot.
+     * The bot must have the can_invite_users administrator rights.
+     * Returns the edited invite link as a {@see https://core.telegram.org/bots/api#chatinvitelink ChatInviteLink} object.
+     * @see https://core.telegram.org/bots/api#editchatsubscriptioninvitelink
+     * @param int|string $chat_id Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
+     * @param string $invite_link The invite link to edit
+     * @param string|null $name Invite link name; 0-32 characters
+     * @return ChatInviteLink|null
+     */
+    public function editChatSubscriptionInviteLink(
+        int|string $chat_id,
+        string $invite_link,
+        ?string $name = null,
+    ): ?ChatInviteLink {
+        return $this->requestJson(__FUNCTION__, compact(
+            'chat_id',
+            'invite_link',
+            'name',
         ), ChatInviteLink::class);
     }
 

--- a/src/Telegram/Properties/ReactionTypeType.php
+++ b/src/Telegram/Properties/ReactionTypeType.php
@@ -6,4 +6,5 @@ enum ReactionTypeType: string
 {
     case EMOJI = 'emoji';
     case CUSTOM_EMOJI = 'custom_emoji';
+    case PAID = 'paid';
 }

--- a/src/Telegram/Types/Chat/ChatMemberMember.php
+++ b/src/Telegram/Types/Chat/ChatMemberMember.php
@@ -18,4 +18,10 @@ class ChatMemberMember extends ChatMember
 
     /** Information about the user */
     public User $user;
+
+    /**
+     * Optional.
+     * Date when the user's subscription will expire; Unix time
+     */
+    public ?int $until_date = null;
 }

--- a/src/Telegram/Types/Payment/TransactionPartnerUser.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerUser.php
@@ -2,6 +2,7 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Payment;
 
+use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Hydrator\Resolver\EnumOrScalar;
 use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
 use SergiX44\Nutgram\Telegram\Types\User\User;
@@ -27,4 +28,11 @@ class TransactionPartnerUser extends TransactionPartner
      * Optional. Bot-specified invoice payload
      */
     public ?string $invoice_payload = null;
+
+    /**
+     * Optional. Information about the paid media bought by the user
+     * @var PaidMedia[]|null
+     */
+    #[ArrayType(PaidMedia::class)]
+    public ?array $paid_media = null;
 }

--- a/src/Telegram/Types/Reaction/ReactionType.php
+++ b/src/Telegram/Types/Reaction/ReactionType.php
@@ -10,6 +10,7 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
  * This object describes the type of a reaction. Currently, it can be one of:
  * - {@see ReactionTypeEmoji ReactionTypeEmoji}
  * - {@see ReactionTypeCustomEmoji ReactionTypeCustomEmoji}
+ * - {@see ReactionTypePaid ReactionTypePaid}
  * @see https://core.telegram.org/bots/api#reactiontype
  */
 #[ReactionTypeResolver]

--- a/src/Telegram/Types/Reaction/ReactionTypePaid.php
+++ b/src/Telegram/Types/Reaction/ReactionTypePaid.php
@@ -18,7 +18,7 @@ class ReactionTypePaid extends ReactionType implements JsonSerializable
      * @var ReactionTypeType|string
      */
     #[EnumOrScalar]
-    public string|ReactionTypeType $type = ReactionTypeType::PAID;
+    public ReactionTypeType|string $type = ReactionTypeType::PAID;
 
     public function jsonSerialize(): array
     {

--- a/src/Telegram/Types/Reaction/ReactionTypePaid.php
+++ b/src/Telegram/Types/Reaction/ReactionTypePaid.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Reaction;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\ReactionTypeType;
+use function SergiX44\Nutgram\Support\array_filter_null;
+
+/**
+ * The reaction is paid.
+ * @see https://core.telegram.org/bots/api#reactiontypepaid
+ */
+class ReactionTypePaid extends ReactionType implements JsonSerializable
+{
+    /**
+     * Type of the reaction, always “paid”
+     * @var ReactionTypeType|string
+     */
+    #[EnumOrScalar]
+    public string|ReactionTypeType $type = ReactionTypeType::PAID;
+
+    public function jsonSerialize(): array
+    {
+        return array_filter_null([
+            'type' => $this->type->value,
+        ]);
+    }
+}


### PR DESCRIPTION
### [ August 14, 2024](https://core.telegram.org/bots/api#august-14-2024)

**Bot API 7.9**

- [x] Update badge
- [x] Added support for [Super Channels](https://telegram.org/blog/superchannels-star-reactions-subscriptions#super-channels), allowing received channel messages to have users or other channels as their senders.
- [x] Added the ability to send paid media to any chat.
- [x] Added the parameter _business\_connection\_id_ to the method [sendPaidMedia](https://core.telegram.org/bots/api#sendpaidmedia), allowing bots to send paid media on behalf of a business account.
- [x] Added the field _paid\_media_ to the class [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser) for transactions involving paid media.
- [x] Added the method [createChatSubscriptionInviteLink](https://core.telegram.org/bots/api#createchatsubscriptioninvitelink), allowing bots to create subscription invite links.
- [x] Added the method [editChatSubscriptionInviteLink](https://core.telegram.org/bots/api#editchatsubscriptioninvitelink), allowing bots to edit the _name_ of subscription invite links.
- [x] Added the field _until\_date_ to the class [ChatMemberMember](https://core.telegram.org/bots/api#chatmembermember) for members with an active subscription.
- [x] Added support for paid reactions and the class [ReactionTypePaid](https://core.telegram.org/bots/api#reactiontypepaid).