### PR TITLE
Make validateWebAppDataForThirdParty static 😅

### DIFF
--- a/src/Support/ValidatesWebData.php
+++ b/src/Support/ValidatesWebData.php
@@ -44,7 +44,8 @@ trait ValidatesWebData
      * @throws InvalidDataException If the webapp data is invalid.
      * @see https://core.telegram.org/bots/webapps#validating-data-for-third-party-use
      */
-    public function validateWebAppDataForThirdParty(
+    public static function validateWebAppDataForThirdParty(
+        int $botId,
         string $queryString,
         string $publicKey = self::PUBLICKEY_PROD
     ): WebAppData {
@@ -52,14 +53,16 @@ trait ValidatesWebData
             throw new RuntimeException('Sodium extension is required for this method');
         }
 
-        [$sortedData, , $signature] = $this->parseQueryString($queryString, ['hash', 'signature']);
-        $dataCheckString = sprintf("%s:WebAppData\n%s", $this->getBotId(), $sortedData);
+        $bot = self::fake();
 
-        if (!$this->ed25519Verify($publicKey, $dataCheckString, $signature)) {
+        [$sortedData, , $signature] = $bot->parseQueryString($queryString, ['hash', 'signature']);
+        $dataCheckString = sprintf("%s:WebAppData\n%s", $botId, $sortedData);
+
+        if (!$bot->ed25519Verify($publicKey, $dataCheckString, $signature)) {
             throw new InvalidDataException('Invalid webapp data');
         }
 
-        return $this->hydrator->hydrate($this->queryStringToArray($queryString), WebAppData::class);
+        return $bot->hydrator->hydrate($bot->queryStringToArray($queryString), WebAppData::class);
     }
 
     /**

--- a/src/Testing/FakeNutgram.php
+++ b/src/Testing/FakeNutgram.php
@@ -436,13 +436,11 @@ class FakeNutgram extends Nutgram
      * @return array
      * @internal For testing purposes only.
      */
-    public static function generateWebAppDataForThirdParty(int $botId, array $data): array
+    public function generateWebAppDataForThirdParty(int $botId, array $data): array
     {
         if (!extension_loaded('sodium')) {
             throw new RuntimeException('Sodium extension is required for this method');
         }
-
-        $bot = self::fake();
 
         // generate keypair
         $keyPair = sodium_crypto_sign_keypair();
@@ -455,7 +453,7 @@ class FakeNutgram extends Nutgram
 
         // generate signature
         $queryString = http_build_query(array_filter($data));
-        [$sortedData] = $bot->parseQueryString($queryString, ['hash', 'signature']);
+        [$sortedData] = $this->parseQueryString($queryString, ['hash', 'signature']);
         $dataCheckString = sprintf("%s:WebAppData\n%s", $botId, $sortedData);
         $signature = sodium_crypto_sign_detached($dataCheckString, $secretKey);
         $signature = sodium_bin2base64($signature, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);

--- a/src/Testing/FakeNutgram.php
+++ b/src/Testing/FakeNutgram.php
@@ -436,11 +436,13 @@ class FakeNutgram extends Nutgram
      * @return array
      * @internal For testing purposes only.
      */
-    public function generateWebAppDataForThirdParty(int $botId, array $data): array
+    public static function generateWebAppDataForThirdParty(int $botId, array $data): array
     {
         if (!extension_loaded('sodium')) {
             throw new RuntimeException('Sodium extension is required for this method');
         }
+
+        $bot = self::fake();
 
         // generate keypair
         $keyPair = sodium_crypto_sign_keypair();
@@ -453,7 +455,7 @@ class FakeNutgram extends Nutgram
 
         // generate signature
         $queryString = http_build_query(array_filter($data));
-        [$sortedData] = $this->parseQueryString($queryString, ['hash', 'signature']);
+        [$sortedData] = $bot->parseQueryString($queryString, ['hash', 'signature']);
         $dataCheckString = sprintf("%s:WebAppData\n%s", $botId, $sortedData);
         $signature = sodium_crypto_sign_detached($dataCheckString, $secretKey);
         $signature = sodium_bin2base64($signature, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);

--- a/src/Testing/FakeNutgram.php
+++ b/src/Testing/FakeNutgram.php
@@ -422,7 +422,7 @@ class FakeNutgram extends Nutgram
     {
         $queryString = http_build_query(array_filter($data));
 
-        [$sortedData] = $this->parseQueryString($queryString, ['hash']);
+        [$sortedData] = self::parseQueryString($queryString, ['hash']);
         $secretKey = $this->createHashHmac(self::TOKEN, 'WebAppData');
         $hash = bin2hex($this->createHashHmac($sortedData, $secretKey));
 
@@ -436,7 +436,7 @@ class FakeNutgram extends Nutgram
      * @return array
      * @internal For testing purposes only.
      */
-    public function generateWebAppDataForThirdParty(int $botId, array $data): array
+    public static function generateWebAppDataForThirdParty(int $botId, array $data): array
     {
         if (!extension_loaded('sodium')) {
             throw new RuntimeException('Sodium extension is required for this method');
@@ -453,7 +453,7 @@ class FakeNutgram extends Nutgram
 
         // generate signature
         $queryString = http_build_query(array_filter($data));
-        [$sortedData] = $this->parseQueryString($queryString, ['hash', 'signature']);
+        [$sortedData] = self::parseQueryString($queryString, ['hash', 'signature']);
         $dataCheckString = sprintf("%s:WebAppData\n%s", $botId, $sortedData);
         $signature = sodium_crypto_sign_detached($dataCheckString, $secretKey);
         $signature = sodium_bin2base64($signature, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
@@ -472,7 +472,7 @@ class FakeNutgram extends Nutgram
     {
         $queryString = http_build_query(array_filter($data));
 
-        [$sortedData] = $this->parseQueryString($queryString, ['hash']);
+        [$sortedData] = self::parseQueryString($queryString, ['hash']);
         $secretKey = $this->createHash(self::TOKEN);
         $hash = bin2hex($this->createHashHmac($sortedData, $secretKey));
 

--- a/tests/Feature/Web/ValidateWebAppDataForThirdPartyTest.php
+++ b/tests/Feature/Web/ValidateWebAppDataForThirdPartyTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use SergiX44\Nutgram\Configuration;
 use SergiX44\Nutgram\Exception\InvalidDataException;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Web\WebAppData;
 use SergiX44\Nutgram\Telegram\Web\WebAppUser;
+use SergiX44\Nutgram\Testing\FakeNutgram;
 
 beforeEach(function () {
     $this->input = [
@@ -23,22 +23,30 @@ beforeEach(function () {
 })->skip(!extension_loaded('sodium'), 'Sodium extension is required');
 
 it('validates webapp data for third-party use', function () {
-    $botId = 134679134;
-    $bot = Nutgram::fake(config: new Configuration(botId: $botId));
-    [$initData, $publicKey] = $bot->generateWebAppDataForThirdParty($botId, $this->input);
+    [$initData, $publicKey] = FakeNutgram::generateWebAppDataForThirdParty(
+        botId: 134679134,
+        data: $this->input,
+    );
 
-    $data = $bot->validateWebAppDataForThirdParty($initData, $publicKey);
+    $data = Nutgram::validateWebAppDataForThirdParty(
+        botId: 134679134,
+        queryString: $initData,
+        publicKey: $publicKey,
+    );
 
     expect($data)->toBeInstanceOf(WebAppData::class);
     expect($data->user)->toBeInstanceOf(WebAppUser::class);
 });
 
 it('fails to validate webapp data for third-party use', function () {
-    $botId = 134679134;
-    $bot = Nutgram::fake(config: new Configuration(botId: $botId));
-    [$initData, $publicKey] = $bot->generateWebAppDataForThirdParty($botId, $this->input);
+    [$initData, $publicKey] = FakeNutgram::generateWebAppDataForThirdParty(
+        botId: 134679134,
+        data: $this->input,
+    );
 
-    $publicKey = '0000000000000000000000000000000000000000000000000000000000000000';
-
-    $bot->validateWebAppDataForThirdParty($initData, $publicKey);
+    Nutgram::validateWebAppDataForThirdParty(
+        botId: 999999999,
+        queryString: $initData,
+        publicKey: $publicKey
+    );
 })->throws(InvalidDataException::class, 'Invalid webapp data');

--- a/tests/Feature/Web/ValidateWebAppDataForThirdPartyTest.php
+++ b/tests/Feature/Web/ValidateWebAppDataForThirdPartyTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use SergiX44\Nutgram\Configuration;
 use SergiX44\Nutgram\Exception\InvalidDataException;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Web\WebAppData;
 use SergiX44\Nutgram\Telegram\Web\WebAppUser;
+use SergiX44\Nutgram\Testing\FakeNutgram;
 
 beforeEach(function () {
     $this->input = [
@@ -23,22 +23,30 @@ beforeEach(function () {
 })->skip(!extension_loaded('sodium'), 'Sodium extension is required');
 
 it('validates webapp data for third-party use', function () {
-    $botId = 134679134;
-    $bot = Nutgram::fake(config: new Configuration(botId: $botId));
-    [$initData, $publicKey] = $bot->generateWebAppDataForThirdParty($botId, $this->input);
+    [$initData, $publicKey] = FakeNutgram::generateWebAppDataForThirdParty(
+        botId: 134679134,
+        data: $this->input,
+    );
 
-    $data = $bot->validateWebAppDataForThirdParty($initData, $publicKey);
+    $data = Nutgram::validateWebAppDataForThirdParty(
+        botId: 134679134,
+        queryString: $initData,
+        publicKey: $publicKey,
+    );
 
     expect($data)->toBeInstanceOf(WebAppData::class);
     expect($data->user)->toBeInstanceOf(WebAppUser::class);
 });
 
 it('fails to validate webapp data for third-party use', function () {
-    $botId = 134679134;
-    $bot = Nutgram::fake(config: new Configuration(botId: $botId));
-    [$initData, $publicKey] = $bot->generateWebAppDataForThirdParty($botId, $this->input);
+    [$initData, $publicKey] = FakeNutgram::generateWebAppDataForThirdParty(
+        botId: 134679134,
+        data: $this->input,
+    );
 
-    $publicKey = '0000000000000000000000000000000000000000000000000000000000000000';
-
-    $bot->validateWebAppDataForThirdParty($initData, $publicKey);
+    Nutgram::validateWebAppDataForThirdParty(
+        botId: 999999999,
+        queryString: $initData,
+        publicKey: $publicKey,
+    );
 })->throws(InvalidDataException::class, 'Invalid webapp data');

--- a/tests/Feature/Web/ValidateWebAppDataForThirdPartyTest.php
+++ b/tests/Feature/Web/ValidateWebAppDataForThirdPartyTest.php
@@ -1,10 +1,10 @@
 <?php
 
+use SergiX44\Nutgram\Configuration;
 use SergiX44\Nutgram\Exception\InvalidDataException;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Web\WebAppData;
 use SergiX44\Nutgram\Telegram\Web\WebAppUser;
-use SergiX44\Nutgram\Testing\FakeNutgram;
 
 beforeEach(function () {
     $this->input = [
@@ -23,30 +23,22 @@ beforeEach(function () {
 })->skip(!extension_loaded('sodium'), 'Sodium extension is required');
 
 it('validates webapp data for third-party use', function () {
-    [$initData, $publicKey] = FakeNutgram::generateWebAppDataForThirdParty(
-        botId: 134679134,
-        data: $this->input,
-    );
+    $botId = 134679134;
+    $bot = Nutgram::fake(config: new Configuration(botId: $botId));
+    [$initData, $publicKey] = $bot->generateWebAppDataForThirdParty($botId, $this->input);
 
-    $data = Nutgram::validateWebAppDataForThirdParty(
-        botId: 134679134,
-        queryString: $initData,
-        publicKey: $publicKey,
-    );
+    $data = $bot->validateWebAppDataForThirdParty($initData, $publicKey);
 
     expect($data)->toBeInstanceOf(WebAppData::class);
     expect($data->user)->toBeInstanceOf(WebAppUser::class);
 });
 
 it('fails to validate webapp data for third-party use', function () {
-    [$initData, $publicKey] = FakeNutgram::generateWebAppDataForThirdParty(
-        botId: 134679134,
-        data: $this->input,
-    );
+    $botId = 134679134;
+    $bot = Nutgram::fake(config: new Configuration(botId: $botId));
+    [$initData, $publicKey] = $bot->generateWebAppDataForThirdParty($botId, $this->input);
 
-    Nutgram::validateWebAppDataForThirdParty(
-        botId: 999999999,
-        queryString: $initData,
-        publicKey: $publicKey
-    );
+    $publicKey = '0000000000000000000000000000000000000000000000000000000000000000';
+
+    $bot->validateWebAppDataForThirdParty($initData, $publicKey);
 })->throws(InvalidDataException::class, 'Invalid webapp data');


### PR DESCRIPTION
https://core.telegram.org/bots/webapps#validating-data-for-third-party-use

>  If you need to share the data with a third party, they can validate the data without requiring access to your bot's token.

This means that because you do not have the bot token, creating a new Nutgram instance is useless.
