### PR TITLE
Update to Bot API 8.1

### DIFF
--- a/src/Telegram/Properties/TransactionPartnerType.php
+++ b/src/Telegram/Properties/TransactionPartnerType.php
@@ -6,6 +6,7 @@ enum TransactionPartnerType: string
 {
     case FRAGMENT = 'fragment';
     case USER = 'user';
+    case AFFILIATE_PROGRAM = 'affiliate_program';
     case TELEGRAM_ADS = 'telegram_ads';
     case TELEGRAM_API = 'telegram_api';
     case OTHER = 'other';

--- a/src/Telegram/Types/Payment/AffiliateInfo.php
+++ b/src/Telegram/Types/Payment/AffiliateInfo.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use JsonSerializable;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Chat\Chat;
+use SergiX44\Nutgram\Telegram\Types\User\User;
+use function SergiX44\Nutgram\Support\array_filter_null;
+
+/**
+ * Contains information about the affiliate that received a commission via this transaction.
+ * @see https://core.telegram.org/bots/api#affiliateinfo
+ */
+class AffiliateInfo extends BaseType implements JsonSerializable
+{
+    /**
+     * Optional. The bot or the user that received an affiliate commission if it was received by a bot or a user
+     */
+    public ?User $affiliate_user = null;
+
+    /**
+     * Optional. The chat that received an affiliate commission if it was received by a chat
+     */
+    public ?Chat $affiliate_chat = null;
+
+    /**
+     * The number of Telegram Stars received by the affiliate for each 1000 Telegram Stars received by the bot from referred users
+     */
+    public int $commission_per_mille;
+
+    /**
+     * Integer amount of Telegram Stars received by the affiliate from the transaction, rounded to 0; can be negative for refunds
+     */
+    public int $amount;
+
+    /**
+     * Optional. The number of 1/1000000000 shares of Telegram Stars received by the affiliate; from -999999999 to 999999999; can be negative for refunds
+     */
+    public ?int $nanostar_amount = null;
+
+    public function jsonSerialize(): array
+    {
+        return array_filter_null([
+            'affiliate_user' => $this->affiliate_user,
+            'affiliate_chat' => $this->affiliate_chat,
+            'commission_per_mille' => $this->commission_per_mille,
+            'amount' => $this->amount,
+            'nanostar_amount' => $this->nanostar_amount,
+        ]);
+    }
+}

--- a/src/Telegram/Types/Payment/StarTransaction.php
+++ b/src/Telegram/Types/Payment/StarTransaction.php
@@ -14,7 +14,7 @@ class StarTransaction extends BaseType implements JsonSerializable
 {
     /**
      * Unique identifier of the transaction.
-     * Coincides with the identifer of the original transaction for refund transactions.
+     * Coincides with the identifier of the original transaction for refund transactions.
      * Coincides with SuccessfulPayment.telegram_payment_charge_id for successful incoming payments from users.
      */
     public string $id;
@@ -23,6 +23,13 @@ class StarTransaction extends BaseType implements JsonSerializable
      * Number of Telegram Stars transferred by the transaction
      */
     public int $amount;
+
+    /**
+     * Optional.
+     * The number of 1/1000000000 shares of Telegram Stars transferred by the transaction;
+     * from 0 to 999999999
+     */
+    public ?int $nanostar_amount = null;
 
     /**
      * Date the transaction was created in Unix time
@@ -48,6 +55,7 @@ class StarTransaction extends BaseType implements JsonSerializable
         return array_filter_null([
             'id' => $this->id,
             'amount' => $this->amount,
+            'nanostar_amount' => $this->nanostar_amount,
             'date' => $this->date,
             'source' => $this->source,
             'receiver' => $this->receiver,

--- a/src/Telegram/Types/Payment/TransactionPartner.php
+++ b/src/Telegram/Types/Payment/TransactionPartner.php
@@ -11,6 +11,7 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
  * Currently, it can be one of:
  * - {@see TransactionPartnerFragment}
  * - {@see TransactionPartnerUser}
+ * - {@see TransactionPartnerAffiliateProgram}
  * - {@see TransactionPartnerTelegramAds}
  * - {@see TransactionPartnerTelegramApi}
  * - {@see TransactionPartnerOther}
@@ -20,7 +21,7 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
 abstract class TransactionPartner extends BaseType
 {
     /**
-     * Type of the transaction partner, can be “fragment”, “user”, “telegram_ads” or “other”.
+     * Type of the transaction partner.
      */
     #[EnumOrScalar]
     public TransactionPartnerType|string $type;

--- a/src/Telegram/Types/Payment/TransactionPartnerAffiliateProgram.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerAffiliateProgram.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+use SergiX44\Nutgram\Telegram\Types\User\User;
+use function SergiX44\Nutgram\Support\array_filter_null;
+
+/**
+ * Describes the affiliate program that issued the affiliate commission received via this transaction.
+ * @see https://core.telegram.org/bots/api#transactionpartneraffiliateprogram
+ */
+class TransactionPartnerAffiliateProgram extends TransactionPartner implements JsonSerializable
+{
+    /**
+     * Type of the transaction partner, always “affiliate_program”
+     */
+    #[EnumOrScalar]
+    public TransactionPartnerType|string $type = TransactionPartnerType::AFFILIATE_PROGRAM;
+
+    /**
+     * Optional. Information about the bot that sponsored the affiliate program
+     */
+    public ?User $sponsor_user = null;
+
+    /**
+     * The number of Telegram Stars received by the bot for each 1000 Telegram Stars received by the affiliate program sponsor from referred users
+     */
+    public int $commission_per_mille;
+
+    public function jsonSerialize(): array
+    {
+        return array_filter_null([
+            'type' => $this->type,
+            'sponsor_user' => $this->sponsor_user,
+            'commission_per_mille' => $this->commission_per_mille,
+        ]);
+    }
+}

--- a/src/Telegram/Types/Payment/TransactionPartnerUser.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerUser.php
@@ -25,6 +25,11 @@ class TransactionPartnerUser extends TransactionPartner
     public User $user;
 
     /**
+     * Optional. Information about the affiliate that received a commission via this transaction
+     */
+    public ?AffiliateInfo $affiliate = null;
+
+    /**
      * Optional. Bot-specified invoice payload
      */
     public ?string $invoice_payload = null;


### PR DESCRIPTION
#### [December 4, 2024](https://core.telegram.org/bots/api#december-4-2024)

**Bot API 8.1**

-   Added the field _nanostar\_amount_ to the class [StarTransaction](https://core.telegram.org/bots/api#transactionpartneruser#startransaction).
-   Added the class [TransactionPartnerAffiliateProgram](https://core.telegram.org/bots/api#transactionpartneruser#transactionpartneraffiliateprogram) for transactions pertaining to incoming affiliate commissions.
-   Added the class [AffiliateInfo](https://core.telegram.org/bots/api#transactionpartneruser#affiliateinfo) and the field _affiliate_ to the class [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser#transactionpartneruser), allowing bots to identify the relevant affiliate in transactions with an affiliate commission.