### PR TITLE
Update to Bot API 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://i.imgur.com/yrd8jr2.png" width="400px">
 </p>
 
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-8.2%09--%20January%2004,%202025-28a8ea.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-8.2%09--%20January%2001,%202025-28a8ea.svg?logo=telegram)](https://core.telegram.org/bots/api)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nutgram/nutgram.svg?label=composer&logo=composer)](https://packagist.org/packages/nutgram/nutgram)
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 ![License](https://img.shields.io/github/license/nutgram/nutgram)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://i.imgur.com/yrd8jr2.png" width="400px">
 </p>
 
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-8.1%09--%20December%2004,%202024-blue.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-8.2%09--%20January%2004,%202025-28a8ea.svg?logo=telegram)](https://core.telegram.org/bots/api)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nutgram/nutgram.svg?label=composer&logo=composer)](https://packagist.org/packages/nutgram/nutgram)
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 ![License](https://img.shields.io/github/license/nutgram/nutgram)

--- a/src/Telegram/Endpoints/Stickers.php
+++ b/src/Telegram/Endpoints/Stickers.php
@@ -379,6 +379,7 @@ trait Stickers
      * @param string|null $text Text that will be shown along with the gift; 0-255 characters
      * @param string|null $text_parse_mode Mode for parsing entities in the text. See {@see formatting options https://core.telegram.org/bots/api#formatting-options} for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
      * @param array|null $text_entities A JSON-serialized list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
+     * @param bool|null $pay_for_upgrade Pass True to pay for the gift upgrade from the bot's balance, thereby making the upgrade free for the receiver
      * @return bool|null
      * @see https://core.telegram.org/bots/api#sendgift
      */
@@ -388,9 +389,56 @@ trait Stickers
         ?string $text = null,
         ?string $text_parse_mode = null,
         ?array $text_entities = null,
+        ?bool $pay_for_upgrade = null,
     ): ?bool {
         $user_id ??= $this->userId();
-        $parameters = compact('gift_id', 'user_id', 'text', 'text_parse_mode', 'text_entities');
+        $parameters = compact('gift_id', 'user_id', 'text', 'text_parse_mode', 'text_entities', 'pay_for_upgrade');
         return $this->requestJson(__FUNCTION__, $parameters);
+    }
+
+    /**
+     * Verifies a user on behalf of the organization which is represented by the bot. Returns True on success.
+     * @param int $user_id Unique identifier of the target user
+     * @param string|null $custom_description Custom description for the verification; 0-70 characters. Must be empty if the organization isn't allowed to provide a custom verification description.
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#verifyuser
+     */
+    public function verifyUser(int $user_id, ?string $custom_description = null): ?bool
+    {
+        return $this->requestJson(__FUNCTION__, compact('user_id', 'custom_description'));
+    }
+
+    /**
+     * Verifies a chat on behalf of the organization which is represented by the bot. Returns True on success.
+     * @param int|string $chat_id Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
+     * @param string|null $custom_description Custom description for the verification; 0-70 characters. Must be empty if the organization isn't allowed to provide a custom verification description.
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#verifychat
+     */
+    public function verifyChat(int|string $chat_id, ?string $custom_description = null): ?bool
+    {
+        return $this->requestJson(__FUNCTION__, compact('chat_id', 'custom_description'));
+    }
+
+    /**
+     * Removes verification from a user who is currently verified on behalf of the organization represented by the bot. Returns True on success.
+     * @param int $user_id Unique identifier of the target user
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#removeuserverification
+     */
+    public function removeUserVerification(int $user_id): ?bool
+    {
+        return $this->requestJson(__FUNCTION__, compact('user_id'));
+    }
+
+    /**
+     * Removes verification from a chat that is currently verified on behalf of the organization represented by the bot. Returns True on success.
+     * @param int|string $chat_id Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#removechatverification
+     */
+    public function removeChatVerification(int|string $chat_id): ?bool
+    {
+        return $this->requestJson(__FUNCTION__, compact('chat_id'));
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultArticle.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultArticle.php
@@ -42,7 +42,7 @@ class InlineQueryResultArticle extends InlineQueryResult
     /**
      * Optional.
      * Pass True if you don't want the URL to be shown in the message
-     * @deprecated since version Telegram Bot API 8.2. Pass an empty string as "url" instead.
+     * @deprecated Pass an empty string as "url" instead.
      */
     public ?bool $hide_url = null;
 
@@ -76,7 +76,7 @@ class InlineQueryResultArticle extends InlineQueryResult
      * @param InputMessageContent $input_message_content Content of the message to be sent
      * @param InlineKeyboardMarkup|null $reply_markup Optional. {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
      * @param string|null $url Optional. URL of the result
-     * @param bool|null $hide_url [DEPRECATED] since version Telegram Bot API 8.2. Pass an empty string as "url" instead.
+     * @param bool|null $hide_url [DEPRECATED] Pass an empty string as "url" instead.
      * @param string|null $description Optional. Short description of the result
      * @param string|null $thumbnail_url Optional. Url of the thumbnail for the result
      * @param int|null $thumbnail_width Optional. Thumbnail width
@@ -113,7 +113,7 @@ class InlineQueryResultArticle extends InlineQueryResult
      * @param InputMessageContent $input_message_content Content of the message to be sent
      * @param InlineKeyboardMarkup|null $reply_markup Optional. {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
      * @param string|null $url Optional. URL of the result
-     * @param bool|null $hide_url [DEPRECATED] since version Telegram Bot API 8.2. Pass an empty string as "url" instead.
+     * @param bool|null $hide_url [DEPRECATED] Pass an empty string as "url" instead.
      * @param string|null $description Optional. Short description of the result
      * @param string|null $thumbnail_url Optional. Url of the thumbnail for the result
      * @param int|null $thumbnail_width Optional. Thumbnail width

--- a/src/Telegram/Types/Inline/InlineQueryResultArticle.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultArticle.php
@@ -42,6 +42,7 @@ class InlineQueryResultArticle extends InlineQueryResult
     /**
      * Optional.
      * Pass True if you don't want the URL to be shown in the message
+     * @deprecated since version Telegram Bot API 8.2. Pass an empty string as "url" instead.
      */
     public ?bool $hide_url = null;
 
@@ -69,6 +70,18 @@ class InlineQueryResultArticle extends InlineQueryResult
      */
     public ?int $thumbnail_height = null;
 
+    /**
+     * @param string $id Unique identifier for this result, 1-64 Bytes
+     * @param string $title Title of the result
+     * @param InputMessageContent $input_message_content Content of the message to be sent
+     * @param InlineKeyboardMarkup|null $reply_markup Optional. {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
+     * @param string|null $url Optional. URL of the result
+     * @param bool|null $hide_url [DEPRECATED] since version Telegram Bot API 8.2. Pass an empty string as "url" instead.
+     * @param string|null $description Optional. Short description of the result
+     * @param string|null $thumbnail_url Optional. Url of the thumbnail for the result
+     * @param int|null $thumbnail_width Optional. Thumbnail width
+     * @param int|null $thumbnail_height Optional. Thumbnail height
+     */
     public function __construct(
         string $id,
         string $title,
@@ -94,6 +107,18 @@ class InlineQueryResultArticle extends InlineQueryResult
         $this->thumbnail_height = $thumbnail_height;
     }
 
+    /**
+     * @param string $id Unique identifier for this result, 1-64 Bytes
+     * @param string $title Title of the result
+     * @param InputMessageContent $input_message_content Content of the message to be sent
+     * @param InlineKeyboardMarkup|null $reply_markup Optional. {@see https://core.telegram.org/bots/features#inline-keyboards Inline keyboard} attached to the message
+     * @param string|null $url Optional. URL of the result
+     * @param bool|null $hide_url [DEPRECATED] since version Telegram Bot API 8.2. Pass an empty string as "url" instead.
+     * @param string|null $description Optional. Short description of the result
+     * @param string|null $thumbnail_url Optional. Url of the thumbnail for the result
+     * @param int|null $thumbnail_width Optional. Thumbnail width
+     * @param int|null $thumbnail_height Optional. Thumbnail height
+     */
     public static function make(
         string $id,
         string $title,

--- a/src/Telegram/Types/Sticker/Gift.php
+++ b/src/Telegram/Types/Sticker/Gift.php
@@ -27,6 +27,12 @@ class Gift extends BaseType
 
     /**
      * Optional.
+     * The number of Telegram Stars that must be paid to upgrade the gift to a unique one
+     */
+    public ?int $upgrade_star_count = null;
+
+    /**
+     * Optional.
      * The total number of the gifts of this type that can be sent; for limited gifts only
      */
     public ?int $total_count = null;


### PR DESCRIPTION
#### January 1, 2025

[**Bot API 8.2**](https://core.telegram.org/bots/api#january-1-2025)

-   Added the methods [verifyUser](https://core.telegram.org/bots/api#verifyuser), [verifyChat](https://core.telegram.org/bots/api#verifychat), [removeUserVerification](https://core.telegram.org/bots/api#removeuserverification) and [removeChatVerification](https://core.telegram.org/bots/api#removechatverification), allowing bots to manage [verifications on behalf of an organization](https://telegram.org/verify#third-party-verification).
-   Added the field _upgrade\_star\_count_ to the class [Gift](https://core.telegram.org/bots/api#gift).
-   Added the parameter _pay\_for\_upgrade_ to the method [sendGift](https://core.telegram.org/bots/api#sendgift).
-   Removed the field _hide\_url_ from the class [InlineQueryResultArticle](https://core.telegram.org/bots/api#inlinequeryresultarticle). Pass an empty string as _url_ instead.