### PR TITLE
Update to Bot API 7.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://i.imgur.com/yrd8jr2.png" width="400px">
 </p>
 
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.9%09--%20August%2014,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.10%09--%20September%2014,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nutgram/nutgram.svg?label=composer&logo=composer)](https://packagist.org/packages/nutgram/nutgram)
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 ![License](https://img.shields.io/github/license/nutgram/nutgram)

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -37,6 +37,7 @@ final readonly class Configuration
         'callback_query',
         'shipping_query',
         'pre_checkout_query',
+        'purchased_paid_media',
         'poll',
         'poll_answer',
         'my_chat_member',

--- a/src/Handlers/Listeners/UpdateListeners.php
+++ b/src/Handlers/Listeners/UpdateListeners.php
@@ -203,6 +203,30 @@ trait UpdateListeners
      * @param $callable
      * @return Handler
      */
+    public function onPaidMediaPurchased($callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::PURCHASED_PAID_MEDIA->value][] = new Handler($callable);
+    }
+
+    /**
+     * @param string $pattern
+     * @param $callable
+     * @return Handler
+     */
+    public function onPaidMediaPurchasedPayload(string $pattern, $callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::PURCHASED_PAID_MEDIA->value][$pattern] = new Handler(
+            $callable,
+            $pattern
+        );
+    }
+
+    /**
+     * @param $callable
+     * @return Handler
+     */
     public function onUpdatePoll($callable): Handler
     {
         $this->checkFinalized();

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -105,6 +105,9 @@ abstract class ResolveHandlers extends CollectHandlers
         } elseif ($updateType === UpdateType::INLINE_QUERY) {
             $data = $this->update->inline_query?->query;
             $this->addHandlersBy($resolvedHandlers, $updateType->value, value: $data);
+        } elseif ($updateType === UpdateType::PURCHASED_PAID_MEDIA) {
+            $data = $this->update->purchased_paid_media?->paid_media_payload;
+            $this->addHandlersBy($resolvedHandlers, $updateType->value, value: $data);
         }
 
         if (empty($resolvedHandlers) && $updateType !== null) {

--- a/src/Proxies/UpdateProxy.php
+++ b/src/Proxies/UpdateProxy.php
@@ -17,6 +17,7 @@ use SergiX44\Nutgram\Telegram\Types\Inline\ChosenInlineResult;
 use SergiX44\Nutgram\Telegram\Types\Inline\InlineQuery;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
+use SergiX44\Nutgram\Telegram\Types\Payment\PaidMediaPurchased;
 use SergiX44\Nutgram\Telegram\Types\Payment\PreCheckoutQuery;
 use SergiX44\Nutgram\Telegram\Types\Payment\ShippingQuery;
 use SergiX44\Nutgram\Telegram\Types\Poll\Poll;
@@ -187,6 +188,11 @@ trait UpdateProxy
     public function preCheckoutQuery(): ?PreCheckoutQuery
     {
         return $this->update?->pre_checkout_query;
+    }
+
+    public function purchasedPaidMedia(): ?PaidMediaPurchased
+    {
+        return $this->update?->purchased_paid_media;
     }
 
     public function poll(): ?Poll

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -822,6 +822,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param string|null $payload Bot-defined paid media payload, 0-128 bytes. This will not be displayed to the user, use it for your internal processes.
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -838,6 +839,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
+        ?string $payload = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -854,6 +856,7 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'business_connection_id',
+            'payload',
         );
 
         return $this->requestMultipart(__FUNCTION__, [

--- a/src/Telegram/Properties/UpdateType.php
+++ b/src/Telegram/Properties/UpdateType.php
@@ -21,6 +21,7 @@ enum UpdateType: string
     case CALLBACK_QUERY = 'callback_query';
     case SHIPPING_QUERY = 'shipping_query';
     case PRE_CHECKOUT_QUERY = 'pre_checkout_query';
+    case PURCHASED_PAID_MEDIA = 'purchased_paid_media';
     case POLL = 'poll';
     case POLL_ANSWER = 'poll_answer';
     case MY_CHAT_MEMBER = 'my_chat_member';

--- a/src/Telegram/Types/Boost/ChatBoostSourceGiveaway.php
+++ b/src/Telegram/Types/Boost/ChatBoostSourceGiveaway.php
@@ -29,6 +29,11 @@ class ChatBoostSourceGiveaway extends ChatBoostSource
     public ?User $user = null;
 
     /**
+     * Optional. The number of Telegram Stars to be split between giveaway winners; for Telegram Star giveaways only
+     */
+    public ?int $prize_star_count = null;
+
+    /**
      * Optional. True, if the giveaway was completed, but there was no user to win the prize
      */
     public ?bool $is_unclaimed = null;

--- a/src/Telegram/Types/Common/Update.php
+++ b/src/Telegram/Types/Common/Update.php
@@ -212,6 +212,7 @@ class Update extends BaseType
             $this->callback_query !== null => UpdateType::CALLBACK_QUERY,
             $this->shipping_query !== null => UpdateType::SHIPPING_QUERY,
             $this->pre_checkout_query !== null => UpdateType::PRE_CHECKOUT_QUERY,
+            $this->purchased_paid_media !== null => UpdateType::PURCHASED_PAID_MEDIA,
             $this->poll !== null => UpdateType::POLL,
             $this->poll_answer !== null => UpdateType::POLL_ANSWER,
             $this->my_chat_member !== null => UpdateType::MY_CHAT_MEMBER,
@@ -245,6 +246,7 @@ class Update extends BaseType
             $this->callback_query !== null => $this->callback_query->from,
             $this->shipping_query !== null => $this->shipping_query->from,
             $this->pre_checkout_query !== null => $this->pre_checkout_query->from,
+            $this->purchased_paid_media !== null => $this->purchased_paid_media->from,
             // poll: doesn't have a user
             $this->poll_answer !== null => $this->poll_answer->user,
             $this->my_chat_member !== null => $this->my_chat_member->from,
@@ -274,6 +276,7 @@ class Update extends BaseType
             $this->callback_query !== null => $this->callback_query->from = $user,
             $this->shipping_query !== null => $this->shipping_query->from = $user,
             $this->pre_checkout_query !== null => $this->pre_checkout_query->from = $user,
+            $this->purchased_paid_media !== null => $this->purchased_paid_media->from = $user,
             // poll: doesn't have a user
             $this->poll_answer !== null => $this->poll_answer->user = $user,
             $this->my_chat_member !== null => $this->my_chat_member->from = $user,
@@ -303,6 +306,7 @@ class Update extends BaseType
             $this->callback_query !== null => $this->callback_query->message?->chat,
             // shipping_query doesn't have a chat
             // pre_checkout_query doesn't have a chat
+            // purchased_paid_media doesn't have a chat
             // poll doesn't have a chat
             $this->poll_answer !== null => Chat::make($this->poll_answer->user->id, ChatType::PRIVATE),
             $this->my_chat_member !== null => $this->my_chat_member->chat,
@@ -332,6 +336,7 @@ class Update extends BaseType
             $this->callback_query !== null => $this->callback_query->message !== null ? $this->callback_query->message->chat = $chat : null,
             // shipping_query doesn't have a chat
             // pre_checkout_query doesn't have a chat
+            // purchased_paid_media doesn't have a chat
             // poll doesn't have a chat
             $this->poll_answer !== null => $chat,
             $this->my_chat_member !== null => $this->my_chat_member->chat = $chat,

--- a/src/Telegram/Types/Common/Update.php
+++ b/src/Telegram/Types/Common/Update.php
@@ -16,6 +16,7 @@ use SergiX44\Nutgram\Telegram\Types\Inline\CallbackQuery;
 use SergiX44\Nutgram\Telegram\Types\Inline\ChosenInlineResult;
 use SergiX44\Nutgram\Telegram\Types\Inline\InlineQuery;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
+use SergiX44\Nutgram\Telegram\Types\Payment\PaidMediaPurchased;
 use SergiX44\Nutgram\Telegram\Types\Payment\PreCheckoutQuery;
 use SergiX44\Nutgram\Telegram\Types\Payment\ShippingQuery;
 use SergiX44\Nutgram\Telegram\Types\Poll\Poll;
@@ -133,6 +134,12 @@ class Update extends BaseType
      * Contains full information about checkout
      */
     public ?PreCheckoutQuery $pre_checkout_query = null;
+
+    /**
+     * Optional.
+     * A user purchased paid media with a non-empty payload sent by the bot in a non-channel chat
+     */
+    public ?PaidMediaPurchased $purchased_paid_media = null;
 
     /**
      * Optional.

--- a/src/Telegram/Types/Giveaway/Giveaway.php
+++ b/src/Telegram/Types/Giveaway/Giveaway.php
@@ -56,6 +56,11 @@ class Giveaway extends BaseType
     public ?array $country_codes = null;
 
     /**
+     * Optional. The number of Telegram Stars to be split between giveaway winners; for Telegram Star giveaways only
+     */
+    public ?int $prize_star_count = null;
+
+    /**
      * Optional. The number of months the Telegram Premium subscription won from the giveaway will be active for
      * @var int|null
      */

--- a/src/Telegram/Types/Giveaway/GiveawayCompleted.php
+++ b/src/Telegram/Types/Giveaway/GiveawayCompleted.php
@@ -25,4 +25,10 @@ class GiveawayCompleted extends BaseType
      * Optional. Message with the giveaway that was completed, if it wasn't deleted
      */
     public ?Message $giveaway_message = null;
+
+    /**
+     * Optional. True, if the giveaway is a Telegram Star giveaway.
+     * Otherwise, currently, the giveaway is a Telegram Premium giveaway.
+     */
+    public ?bool $is_star_giveaway = null;
 }

--- a/src/Telegram/Types/Giveaway/GiveawayCreated.php
+++ b/src/Telegram/Types/Giveaway/GiveawayCreated.php
@@ -10,4 +10,8 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
  */
 class GiveawayCreated extends BaseType
 {
+    /**
+     * Optional. The number of Telegram Stars to be split between giveaway winners; for Telegram Star giveaways only
+     */
+    public ?int $prize_star_count = null;
 }

--- a/src/Telegram/Types/Giveaway/GiveawayWinners.php
+++ b/src/Telegram/Types/Giveaway/GiveawayWinners.php
@@ -47,6 +47,11 @@ class GiveawayWinners extends BaseType
     public ?int $additional_chat_count = null;
 
     /**
+     * Optional. The number of Telegram Stars to be split between giveaway winners; for Telegram Star giveaways only
+     */
+    public ?int $prize_star_count = null;
+
+    /**
      * Optional. The number of months the Telegram Premium subscription won from the giveaway will be active for
      * @var ?int
      */

--- a/src/Telegram/Types/Payment/PaidMediaPurchased.php
+++ b/src/Telegram/Types/Payment/PaidMediaPurchased.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\User\User;
+
+/**
+ * This object contains information about a paid media purchase.
+ * @see https://core.telegram.org/bots/api#paidmediapurchased
+ */
+class PaidMediaPurchased extends BaseType
+{
+    /**
+     * User who purchased the media
+     */
+    public User $from;
+
+    /**
+     * Bot-specified paid media payload
+     */
+    public string $paid_media_payload;
+}

--- a/src/Telegram/Types/Payment/TransactionPartnerUser.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerUser.php
@@ -35,4 +35,9 @@ class TransactionPartnerUser extends TransactionPartner
      */
     #[ArrayType(PaidMedia::class)]
     public ?array $paid_media = null;
+
+    /**
+     * Optional. Bot-specified paid media payload
+     */
+    public ?string $paid_media_payload = null;
 }

--- a/tests/Datasets/paid_media_purchased.php
+++ b/tests/Datasets/paid_media_purchased.php
@@ -1,0 +1,7 @@
+<?php
+
+dataset('paid_media_purchased', function () {
+    $file = file_get_contents(__DIR__.'/../Fixtures/Updates/paid_media_purchased.json');
+
+    return [json_decode($file)];
+});

--- a/tests/Feature/Listeners/UpdateListenersTest.php
+++ b/tests/Feature/Listeners/UpdateListenersTest.php
@@ -298,6 +298,30 @@ it('calls onPreCheckoutQueryPayload() handler', function ($update) {
     expect($bot->get('called'))->toBeTrue();
 })->with('pre_checkout_query');
 
+it('calls onPaidMediaPurchased() handler', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onPaidMediaPurchased(function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called', false))->toBeTrue();
+})->with('paid_media_purchased');
+
+it('calls onPaidMediaPurchasedPayload() handler', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onPaidMediaPurchasedPayload('wow', function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called', false))->toBeTrue();
+})->with('paid_media_purchased');
+
 it('calls onUpdatePoll() handler', function ($update) {
     $bot = Nutgram::fake($update);
 

--- a/tests/Feature/Proxies/UpdateProxyTest.php
+++ b/tests/Feature/Proxies/UpdateProxyTest.php
@@ -9,6 +9,7 @@ use SergiX44\Nutgram\Telegram\Types\Inline\CallbackQuery;
 use SergiX44\Nutgram\Telegram\Types\Inline\ChosenInlineResult;
 use SergiX44\Nutgram\Telegram\Types\Inline\InlineQuery;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
+use SergiX44\Nutgram\Telegram\Types\Payment\PaidMediaPurchased;
 use SergiX44\Nutgram\Telegram\Types\Payment\PreCheckoutQuery;
 use SergiX44\Nutgram\Telegram\Types\Payment\ShippingQuery;
 use SergiX44\Nutgram\Telegram\Types\Poll\Poll;
@@ -128,6 +129,15 @@ test('preCheckoutQuery() returns PreCheckoutQuery object', function ($update) {
     expect($bot->preCheckoutQuery()->getBot())->toBeInstanceOf(Nutgram::class);
     expect($bot->preCheckoutQuery()->from->getBot())->toBeInstanceOf(Nutgram::class);
 })->with('pre_checkout_query');
+
+test('purchasedPaidMedia() returns PaidMediaPurchased object', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->run();
+
+    expect($bot->purchasedPaidMedia())->toBeInstanceOf(PaidMediaPurchased::class);
+    expect($bot->purchasedPaidMedia()->getBot())->toBeInstanceOf(Nutgram::class);
+})->with('paid_media_purchased');
 
 test('poll() returns Poll object', function ($update) {
     $bot = Nutgram::fake($update);

--- a/tests/Fixtures/Updates/paid_media_purchased.json
+++ b/tests/Fixtures/Updates/paid_media_purchased.json
@@ -1,0 +1,15 @@
+{
+  "update_id": 123456789,
+  "purchased_paid_media": {
+    "from": {
+      "id": 12345,
+      "is_bot": false,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "language_code": "it",
+      "is_premium": false
+    },
+    "paid_media_payload": "wow"
+  }
+}


### PR DESCRIPTION
## [Bot API 7.10](https://core.telegram.org/bots/api#september-6-2024)

### Telegram
- [x] Added updates about purchased paid media, represented by the class [PaidMediaPurchased](https://core.telegram.org/bots/api#paidmediapurchased) and the field _purchased\_paid\_media_ in the class [Update](https://core.telegram.org/bots/api#update).
- [x] Added the ability to specify a payload in [sendPaidMedia](https://core.telegram.org/bots/api#sendpaidmedia) that is received back by the bot in [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser) and _purchased\_paid\_media_ updates.
- [x] Added the field _prize\_star\_count_ to the classes [GiveawayCreated](https://core.telegram.org/bots/api#giveawaycreated), [Giveaway](https://core.telegram.org/bots/api#giveaway), [GiveawayWinners](https://core.telegram.org/bots/api#giveawaywinners) and [ChatBoostSourceGiveaway](https://core.telegram.org/bots/api#chatboostsourcegiveaway).
- [x] Added the field _is\_star\_giveaway_ to the class [GiveawayCompleted](https://core.telegram.org/bots/api#giveawaycompleted).
- [x] Added the field _SecondaryButton_ to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
- [x] Added the event _secondaryButtonClicked_ for Mini Apps.
- [x] Added the field _bottomBarColor_ and the method _setBottomBarColor_ to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).
- [x] Added the field _bottom\_bar\_bg\_color_ to the class [ThemeParams](https://core.telegram.org/bots/webapps#themeparams).

### Nutgram
- [x] Update badge
- [x] Add onPaidMediaPurchased listener
- [x] Add onPaidMediaPurchasedPayload listener 
- [x] Add  purchasedPaidMedia proxy