### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/src/Telegram/Client.php
+++ b/src/Telegram/Client.php
@@ -360,7 +360,7 @@ trait Client
      * @throws JsonException
      * @throws TelegramException
      */
-    protected function mapResponse(ResponseInterface $response, string $mapTo, Exception $clientException = null): mixed
+    protected function mapResponse(ResponseInterface $response, string $mapTo, ?Exception $clientException = null): mixed
     {
         $json = json_decode((string)$response->getBody(), flags: JSON_THROW_ON_ERROR);
         $json = $this->fireHandlersBy(self::AFTER_API_REQUEST, [$json]) ?? $json;

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -2249,7 +2249,7 @@ trait AvailableMethods
      * @param int|null $user_id Unique identifier of the target user
      * @return UserChatBoosts|null
      */
-    public function getUserChatBoosts(int|string $chat_id = null, int $user_id = null): ?UserChatBoosts
+    public function getUserChatBoosts(null|int|string $chat_id = null, ?int $user_id = null): ?UserChatBoosts
     {
         return $this->requestJson(__FUNCTION__, compact('chat_id', 'user_id'), UserChatBoosts::class);
     }

--- a/src/Testing/FakeNutgram.php
+++ b/src/Testing/FakeNutgram.php
@@ -91,9 +91,9 @@ class FakeNutgram extends Nutgram
      * @return FakeNutgram
      */
     public static function instance(
-        array|object $update = null,
+        null|array|object $update = null,
         array $responses = [],
-        Configuration $config = null
+        ?Configuration $config = null
     ): self {
         $mock = new MockHandler($responses);
         $handlerStack = HandlerStack::create($mock);


### PR DESCRIPTION
PHP: 8.4
Nutgram: 4.32.1
I catch warnings 
<img width="1725" alt="Screenshot 2025-02-12 at 12 30 05 PM" src="https://github.com/user-attachments/assets/0132b14e-8e52-421c-ae60-7ffd3d058329" />

[deprecate-implicitly-nullable-types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

This PR adds nullable type to parameters
