### PR TITLE
Update to Bot API 7.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://i.imgur.com/yrd8jr2.png" width="400px">
 </p>
 
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.10%09--%20September%206,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-7.11%09--%20October%2031,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nutgram/nutgram.svg?label=composer&logo=composer)](https://packagist.org/packages/nutgram/nutgram)
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 ![License](https://img.shields.io/github/license/nutgram/nutgram)

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -111,6 +111,7 @@ trait AvailableMethods
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @return Message|null
      */
     public function sendMessage(
@@ -129,6 +130,7 @@ trait AvailableMethods
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -149,6 +151,7 @@ trait AvailableMethods
             'reply_markup',
             'business_connection_id',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
 
         return $this->requestJson(__FUNCTION__, $parameters, Message::class);
@@ -239,6 +242,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @return MessageId|null
      */
     public function copyMessage(
@@ -256,6 +260,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?bool $show_caption_above_media = null,
+        ?bool $allow_paid_broadcast = null,
     ): ?MessageId {
         return $this->requestJson(__FUNCTION__, compact(
             'chat_id',
@@ -272,6 +277,7 @@ trait AvailableMethods
             'reply_parameters',
             'reply_markup',
             'show_caption_above_media',
+            'allow_paid_broadcast',
         ), MessageId::class);
     }
 
@@ -332,6 +338,7 @@ trait AvailableMethods
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -352,6 +359,7 @@ trait AvailableMethods
         ?string $business_connection_id = null,
         ?bool $show_caption_above_media = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -373,6 +381,7 @@ trait AvailableMethods
             'business_connection_id',
             'show_caption_above_media',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'photo', $photo, $opt, $clientOpt);
@@ -402,6 +411,7 @@ trait AvailableMethods
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -424,6 +434,7 @@ trait AvailableMethods
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -447,6 +458,7 @@ trait AvailableMethods
             'reply_markup',
             'business_connection_id',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'audio', $audio, $opt, $clientOpt);
@@ -473,6 +485,7 @@ trait AvailableMethods
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -493,6 +506,7 @@ trait AvailableMethods
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -514,6 +528,7 @@ trait AvailableMethods
             'reply_markup',
             'business_connection_id',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'document', $document, $opt, $clientOpt);
@@ -545,6 +560,7 @@ trait AvailableMethods
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -570,6 +586,7 @@ trait AvailableMethods
         ?string $business_connection_id = null,
         ?bool $show_caption_above_media = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -596,6 +613,7 @@ trait AvailableMethods
             'business_connection_id',
             'show_caption_above_media',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'video', $video, $opt, $clientOpt);
@@ -626,6 +644,7 @@ trait AvailableMethods
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -650,6 +669,7 @@ trait AvailableMethods
         ?string $business_connection_id = null,
         ?bool $show_caption_above_media = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -675,6 +695,7 @@ trait AvailableMethods
             'business_connection_id',
             'show_caption_above_media',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'animation', $animation, $opt, $clientOpt);
@@ -701,6 +722,7 @@ trait AvailableMethods
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -720,6 +742,7 @@ trait AvailableMethods
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -740,6 +763,7 @@ trait AvailableMethods
             'reply_markup',
             'business_connection_id',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'voice', $voice, $opt, $clientOpt);
@@ -764,6 +788,7 @@ trait AvailableMethods
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -782,6 +807,7 @@ trait AvailableMethods
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -801,6 +827,7 @@ trait AvailableMethods
             'reply_markup',
             'business_connection_id',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'video_note', $video_note, $opt, $clientOpt);
@@ -823,6 +850,7 @@ trait AvailableMethods
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $payload Bot-defined paid media payload, 0-128 bytes. This will not be displayed to the user, use it for your internal processes.
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -840,6 +868,7 @@ trait AvailableMethods
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $payload = null,
+        ?bool $allow_paid_broadcast = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -857,6 +886,7 @@ trait AvailableMethods
             'reply_markup',
             'business_connection_id',
             'payload',
+            'allow_paid_broadcast',
         );
 
         return $this->requestMultipart(__FUNCTION__, [
@@ -880,6 +910,7 @@ trait AvailableMethods
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param array $clientOpt Client options
      * @return Message[]|null
      */
@@ -894,6 +925,7 @@ trait AvailableMethods
         ?ReplyParameters $reply_parameters = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
         array $clientOpt = [],
     ): ?array {
         $chat_id ??= $this->chatId();
@@ -912,6 +944,7 @@ trait AvailableMethods
                 'reply_parameters',
                 'business_connection_id',
                 'message_effect_id',
+                'allow_paid_broadcast',
             ),
         ], Message::class, $clientOpt);
     }
@@ -936,6 +969,7 @@ trait AvailableMethods
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @return Message|null
      */
     public function sendLocation(
@@ -955,6 +989,7 @@ trait AvailableMethods
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -977,6 +1012,7 @@ trait AvailableMethods
             'reply_markup',
             'business_connection_id',
             'message_effect_id',
+            'allow_paid_broadcast',
         ), Message::class);
     }
 
@@ -1032,6 +1068,7 @@ trait AvailableMethods
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @return Message|null
      */
     public function sendVenue(
@@ -1053,6 +1090,7 @@ trait AvailableMethods
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -1077,6 +1115,7 @@ trait AvailableMethods
             'reply_markup',
             'business_connection_id',
             'message_effect_id',
+            'allow_paid_broadcast',
         ), Message::class);
     }
 
@@ -1098,6 +1137,7 @@ trait AvailableMethods
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @return Message|null
      */
     public function sendContact(
@@ -1115,6 +1155,7 @@ trait AvailableMethods
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -1135,6 +1176,7 @@ trait AvailableMethods
             'reply_markup',
             'business_connection_id',
             'message_effect_id',
+            'allow_paid_broadcast',
         ), Message::class);
     }
 
@@ -1166,6 +1208,7 @@ trait AvailableMethods
      * @param ParseMode|string|null $question_parse_mode Mode for parsing entities in the question. See {@see https://core.telegram.org/bots/api#formatting-options formatting options} for more details. Currently, only custom emoji entities are allowed.
      * @param MessageEntity[]|null $question_entities A JSON-serialized list of special entities that appear in the poll question. It can be specified instead of question_parse_mode
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @return Message|null
      */
     public function sendPoll(
@@ -1193,6 +1236,7 @@ trait AvailableMethods
         ParseMode|string|null $question_parse_mode = null,
         ?array $question_entities = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -1221,6 +1265,7 @@ trait AvailableMethods
             'question_parse_mode',
             'question_entities',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
         return $this->requestJson(__FUNCTION__, [
             'options' => json_encode($options, JSON_THROW_ON_ERROR),
@@ -1243,6 +1288,7 @@ trait AvailableMethods
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @return Message|null
      */
     public function sendDice(
@@ -1257,6 +1303,7 @@ trait AvailableMethods
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -1273,6 +1320,7 @@ trait AvailableMethods
             'reply_markup',
             'business_connection_id',
             'message_effect_id',
+            'allow_paid_broadcast',
         ), Message::class);
     }
 

--- a/src/Telegram/Endpoints/Games.php
+++ b/src/Telegram/Endpoints/Games.php
@@ -30,6 +30,7 @@ trait Games
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @return Message|null
      */
     public function sendGame(
@@ -44,6 +45,7 @@ trait Games
         ?InlineKeyboardMarkup $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -60,6 +62,7 @@ trait Games
             'reply_markup',
             'business_connection_id',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
 
         return $this->requestJson(__FUNCTION__, $parameters, Message::class);

--- a/src/Telegram/Endpoints/Payments.php
+++ b/src/Telegram/Endpoints/Payments.php
@@ -51,6 +51,7 @@ trait Payments
      * @param ReplyParameters|null $reply_parameters Description of the message to reply to
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button.
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @return Message|null
      */
     public function sendInvoice(
@@ -84,6 +85,7 @@ trait Payments
         ?ReplyParameters $reply_parameters = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
     ): ?Message {
         $chat_id ??= $this->chatId();
         $message_thread_id ??= $this->messageThreadId();
@@ -118,6 +120,7 @@ trait Payments
             'reply_parameters',
             'reply_markup',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
         $parameters['prices'] = json_encode($prices, JSON_THROW_ON_ERROR);
         return $this->requestJson(__FUNCTION__, $parameters, Message::class);

--- a/src/Telegram/Endpoints/Stickers.php
+++ b/src/Telegram/Endpoints/Stickers.php
@@ -42,6 +42,7 @@ trait Stickers
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -58,6 +59,7 @@ trait Stickers
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?string $business_connection_id = null,
         ?string $message_effect_id = null,
+        ?bool $allow_paid_broadcast = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -75,6 +77,7 @@ trait Stickers
             'reply_markup',
             'business_connection_id',
             'message_effect_id',
+            'allow_paid_broadcast',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'sticker', $sticker, $opt, $clientOpt);

--- a/src/Telegram/Endpoints/UpdatesMessages.php
+++ b/src/Telegram/Endpoints/UpdatesMessages.php
@@ -106,7 +106,7 @@ trait UpdatesMessages
     }
 
     /**
-     * Use this method to edit animation, audio, document, photo, or video messages.
+     * Use this method to edit animation, audio, document, photo, or video messages, or to add media to text messages.
      * If a message is part of a message album, then it can be edited only to an audio for audio albums, only to a document for document albums and to a photo or a video otherwise.
      * When an inline message is edited, a new file can't be uploaded;
      * use a previously uploaded file via its file_id or specify a URL.

--- a/src/Telegram/Properties/TransactionPartnerType.php
+++ b/src/Telegram/Properties/TransactionPartnerType.php
@@ -7,5 +7,6 @@ enum TransactionPartnerType: string
     case FRAGMENT = 'fragment';
     case USER = 'user';
     case TELEGRAM_ADS = 'telegram_ads';
+    case TELEGRAM_API = 'telegram_api';
     case OTHER = 'other';
 }

--- a/src/Telegram/Types/Keyboard/CopyTextButton.php
+++ b/src/Telegram/Types/Keyboard/CopyTextButton.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Keyboard;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * This object represents an inline keyboard button that copies specified text to the clipboard.
+ * @see https://core.telegram.org/bots/api#copytextbutton
+ */
+class CopyTextButton extends BaseType
+{
+    /**
+     * The text to be copied to the clipboard; 1-256 characters
+     */
+    public string $text;
+
+    public function __construct(string $text)
+    {
+        parent::__construct();
+        $this->text = $text;
+    }
+
+    public static function make(string $text): self
+    {
+        return new self($text);
+    }
+}

--- a/src/Telegram/Types/Keyboard/InlineKeyboardButton.php
+++ b/src/Telegram/Types/Keyboard/InlineKeyboardButton.php
@@ -72,6 +72,12 @@ class InlineKeyboardButton extends BaseType implements JsonSerializable
 
     /**
      * Optional.
+     * Description of the button that copies the specified text to the clipboard.
+     */
+    public ?CopyTextButton $copy_text = null;
+
+    /**
+     * Optional.
      * Description of the game that will be launched when the user presses the button.NOTE: This type of button must always be the first button in the first row.
      */
     public ?CallbackGame $callback_game = null;
@@ -95,6 +101,7 @@ class InlineKeyboardButton extends BaseType implements JsonSerializable
         ?bool $pay = null,
         ?WebAppInfo $web_app = null,
         ?SwitchInlineQueryChosenChat $switch_inline_query_chosen_chat = null,
+        ?CopyTextButton $copy_text = null,
     ) {
         parent::__construct();
         $this->text = $text;
@@ -107,6 +114,7 @@ class InlineKeyboardButton extends BaseType implements JsonSerializable
         $this->pay = $pay;
         $this->web_app = $web_app;
         $this->switch_inline_query_chosen_chat = $switch_inline_query_chosen_chat;
+        $this->copy_text = $copy_text;
     }
 
     public static function make(
@@ -120,6 +128,7 @@ class InlineKeyboardButton extends BaseType implements JsonSerializable
         ?bool $pay = null,
         ?WebAppInfo $web_app = null,
         ?SwitchInlineQueryChosenChat $switch_inline_query_chosen_chat = null,
+        ?CopyTextButton $copy_text = null,
     ): InlineKeyboardButton {
         return new self(
             $text,
@@ -132,6 +141,7 @@ class InlineKeyboardButton extends BaseType implements JsonSerializable
             $pay,
             $web_app,
             $switch_inline_query_chosen_chat,
+            $copy_text,
         );
     }
 
@@ -148,6 +158,7 @@ class InlineKeyboardButton extends BaseType implements JsonSerializable
             'callback_game' => $this->callback_game,
             'pay' => $this->pay,
             'web_app' => $this->web_app,
+            'copy_text' => $this->copy_text,
         ]);
     }
 }

--- a/src/Telegram/Types/Payment/TransactionPartner.php
+++ b/src/Telegram/Types/Payment/TransactionPartner.php
@@ -12,6 +12,7 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
  * - {@see TransactionPartnerFragment}
  * - {@see TransactionPartnerUser}
  * - {@see TransactionPartnerTelegramAds}
+ * - {@see TransactionPartnerTelegramApi}
  * - {@see TransactionPartnerOther}
  * @see https://core.telegram.org/bots/api#transactionpartner
  */

--- a/src/Telegram/Types/Payment/TransactionPartnerTelegramApi.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerTelegramApi.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+
+/**
+ * Describes a transaction with payment for {@see https://core.telegram.org/bots/api#paid-broadcasts paid broadcasting}.
+ * @see https://core.telegram.org/bots/api#transactionpartnertelegramapi
+ */
+class TransactionPartnerTelegramApi extends TransactionPartner
+{
+    /**
+     * Type of the transaction partner, always “telegram_api”.
+     */
+    #[EnumOrScalar]
+    public TransactionPartnerType|string $type = TransactionPartnerType::TELEGRAM_API;
+
+    /**
+     * The number of successful requests that exceeded regular limits and were therefore billed
+     */
+    public int $request_count;
+}


### PR DESCRIPTION
### [October 31, 2024](https://core.telegram.org/bots/api-changelog#october-31-2024)

**Bot API 7.11**

- [x] Added the class [CopyTextButton](https://core.telegram.org/bots/api#copytextbutton) and the field _copy\_text_ in the class [InlineKeyboardButton](https://core.telegram.org/bots/api#inlinekeyboardbutton) allowing bots to send and receive inline buttons that copy arbitrary text.
- [x] Added the parameter _allow\_paid\_broadcast_ to the methods [sendMessage](https://core.telegram.org/bots/api#sendmessage), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendAudio](https://core.telegram.org/bots/api#sendaudio), [sendDocument](https://core.telegram.org/bots/api#senddocument), [sendPaidMedia](https://core.telegram.org/bots/api#sendpaidmedia), [sendSticker](https://core.telegram.org/bots/api#sendsticker), [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote), [sendVoice](https://core.telegram.org/bots/api#sendvoice), [sendLocation](https://core.telegram.org/bots/api#sendlocation), [sendVenue](https://core.telegram.org/bots/api#sendvenue), [sendContact](https://core.telegram.org/bots/api#sendcontact), [sendPoll](https://core.telegram.org/bots/api#sendpoll), [sendDice](https://core.telegram.org/bots/api#senddice), [sendInvoice](https://core.telegram.org/bots/api#sendinvoice), [sendGame](https://core.telegram.org/bots/api#sendgame), [sendMediaGroup](https://core.telegram.org/bots/api#sendmediagroup) and [copyMessage](https://core.telegram.org/bots/api#copymessage).
- [x] Added the class [TransactionPartnerTelegramApi](https://core.telegram.org/bots/api#transactionpartnertelegramapi) for transactions related to paid broadcasted messages.
- [x] Introduced the ability to add media to existing text messages using the method [editMessageMedia](https://core.telegram.org/bots/api#editmessagemedia).
- [x] Added support for hashtag and cashtag [entities](https://core.telegram.org/bots/api#messageentity) with a specified chat username that opens a search for the relevant tag within the specified chat.