### PR TITLE
Fix incorrect parameter passed to sendMessage method

### DIFF
--- a/src/Telegram/Endpoints/CustomEndpoints.php
+++ b/src/Telegram/Endpoints/CustomEndpoints.php
@@ -593,7 +593,7 @@ trait CustomEndpoints
                 return $this->sendAttachment($endpoint, $param, $media, $opt, $clientOpt);
             }
 
-            return $this->sendMessage($chunk, $opt);
+            return $this->sendMessage($chunk, $opt['chat_id']);
         }, $chunks, array_keys($chunks));
     }
 }


### PR DESCRIPTION
Changed second argument from $opt to $opt['chat_id'] to prevent exceptions when using the method