### PR TITLE
Fix the inability to reuse the same InputFile multiple times

### DIFF
--- a/src/Telegram/Types/Internal/InputFile.php
+++ b/src/Telegram/Types/Internal/InputFile.php
@@ -2,8 +2,10 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Internal;
 
+use GuzzleHttp\Psr7\Utils;
 use InvalidArgumentException;
 use JsonSerializable;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * This object represents the contents of a file to be uploaded. Must be posted using
@@ -12,7 +14,7 @@ use JsonSerializable;
 class InputFile implements JsonSerializable
 {
     /**
-     * @var resource
+     * @var StreamInterface
      */
     protected $resource;
 
@@ -29,14 +31,14 @@ class InputFile implements JsonSerializable
     {
         $this->filename = $filename;
         if (is_resource($resource)) {
-            $this->resource = $resource;
+            $this->resource = Utils::streamFor($resource);
         } elseif (is_string($resource) && file_exists($resource)) {
             $res = fopen($resource, 'rb+');
             if ($res === false) {
                 throw new InvalidArgumentException('Cannot open the specified resource.');
             }
 
-            $this->resource = $res;
+            $this->resource = Utils::streamFor($res);
         } else {
             throw new InvalidArgumentException('Invalid resource specified.');
         }
@@ -63,7 +65,7 @@ class InputFile implements JsonSerializable
     }
 
     /**
-     * @return resource
+     * @return StreamInterface
      */
     public function getResource()
     {
@@ -75,10 +77,10 @@ class InputFile implements JsonSerializable
      */
     public function getFilename(): string
     {
-        $metadata = stream_get_meta_data($this->resource);
+        $uri = $this->resource->getMetadata('uri');
 
-        if ($this->filename === null && isset($metadata['uri'])) {
-            return basename($metadata['uri']);
+        if ($this->filename === null && !empty($uri)) {
+            return basename($uri);
         }
 
         return basename($this->filename ?? uniqid(more_entropy: true));

--- a/tests/Feature/EndpointsTest.php
+++ b/tests/Feature/EndpointsTest.php
@@ -2,6 +2,7 @@
 
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\StreamInterface;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Exceptions\TelegramException;
 use SergiX44\Nutgram\Telegram\Limits;
@@ -370,11 +371,11 @@ it('sends a media group', function () {
                 fn ($x) => $x
                     ->name->toBe('photoA.jpg')
                     ->filename->toBe('photoA.jpg')
-                    ->contents->toBeResource(),
+                    ->contents->toBeInstanceOf(StreamInterface::class),
                 fn ($x) => $x
                     ->name->toBe('photoB.jpg')
                     ->filename->toBe('photoB.jpg')
-                    ->contents->toBeResource(),
+                    ->contents->toBeInstanceOf(StreamInterface::class),
                 fn ($x) => $x
                     ->name->toBe('media')
                     ->contents->toBe('[{"type":"photo","media":"attach:\/\/photoA.jpg","caption":"150"},{"type":"photo","media":"attach:\/\/photoB.jpg","caption":"200"}]'),


### PR DESCRIPTION
This pull request updates the InputFile class to use StreamInterface internally instead of resource. This change addresses an issue where Guzzle closes the underlying resource after a request, making it impossible to reuse the same InputFile instance multiple times. By switching to StreamInterface, we ensure better compatibility with Guzzle and improved reusability of the InputFile class across multiple requests.