### PR TITLE
Fix missing $_SERVER key check

### DIFF
--- a/src/RunningMode/Webhook.php
+++ b/src/RunningMode/Webhook.php
@@ -25,7 +25,7 @@ class Webhook implements RunningMode
      */
     public function __construct(?Closure $getToken = null, ?string $secretToken = null)
     {
-        $this->resolveSecretToken = $getToken ?? static fn (): string => $_SERVER['HTTP_X_TELEGRAM_BOT_API_SECRET_TOKEN'];
+        $this->resolveSecretToken = $getToken ?? static fn (): string => $_SERVER['HTTP_X_TELEGRAM_BOT_API_SECRET_TOKEN'] ?? '';
         $this->secretToken = $secretToken;
     }
 


### PR DESCRIPTION
This pull request includes a small but important change to the `Webhook` class in the `src/RunningMode/Webhook.php` file. The change ensures that the `resolveSecretToken` function returns an empty string if the `HTTP_X_TELEGRAM_BOT_API_SECRET_TOKEN` is not set in the server environment variables.