### PR TITLE
Added support for running modes

### DIFF
--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -199,11 +199,12 @@ class Nutgram extends ResolveHandlers
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
+     * @param mixed ...$args for RunningMode processUpdates
      */
-    public function run(): void
+    public function run(...$args): void
     {
         $this->preflight();
-        $this->container->get(RunningMode::class)->processUpdates($this);
+        $this->container->get(RunningMode::class)->processUpdates($this, ...$args);
     }
 
     /**

--- a/src/RunningMode/Fake.php
+++ b/src/RunningMode/Fake.php
@@ -26,7 +26,7 @@ class Fake implements RunningMode
      * @throws \Psr\SimpleCache\InvalidArgumentException
      * @throws \Throwable
      */
-    public function processUpdates(Nutgram $bot): void
+    public function processUpdates(Nutgram $bot, ...$args): void
     {
         $update = match (true) {
             $this->update instanceof Update => $this->update,

--- a/src/RunningMode/Functional.php
+++ b/src/RunningMode/Functional.php
@@ -8,7 +8,7 @@ use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Types\Common\Update;
 use Throwable;
 
-class YandexFunc implements RunningMode
+class Functional implements RunningMode
 {
     /**
      *

--- a/src/RunningMode/Lambda.php
+++ b/src/RunningMode/Lambda.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SergiX44\Nutgram\RunningMode;
+
+use Psr\Log\LoggerInterface;
+use SergiX44\Nutgram\Hydrator\Hydrator;
+use SergiX44\Nutgram\Nutgram;
+use SergiX44\Nutgram\Telegram\Types\Common\Update;
+use Throwable;
+
+class YandexFunc implements RunningMode
+{
+    /**
+     *
+     * @param Nutgram $bot
+     * @param (string|null) ...$args
+     * @return void
+     */
+    public function processUpdates(Nutgram $bot, ...$args): void
+    {
+        foreach ($args as $arg) {
+            if ($arg  === null) {
+                return;
+            }
+
+            $update = null;
+            try {
+                $update = $bot->getContainer()
+                    ->get(Hydrator::class)
+                    ->hydrate(json_decode($arg, true, flags: JSON_THROW_ON_ERROR), Update::class);
+                $bot->processUpdate($update);
+            } catch (Throwable $e) {
+                $bot->getContainer()
+                    ->get(LoggerInterface::class)
+                    ->error(sprintf('Update failed: %s%s%s', $update?->getType()?->value, PHP_EOL, $this->$arg), ['exception' => $e]);
+                throw $e;
+            }
+        }
+    }
+}

--- a/src/RunningMode/Polling.php
+++ b/src/RunningMode/Polling.php
@@ -20,7 +20,7 @@ class Polling implements RunningMode
         }
     }
 
-    public function processUpdates(Nutgram $bot): void
+    public function processUpdates(Nutgram $bot, ...$args): void
     {
         $this->listenForSignals();
 

--- a/src/RunningMode/RunningMode.php
+++ b/src/RunningMode/RunningMode.php
@@ -7,5 +7,5 @@ use SergiX44\Nutgram\Nutgram;
 
 interface RunningMode
 {
-    public function processUpdates(Nutgram $bot): void;
+    public function processUpdates(Nutgram $bot, ...$args): void;
 }

--- a/src/RunningMode/SingleUpdate.php
+++ b/src/RunningMode/SingleUpdate.php
@@ -9,7 +9,7 @@ class SingleUpdate extends Polling
 {
     private static int $offset = 1;
 
-    public function processUpdates(Nutgram $bot): void
+    public function processUpdates(Nutgram $bot, ...$args): void
     {
         $this->listenForSignals();
         $config = $bot->getConfig();

--- a/src/RunningMode/Webhook.php
+++ b/src/RunningMode/Webhook.php
@@ -36,7 +36,7 @@ class Webhook implements RunningMode
      * @throws InvalidArgumentException
      * @throws Throwable
      */
-    public function processUpdates(Nutgram $bot): void
+    public function processUpdates(Nutgram $bot, ...$args): void
     {
         $input = $this->input();
 


### PR DESCRIPTION
The Nutgram->run method now accepts arguments to specify the running mode. 
Enables more flexible running modes while preserving backward compatibility. 
Added mode for AWS lambda.