### PR TITLE
Reorder document type check in getType function

### DIFF
--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -668,7 +668,6 @@ class Message extends BaseType
             $this->text !== null => MessageType::TEXT,
             $this->audio !== null => MessageType::AUDIO,
             $this->animation !== null => MessageType::ANIMATION,
-            $this->document !== null => MessageType::DOCUMENT,
             $this->game !== null => MessageType::GAME,
             $this->photo !== null => MessageType::PHOTO,
             $this->sticker !== null => MessageType::STICKER,
@@ -715,6 +714,7 @@ class Message extends BaseType
             $this->video_chat_ended !== null => MessageType::VIDEO_CHAT_ENDED,
             $this->video_chat_participants_invited !== null => MessageType::VIDEO_CHAT_PARTICIPANTS_INVITED,
             $this->web_app_data !== null => MessageType::WEB_APP_DATA,
+            $this->document !== null => MessageType::DOCUMENT,
             default => null
         };
     }


### PR DESCRIPTION
This pull request includes a small change to the `getType` method in the `Message` class. The change reorders the condition for `MessageType::DOCUMENT` to ensure it is checked after `photo`, `audio`, `video` and other file based message updates since telegram have `ducoment` object while real message type is `photo` or etc .

Changes to `getType` method:

* [`src/Telegram/Types/Message/Message.php`](diffhunk://#diff-9d564420f323fe3d588e8e035809836b57d473a4e2f01553e294c6e6e21598b0L671): Moved the check for `$this->document !== null` to be after `$this->web_app_data !== null` in the `getType` method. [[1]](diffhunk://#diff-9d564420f323fe3d588e8e035809836b57d473a4e2f01553e294c6e6e21598b0L671) [[2]](diffhunk://#diff-9d564420f323fe3d588e8e035809836b57d473a4e2f01553e294c6e6e21598b0R717)