### PR TITLE
[5.x] Add support for ApiException instance

### DIFF
--- a/src/Handlers/Listeners/SpecialListeners.php
+++ b/src/Handlers/Listeners/SpecialListeners.php
@@ -64,14 +64,14 @@ trait SpecialListeners
     }
 
     /**
-     * @param string $exceptionClass
+     * @param class-string<ApiException>|ApiException $exceptionClass
      * @return Handler
      */
-    public function registerApiException(string $exceptionClass): Handler
+    public function registerApiException(string|ApiException $exceptionClass): Handler
     {
         $this->checkFinalized();
 
-        if (!is_subclass_of($exceptionClass, ApiException::class)) {
+        if (is_string($exceptionClass) && !is_subclass_of($exceptionClass, ApiException::class)) {
             throw new InvalidArgumentException(
                 sprintf('The provided exception must be a subclass of %s.', ApiException::class)
             );

--- a/tests/Fixtures/Exceptions/UserDeactivatedException.php
+++ b/tests/Fixtures/Exceptions/UserDeactivatedException.php
@@ -5,8 +5,24 @@ declare(strict_types=1);
 namespace SergiX44\Nutgram\Tests\Fixtures\Exceptions;
 
 use SergiX44\Nutgram\Exception\ApiException;
+use SergiX44\Nutgram\Nutgram;
+use SergiX44\Nutgram\Telegram\Exceptions\TelegramException;
 
 class UserDeactivatedException extends ApiException
 {
     public static ?string $pattern = '.*deactivated.*';
+
+    public function __construct($message = '', int $code = 0, $previous = null, array $parameters = [], protected bool $mute = false)
+    {
+        parent::__construct($message, $code, $previous, $parameters);
+    }
+
+    public function __invoke(Nutgram $bot, TelegramException $e)
+    {
+        if ($this->mute) {
+            return;
+        }
+
+        parent::__invoke($bot, $e);
+    }
 }


### PR DESCRIPTION
## Before
```php
$bot->registerApiException(UserDeactivatedException::class);
```

## After
```php
$bot->registerApiException(UserDeactivatedException::class);
// OR
$bot->registerApiException(new UserDeactivatedException());
```