### PR TITLE
Update to Bot API 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://i.imgur.com/yrd8jr2.png" width="400px">
 </p>
 
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-8.2%09--%20January%2001,%202025-28a8ea.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-8.3%09--%20February%2012,%202025-28a8ea.svg?logo=telegram)](https://core.telegram.org/bots/api)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nutgram/nutgram.svg?label=composer&logo=composer)](https://packagist.org/packages/nutgram/nutgram)
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 ![License](https://img.shields.io/github/license/nutgram/nutgram)

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -168,6 +168,7 @@ trait AvailableMethods
      * @param int|null $message_thread_id Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
      * @param bool|null $disable_notification Sends the message {@see https://telegram.org/blog/channels-2-0#silent-messages silently}. Users will receive a notification with no sound.
      * @param bool|null $protect_content Protects the contents of the forwarded message from forwarding and saving
+     * @param int|null $video_start_timestamp New start timestamp for the forwarded video in the message
      * @return Message|null
      */
     public function forwardMessage(
@@ -177,6 +178,7 @@ trait AvailableMethods
         ?int $message_thread_id = null,
         ?bool $disable_notification = null,
         ?bool $protect_content = null,
+        ?int $video_start_timestamp = null,
     ): ?Message {
         return $this->requestJson(__FUNCTION__, compact(
             'chat_id',
@@ -184,7 +186,8 @@ trait AvailableMethods
             'from_chat_id',
             'disable_notification',
             'protect_content',
-            'message_id'
+            'message_id',
+            'video_start_timestamp',
         ), Message::class);
     }
 
@@ -243,6 +246,7 @@ trait AvailableMethods
      * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove reply keyboard or to force a reply from the user.
      * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
+     * @param int|null $video_start_timestamp New start timestamp for the forwarded video in the message
      * @return MessageId|null
      */
     public function copyMessage(
@@ -261,6 +265,7 @@ trait AvailableMethods
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
         ?bool $show_caption_above_media = null,
         ?bool $allow_paid_broadcast = null,
+        ?int $video_start_timestamp = null,
     ): ?MessageId {
         return $this->requestJson(__FUNCTION__, compact(
             'chat_id',
@@ -278,6 +283,7 @@ trait AvailableMethods
             'reply_markup',
             'show_caption_above_media',
             'allow_paid_broadcast',
+            'video_start_timestamp',
         ), MessageId::class);
     }
 
@@ -561,6 +567,8 @@ trait AvailableMethods
      * @param bool|null $show_caption_above_media Pass True, if the caption must be shown above the message media
      * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
+     * @param InputFile|string|null $cover Cover for the video in the message. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. {@see https://core.telegram.org/bots/api#sending-files More information on Sending Files »}
+     * @param int|null $start_timestamp Start timestamp for the video in the message
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -587,6 +595,8 @@ trait AvailableMethods
         ?bool $show_caption_above_media = null,
         ?string $message_effect_id = null,
         ?bool $allow_paid_broadcast = null,
+        InputFile|string|null $cover = null,
+        ?int $start_timestamp = null,
         array $clientOpt = [],
     ): ?Message {
         $chat_id ??= $this->chatId();
@@ -614,6 +624,8 @@ trait AvailableMethods
             'show_caption_above_media',
             'message_effect_id',
             'allow_paid_broadcast',
+            'cover',
+            'start_timestamp',
         );
 
         return $this->sendAttachment(__FUNCTION__, 'video', $video, $opt, $clientOpt);

--- a/src/Telegram/Endpoints/Stickers.php
+++ b/src/Telegram/Endpoints/Stickers.php
@@ -371,7 +371,7 @@ trait Stickers
     }
 
     /**
-     * Sends a gift to the given user.
+     * Sends a gift to the given user or channel chat.
      * The gift can't be converted to Telegram Stars by the user.
      * Returns True on success.
      * @param string $gift_id Identifier of the gift
@@ -380,6 +380,7 @@ trait Stickers
      * @param string|null $text_parse_mode Mode for parsing entities in the text. See {@see formatting options https://core.telegram.org/bots/api#formatting-options} for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
      * @param array|null $text_entities A JSON-serialized list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
      * @param bool|null $pay_for_upgrade Pass True to pay for the gift upgrade from the bot's balance, thereby making the upgrade free for the receiver
+     * @param int|string|null $chat_id Required if user_id is not specified. Unique identifier for the chat or username of the channel (in the format &#64;channelusername) that will receive the gift.
      * @return bool|null
      * @see https://core.telegram.org/bots/api#sendgift
      */
@@ -390,9 +391,11 @@ trait Stickers
         ?string $text_parse_mode = null,
         ?array $text_entities = null,
         ?bool $pay_for_upgrade = null,
+        int|string|null $chat_id = null,
     ): ?bool {
         $user_id ??= $this->userId();
-        $parameters = compact('gift_id', 'user_id', 'text', 'text_parse_mode', 'text_entities', 'pay_for_upgrade');
+        $chat_id ??= $this->chatId();
+        $parameters = compact('gift_id', 'user_id', 'text', 'text_parse_mode', 'text_entities', 'pay_for_upgrade', 'chat_id');
         return $this->requestJson(__FUNCTION__, $parameters);
     }
 

--- a/src/Telegram/Properties/TransactionPartnerType.php
+++ b/src/Telegram/Properties/TransactionPartnerType.php
@@ -6,6 +6,7 @@ enum TransactionPartnerType: string
 {
     case FRAGMENT = 'fragment';
     case USER = 'user';
+    case CHAT = 'chat';
     case AFFILIATE_PROGRAM = 'affiliate_program';
     case TELEGRAM_ADS = 'telegram_ads';
     case TELEGRAM_API = 'telegram_api';

--- a/src/Telegram/Types/Chat/Chat.php
+++ b/src/Telegram/Types/Chat/Chat.php
@@ -247,6 +247,12 @@ class Chat extends BaseType
 
     /**
      * Optional.
+     * True, if gifts can be sent to the chat
+     */
+    public ?bool $can_send_gift = null;
+
+    /**
+     * Optional.
      * True, if paid media messages can be sent or forwarded to the channel chat.
      * The field is available only for channel chats.
      */

--- a/src/Telegram/Types/Chat/ChatAdministratorRights.php
+++ b/src/Telegram/Types/Chat/ChatAdministratorRights.php
@@ -155,6 +155,9 @@ class ChatAdministratorRights extends BaseType implements JsonSerializable
             'can_post_messages' => $this->can_post_messages,
             'can_edit_messages' => $this->can_edit_messages,
             'can_pin_messages' => $this->can_pin_messages,
+            'can_post_stories' => $this->can_post_stories,
+            'can_edit_stories' => $this->can_edit_stories,
+            'can_delete_stories' => $this->can_delete_stories,
             'can_manage_topics' => $this->can_manage_topics,
         ]);
     }

--- a/src/Telegram/Types/Inline/InlineQueryResultCachedGif.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultCachedGif.php
@@ -131,9 +131,9 @@ class InlineQueryResultCachedGif extends InlineQueryResult
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,
+            'show_caption_above_media' => $this->show_caption_above_media,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
-            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultCachedMpeg4Gif.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultCachedMpeg4Gif.php
@@ -131,9 +131,9 @@ class InlineQueryResultCachedMpeg4Gif extends InlineQueryResult
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,
+            'show_caption_above_media' => $this->show_caption_above_media,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
-            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultCachedPhoto.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultCachedPhoto.php
@@ -142,9 +142,9 @@ class InlineQueryResultCachedPhoto extends InlineQueryResult
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,
+            'show_caption_above_media' => $this->show_caption_above_media,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
-            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultCachedVideo.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultCachedVideo.php
@@ -139,9 +139,9 @@ class InlineQueryResultCachedVideo extends InlineQueryResult
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,
+            'show_caption_above_media' => $this->show_caption_above_media,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
-            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultContact.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultContact.php
@@ -133,9 +133,9 @@ class InlineQueryResultContact extends InlineQueryResult
             'vcard' => $this->vcard,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
-            'thumb_url' => $this->thumbnail_url,
-            'thumb_width' => $this->thumbnail_width,
-            'thumb_height' => $this->thumbnail_height,
+            'thumbnail_url' => $this->thumbnail_url,
+            'thumbnail_width' => $this->thumbnail_width,
+            'thumbnail_height' => $this->thumbnail_height,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultGif.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultGif.php
@@ -181,15 +181,15 @@ class InlineQueryResultGif extends InlineQueryResult
             'gif_width' => $this->gif_width,
             'gif_height' => $this->gif_height,
             'gif_duration' => $this->gif_duration,
-            'thumb_url' => $this->thumbnail_url,
-            'thumb_mime_type' => $this->thumbnail_mime_type,
+            'thumbnail_url' => $this->thumbnail_url,
+            'thumbnail_mime_type' => $this->thumbnail_mime_type,
             'title' => $this->title,
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,
+            'show_caption_above_media' => $this->show_caption_above_media,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
-            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultLocation.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultLocation.php
@@ -165,9 +165,9 @@ class InlineQueryResultLocation extends InlineQueryResult
             'proximity_alert_radius' => $this->proximity_alert_radius,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
-            'thumb_url' => $this->thumbnail_url,
-            'thumb_width' => $this->thumbnail_width,
-            'thumb_height' => $this->thumbnail_height,
+            'thumbnail_url' => $this->thumbnail_url,
+            'thumbnail_width' => $this->thumbnail_width,
+            'thumbnail_height' => $this->thumbnail_height,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultMpeg4Gif.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultMpeg4Gif.php
@@ -181,15 +181,15 @@ class InlineQueryResultMpeg4Gif extends InlineQueryResult
             'mpeg4_width' => $this->mpeg4_width,
             'mpeg4_height' => $this->mpeg4_height,
             'mpeg4_duration' => $this->mpeg4_duration,
-            'thumb_url' => $this->thumbnail_url,
-            'thumb_mime_type' => $this->thumbnail_mime_type,
+            'thumbnail_url' => $this->thumbnail_url,
+            'thumbnail_mime_type' => $this->thumbnail_mime_type,
             'title' => $this->title,
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,
+            'show_caption_above_media' => $this->show_caption_above_media,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
-            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultPhoto.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultPhoto.php
@@ -168,7 +168,7 @@ class InlineQueryResultPhoto extends InlineQueryResult
             'type' => $this->type,
             'id' => $this->id,
             'photo_url' => $this->photo_url,
-            'thumb_url' => $this->thumbnail_url,
+            'thumbnail_url' => $this->thumbnail_url,
             'photo_width' => $this->photo_width,
             'photo_height' => $this->photo_height,
             'title' => $this->title,
@@ -176,9 +176,9 @@ class InlineQueryResultPhoto extends InlineQueryResult
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,
+            'show_caption_above_media' => $this->show_caption_above_media,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
-            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultVenue.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultVenue.php
@@ -173,9 +173,9 @@ class InlineQueryResultVenue extends InlineQueryResult
             'google_place_type' => $this->google_place_type,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
-            'thumb_url' => $this->thumbnail_url,
-            'thumb_width' => $this->thumbnail_width,
-            'thumb_height' => $this->thumbnail_height,
+            'thumbnail_url' => $this->thumbnail_url,
+            'thumbnail_width' => $this->thumbnail_width,
+            'thumbnail_height' => $this->thumbnail_height,
         ]);
     }
 }

--- a/src/Telegram/Types/Inline/InlineQueryResultVideo.php
+++ b/src/Telegram/Types/Inline/InlineQueryResultVideo.php
@@ -189,9 +189,9 @@ class InlineQueryResultVideo extends InlineQueryResult
             'video_height' => $this->video_height,
             'video_duration' => $this->video_duration,
             'description' => $this->description,
+            'show_caption_above_media' => $this->show_caption_above_media,
             'reply_markup' => $this->reply_markup,
             'input_message_content' => $this->input_message_content,
-            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Input/InputMediaAnimation.php
+++ b/src/Telegram/Types/Input/InputMediaAnimation.php
@@ -140,15 +140,15 @@ class InputMediaAnimation extends InputMedia implements JsonSerializable
         return array_filter_null([
             'type' => $this->type,
             'media' => $this->media,
-            'thumb' => $this->thumbnail,
+            'thumbnail' => $this->thumbnail,
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,
+            'show_caption_above_media' => $this->show_caption_above_media,
             'width' => $this->width,
             'height' => $this->height,
             'duration' => $this->duration,
             'has_spoiler' => $this->has_spoiler,
-            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Input/InputMediaAudio.php
+++ b/src/Telegram/Types/Input/InputMediaAudio.php
@@ -121,7 +121,7 @@ class InputMediaAudio extends InputMedia implements JsonSerializable
         return array_filter_null([
             'type' => $this->type,
             'media' => $this->media,
-            'thumb' => $this->thumbnail,
+            'thumbnail' => $this->thumbnail,
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,

--- a/src/Telegram/Types/Input/InputMediaDocument.php
+++ b/src/Telegram/Types/Input/InputMediaDocument.php
@@ -102,7 +102,7 @@ class InputMediaDocument extends InputMedia implements JsonSerializable
         return array_filter_null([
             'type' => $this->type,
             'media' => $this->media,
-            'thumb' => $this->thumbnail,
+            'thumbnail' => $this->thumbnail,
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,

--- a/src/Telegram/Types/Input/InputMediaPhoto.php
+++ b/src/Telegram/Types/Input/InputMediaPhoto.php
@@ -98,8 +98,8 @@ class InputMediaPhoto extends InputMedia implements JsonSerializable
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,
-            'has_spoiler' => $this->has_spoiler,
             'show_caption_above_media' => $this->show_caption_above_media,
+            'has_spoiler' => $this->has_spoiler,
         ]);
     }
 }

--- a/src/Telegram/Types/Input/InputMediaVideo.php
+++ b/src/Telegram/Types/Input/InputMediaVideo.php
@@ -35,6 +35,22 @@ class InputMediaVideo extends InputMedia implements JsonSerializable
 
     /**
      * Optional.
+     * Cover for the video in the message.
+     * Pass a file_id to send a file that exists on the Telegram servers (recommended),
+     * pass an HTTP URL for Telegram to get a file from the Internet,
+     * or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.
+     * {@see https://core.telegram.org/bots/api#sending-files More information on Sending Files »}
+     */
+    public InputFile|string|null $cover = null;
+
+    /**
+     * Optional.
+     * Start timestamp for the video in the message
+     */
+    public ?int $start_timestamp = null;
+
+    /**
+     * Optional.
      * Caption of the video to be sent, 0-1024 characters after entities parsing
      */
     public ?string $caption = null;
@@ -102,6 +118,8 @@ class InputMediaVideo extends InputMedia implements JsonSerializable
         ?bool $supports_streaming = null,
         ?bool $has_spoiler = null,
         ?bool $show_caption_above_media = null,
+        InputFile|string|null $cover = null,
+        ?int $start_timestamp = null,
     ) {
         parent::__construct();
         $this->media = $media;
@@ -115,6 +133,8 @@ class InputMediaVideo extends InputMedia implements JsonSerializable
         $this->supports_streaming = $supports_streaming;
         $this->has_spoiler = $has_spoiler;
         $this->show_caption_above_media = $show_caption_above_media;
+        $this->cover = $cover;
+        $this->start_timestamp = $start_timestamp;
     }
 
     public static function make(
@@ -129,6 +149,8 @@ class InputMediaVideo extends InputMedia implements JsonSerializable
         ?bool $supports_streaming = null,
         ?bool $has_spoiler = null,
         ?bool $show_caption_above_media = null,
+        InputFile|string|null $cover = null,
+        ?int $start_timestamp = null,
     ): self {
         return new self(
             media: $media,
@@ -142,6 +164,8 @@ class InputMediaVideo extends InputMedia implements JsonSerializable
             supports_streaming: $supports_streaming,
             has_spoiler: $has_spoiler,
             show_caption_above_media: $show_caption_above_media,
+            cover: $cover,
+            start_timestamp: $start_timestamp,
         );
     }
 
@@ -150,15 +174,18 @@ class InputMediaVideo extends InputMedia implements JsonSerializable
         return array_filter_null([
             'type' => $this->type,
             'media' => $this->media,
+            'thumbnail' => $this->thumbnail,
+            'cover' => $this->cover,
+            'start_timestamp' => $this->start_timestamp,
             'caption' => $this->caption,
             'parse_mode' => $this->parse_mode,
             'caption_entities' => $this->caption_entities,
+            'show_caption_above_media' => $this->show_caption_above_media,
             'width' => $this->width,
             'height' => $this->height,
             'duration' => $this->duration,
             'supports_streaming' => $this->supports_streaming,
             'has_spoiler' => $this->has_spoiler,
-            'show_caption_above_media' => $this->show_caption_above_media,
         ]);
     }
 }

--- a/src/Telegram/Types/Input/InputPaidMediaVideo.php
+++ b/src/Telegram/Types/Input/InputPaidMediaVideo.php
@@ -3,12 +3,9 @@
 namespace SergiX44\Nutgram\Telegram\Types\Input;
 
 use JsonSerializable;
-use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Hydrator\Resolver\EnumOrScalar;
 use SergiX44\Nutgram\Telegram\Properties\InputPaidMediaType;
-use SergiX44\Nutgram\Telegram\Properties\ParseMode;
 use SergiX44\Nutgram\Telegram\Types\Internal\InputFile;
-use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
 use function SergiX44\Nutgram\Support\array_filter_null;
 
 /**
@@ -34,6 +31,22 @@ class InputPaidMediaVideo extends InputPaidMedia implements JsonSerializable
      * {@see https://core.telegram.org/bots/api#sending-files More information on Sending Files »}
      */
     public InputFile|string|null $thumbnail = null;
+
+    /**
+     * Optional.
+     * Cover for the video in the message.
+     * Pass a file_id to send a file that exists on the Telegram servers (recommended),
+     * pass an HTTP URL for Telegram to get a file from the Internet,
+     * or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.
+     * {@see https://core.telegram.org/bots/api#sending-files More information on Sending Files »}
+     */
+    public InputFile|string|null $cover = null;
+
+    /**
+     * Optional.
+     * Start timestamp for the video in the message
+     */
+    public ?int $start_timestamp = null;
 
     /**
      * Optional.
@@ -66,6 +79,8 @@ class InputPaidMediaVideo extends InputPaidMedia implements JsonSerializable
         ?int $height = null,
         ?int $duration = null,
         ?bool $supports_streaming = null,
+        InputFile|string|null $cover = null,
+        ?int $start_timestamp = null,
     ) {
         parent::__construct();
         $this->media = $media;
@@ -74,6 +89,8 @@ class InputPaidMediaVideo extends InputPaidMedia implements JsonSerializable
         $this->height = $height;
         $this->duration = $duration;
         $this->supports_streaming = $supports_streaming;
+        $this->cover = $cover;
+        $this->start_timestamp = $start_timestamp;
     }
 
     public static function make(
@@ -83,6 +100,8 @@ class InputPaidMediaVideo extends InputPaidMedia implements JsonSerializable
         ?int $height = null,
         ?int $duration = null,
         ?bool $supports_streaming = null,
+        InputFile|string|null $cover = null,
+        ?int $start_timestamp = null,
     ): self {
         return new self(
             media: $media,
@@ -91,6 +110,8 @@ class InputPaidMediaVideo extends InputPaidMedia implements JsonSerializable
             height: $height,
             duration: $duration,
             supports_streaming: $supports_streaming,
+            cover: $cover,
+            start_timestamp: $start_timestamp,
         );
     }
 
@@ -99,6 +120,9 @@ class InputPaidMediaVideo extends InputPaidMedia implements JsonSerializable
         return array_filter_null([
             'type' => $this->type,
             'media' => $this->media,
+            'thumbnail' => $this->thumbnail,
+            'cover' => $this->cover,
+            'start_timestamp' => $this->start_timestamp,
             'width' => $this->width,
             'height' => $this->height,
             'duration' => $this->duration,

--- a/src/Telegram/Types/Input/InputTextMessageContent.php
+++ b/src/Telegram/Types/Input/InputTextMessageContent.php
@@ -41,7 +41,6 @@ class InputTextMessageContent extends InputMessageContent
 
     /**
      * Optional. Link preview generation options for the message
-     * @var LinkPreviewOptions|null
      */
     public ?LinkPreviewOptions $link_preview_options = null;
 
@@ -79,6 +78,7 @@ class InputTextMessageContent extends InputMessageContent
             'parse_mode' => $this->parse_mode,
             'entities' => $this->entities,
             'disable_web_page_preview' => $this->disable_web_page_preview,
+            'link_preview_options' => $this->link_preview_options,
         ]);
     }
 }

--- a/src/Telegram/Types/Keyboard/InlineKeyboardButton.php
+++ b/src/Telegram/Types/Keyboard/InlineKeyboardButton.php
@@ -150,15 +150,15 @@ class InlineKeyboardButton extends BaseType implements JsonSerializable
         return array_filter_null([
             'text' => $this->text,
             'url' => $this->url,
-            'login_url' => $this->login_url,
             'callback_data' => $this->callback_data,
+            'web_app' => $this->web_app,
+            'login_url' => $this->login_url,
             'switch_inline_query' => $this->switch_inline_query,
             'switch_inline_query_current_chat' => $this->switch_inline_query_current_chat,
             'switch_inline_query_chosen_chat' => $this->switch_inline_query_chosen_chat,
+            'copy_text' => $this->copy_text,
             'callback_game' => $this->callback_game,
             'pay' => $this->pay,
-            'web_app' => $this->web_app,
-            'copy_text' => $this->copy_text,
         ]);
     }
 }

--- a/src/Telegram/Types/Media/Video.php
+++ b/src/Telegram/Types/Media/Video.php
@@ -2,6 +2,7 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Media;
 
+use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Nutgram\Telegram\Types\BaseType;
 use SergiX44\Nutgram\Telegram\Types\Internal\Downloadable;
 
@@ -36,6 +37,20 @@ class Video extends BaseType
      * Video thumbnail
      */
     public ?PhotoSize $thumbnail = null;
+
+    /**
+     * Optional.
+     * Available sizes of the cover of the video in the message
+     * @var PhotoSize[]|null
+     */
+    #[ArrayType(PhotoSize::class)]
+    public ?array $cover = null;
+
+    /**
+     * Optional.
+     * Timestamp in seconds from which the video will play in the message
+     */
+    public ?int $start_timestamp = null;
 
     /**
      * Optional.

--- a/src/Telegram/Types/Payment/TransactionPartner.php
+++ b/src/Telegram/Types/Payment/TransactionPartner.php
@@ -15,6 +15,7 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
  * - {@see TransactionPartnerTelegramAds}
  * - {@see TransactionPartnerTelegramApi}
  * - {@see TransactionPartnerOther}
+ * - {@see TransactionPartnerChat}
  * @see https://core.telegram.org/bots/api#transactionpartner
  */
 #[TransactionPartnerResolver]

--- a/src/Telegram/Types/Payment/TransactionPartnerChat.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerChat.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\TransactionPartnerType;
+use SergiX44\Nutgram\Telegram\Types\Chat\Chat;
+
+/**
+ * Describes a transaction with a chat.
+ * @see https://core.telegram.org/bots/api#transactionpartnerchat
+ */
+class TransactionPartnerChat extends TransactionPartner
+{
+    /**
+     * Type of the transaction partner, always “chat”
+     */
+    #[EnumOrScalar]
+    public TransactionPartnerType|string $type = TransactionPartnerType::CHAT;
+
+    /**
+     * Information about the chat
+     */
+    public Chat $chat;
+
+    /**
+     * Optional. The gift sent to the user by the bot
+     */
+    public ?string $gift = null;
+}

--- a/src/Telegram/Types/Payment/TransactionPartnerResolver.php
+++ b/src/Telegram/Types/Payment/TransactionPartnerResolver.php
@@ -17,7 +17,10 @@ class TransactionPartnerResolver extends ConcreteResolver
         return match ($type) {
             TransactionPartnerType::FRAGMENT->value => TransactionPartnerFragment::class,
             TransactionPartnerType::USER->value => TransactionPartnerUser::class,
+            TransactionPartnerType::CHAT->value => TransactionPartnerChat::class,
+            TransactionPartnerType::AFFILIATE_PROGRAM->value => TransactionPartnerAffiliateProgram::class,
             TransactionPartnerType::TELEGRAM_ADS->value => TransactionPartnerTelegramAds::class,
+            TransactionPartnerType::TELEGRAM_API->value => TransactionPartnerTelegramApi::class,
             TransactionPartnerType::OTHER->value => TransactionPartnerOther::class,
             default => (new class extends TransactionPartner {
             })::class,

--- a/src/Telegram/Types/Reaction/ReactionTypeResolver.php
+++ b/src/Telegram/Types/Reaction/ReactionTypeResolver.php
@@ -17,6 +17,7 @@ class ReactionTypeResolver extends ConcreteResolver
         return match ($type) {
             ReactionTypeType::EMOJI->value => ReactionTypeEmoji::class,
             ReactionTypeType::CUSTOM_EMOJI->value => ReactionTypeCustomEmoji::class,
+            ReactionTypeType::PAID->value => ReactionTypePaid::class,
             default => (new class extends ReactionType {
             })::class,
         };


### PR DESCRIPTION
#### [February 12, 2025](https://core.telegram.org/bots/api#february-12-2025)

**Bot API 8.3**

-   Added the parameter _chat\_id_ to the method [sendGift](https://core.telegram.org/bots/api#copymessage#sendgift), allowing bots to send gifts to channel chats.
-   Added the field _can\_send\_gift_ to the class [ChatFullInfo](https://core.telegram.org/bots/api#copymessage#chatfullinfo).
-   Added the class [TransactionPartnerChat](https://core.telegram.org/bots/api#copymessage#transactionpartnerchat) describing transactions with chats.
-   Added the fields _cover_ and _start\_timestamp_ to the class [Video](https://core.telegram.org/bots/api#copymessage#video), containing a message-specific cover and a start timestamp for the video.
-   Added the parameters _cover_ and _start\_timestamp_ to the method [sendVideo](https://core.telegram.org/bots/api#copymessage#sendvideo), allowing bots to specify a cover and a start timestamp for the videos they send.
-   Added the fields _cover_ and _start\_timestamp_ to the classes [InputMediaVideo](https://core.telegram.org/bots/api#copymessage#inputmediavideo) and [InputPaidMediaVideo](https://core.telegram.org/bots/api#copymessage#inputpaidmediavideo), allowing bots to edit video cover and start timestamp and specify them for videos in albums and paid media.
-   Added the parameter _video\_start\_timestamp_ to the methods [forwardMessage](https://core.telegram.org/bots/api#copymessage#forwardmessage) and [copyMessage](https://core.telegram.org/bots/api#copymessage#copymessage), allowing bots to change the start timestamp for forwarded and copied videos.
-   Allowed to add reactions to most types of service messages.