### PR TITLE
[5.x] Add ClockInterface support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,8 +27,5 @@ ij_php_concat_spaces = false
 [src/Telegram/**.php]
 max_line_length = off
 
-[{*.json,*.yml}]
-indent_size = 2
-
 [tests/Fixtures/**.txt]
 insert_final_newline = false

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "nutgram/hydrator": "^6.0.2",
         "psr/log": "^1.0|^2.0|^3.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
+        "psr/clock": "^1.0",
         "sergix44/container": "^3.0"
     },
     "require-dev": {
@@ -43,29 +44,29 @@
         "roave/security-advisories": "dev-latest",
         "vimeo/psalm": "^6.1.0"
     },
-  "suggest": {
-    "ext-sodium": "To validate WebApp data for Third-Party Use"
-  },
-  "autoload": {
-      "psr-4": {
-        "SergiX44\\Nutgram\\": "src/"
-      },
-      "files": [
-        "src/Support/Helpers.php"
-      ]
+    "suggest": {
+        "ext-sodium": "To validate WebApp data for Third-Party Use"
+    },
+    "autoload": {
+        "psr-4": {
+            "SergiX44\\Nutgram\\": "src/"
+        },
+        "files": [
+            "src/Support/Helpers.php"
+        ]
     },
     "autoload-dev": {
-      "psr-4": {
-        "SergiX44\\Nutgram\\Tests\\": "tests/"
-      },
-      "files": [
-        "src/Support/Helpers.php"
-      ]
+        "psr-4": {
+            "SergiX44\\Nutgram\\Tests\\": "tests/"
+        },
+        "files": [
+            "src/Support/Helpers.php"
+        ]
     },
     "scripts": {
-      "test": "@php vendor/bin/pest --fail-on-warning",
-      "test-coverage": "@php vendor/bin/pest --coverage --coverage-clover=coverage.xml --fail-on-warning",
-      "psalm": "@php vendor/bin/psalm --no-cache --config=psalm.xml"
+        "test": "@php vendor/bin/pest --fail-on-warning",
+        "test-coverage": "@php vendor/bin/pest --coverage --coverage-clover=coverage.xml --fail-on-warning",
+        "psalm": "@php vendor/bin/psalm --no-cache --config=psalm.xml"
     },
     "config": {
         "sort-packages": true,

--- a/src/Cache/Adapters/ArrayCache.php
+++ b/src/Cache/Adapters/ArrayCache.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace SergiX44\Nutgram\Cache\Adapters;
 
 use DateInterval;
+use Psr\Clock\ClockInterface;
 use Psr\SimpleCache\CacheInterface;
 use SergiX44\Nutgram\Support\InteractsWithTime;
+use SergiX44\Nutgram\Support\SystemClock;
 
 /**
  * Class ArrayCache
@@ -18,6 +20,10 @@ class ArrayCache implements CacheInterface
 
     private array $cache = [];
     private array $expires = [];
+
+    public function __construct(protected ClockInterface $clock = new SystemClock())
+    {
+    }
 
     /**
      * @inheritDoc

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -7,6 +7,7 @@ namespace SergiX44\Nutgram;
 use Closure;
 use DateInterval;
 use Laravel\SerializableClosure\SerializableClosure;
+use Psr\Clock\ClockInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -14,6 +15,7 @@ use Psr\SimpleCache\CacheInterface;
 use SergiX44\Hydrator\HydratorInterface;
 use SergiX44\Nutgram\Cache\Adapters\ArrayCache;
 use SergiX44\Nutgram\Hydrator\NutgramHydrator;
+use SergiX44\Nutgram\Support\SystemClock;
 
 final readonly class Configuration
 {
@@ -50,8 +52,8 @@ final readonly class Configuration
         'removed_chat_boost',
     ];
     public const DEFAULT_ENABLE_HTTP2 = true;
-
     public const DEFAULT_CONVERSATION_TTL = 43200;
+    public const DEFAULT_CLOCK = SystemClock::class;
 
     public function __construct(
         public string $apiUrl = self::DEFAULT_API_URL,
@@ -71,6 +73,7 @@ final readonly class Configuration
         public int $pollingLimit = self::DEFAULT_POLLING_LIMIT,
         public bool $enableHttp2 = self::DEFAULT_ENABLE_HTTP2,
         public DateInterval|int|null $conversationTtl = self::DEFAULT_CONVERSATION_TTL,
+        public ClockInterface|string $clock = self::DEFAULT_CLOCK,
         public array $extra = [],
     ) {
     }
@@ -98,6 +101,7 @@ final readonly class Configuration
             conversationTtl: array_key_exists('conversation_ttl', $config)
                 ? $config['conversation_ttl']
                 : self::DEFAULT_CONVERSATION_TTL,
+            clock: $config['clock'] ?? self::DEFAULT_CLOCK,
             extra: $config['extra'] ?? [],
         );
     }
@@ -124,6 +128,7 @@ final readonly class Configuration
                 'allowed_updates' => $this->pollingAllowedUpdates,
             ],
             'conversation_ttl' => $this->conversationTtl,
+            'clock' => $this->clock,
             'extra' => $this->extra,
         ];
     }

--- a/src/Middleware/RateLimit.php
+++ b/src/Middleware/RateLimit.php
@@ -2,6 +2,7 @@
 
 namespace SergiX44\Nutgram\Middleware;
 
+use Psr\Clock\ClockInterface;
 use Psr\SimpleCache\CacheInterface;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Support\RateLimiter;
@@ -42,8 +43,10 @@ class RateLimit
         $key = sprintf("%s:%s.%s", $key, $userId, $chatId);
 
         $cache = $bot->getContainer()->get(CacheInterface::class);
+        $clock = $bot->getContainer()->get(ClockInterface::class);
         $rateLimiter = new RateLimiter(
             cache: $cache,
+            clock: $clock,
             key: $key,
             maxAttempts: $this->maxAttempts,
             decaySeconds: $this->decaySeconds,

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -7,6 +7,7 @@ namespace SergiX44\Nutgram;
 use GuzzleHttp\Client as Guzzle;
 use InvalidArgumentException;
 use Laravel\SerializableClosure\SerializableClosure;
+use Psr\Clock\ClockInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -116,6 +117,7 @@ class Nutgram extends ResolveHandlers
             ...$config->clientOptions,
         ]);
         $this->container->set(ClientInterface::class, $this->http);
+        $this->container->singleton(ClockInterface::class, $config->clock);
         $this->container->singleton(Hydrator::class, $config->hydrator);
         $this->container->singleton(CacheInterface::class, $config->cache);
         $this->container->singleton(LoggerInterface::class, $config->logger);

--- a/src/Support/InteractsWithTime.php
+++ b/src/Support/InteractsWithTime.php
@@ -7,29 +7,15 @@ namespace SergiX44\Nutgram\Support;
 use DateInterval;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Psr\Clock\ClockInterface;
 
 trait InteractsWithTime
 {
-    protected static DateTimeImmutable|null $testNow = null;
-
-    public static function hasTestNow(): bool
-    {
-        return self::$testNow !== null;
-    }
-
-    public static function setTestNow(DateTimeImmutable $now): void
-    {
-        self::$testNow = $now;
-    }
-
-    public static function getTestNow(): DateTimeImmutable|null
-    {
-        return self::$testNow;
-    }
+    protected ClockInterface $clock;
 
     protected function getNow(): DateTimeImmutable
     {
-        return self::getTestNow() ?? new DateTimeImmutable();
+        return $this->clock->now();
     }
 
     protected function expiringAt(DateInterval|int $ttl): DateTimeImmutable

--- a/src/Support/RateLimiter.php
+++ b/src/Support/RateLimiter.php
@@ -2,6 +2,7 @@
 
 namespace SergiX44\Nutgram\Support;
 
+use Psr\Clock\ClockInterface;
 use Psr\SimpleCache\CacheInterface;
 
 class RateLimiter
@@ -15,9 +16,16 @@ class RateLimiter
     protected int $maxAttempts;
     protected int $decaySeconds;
 
-    public function __construct(CacheInterface $cache, string $key, int $maxAttempts, int $decaySeconds = 60)
+    public function __construct(
+        CacheInterface $cache,
+        ClockInterface $clock,
+        string $key,
+        int $maxAttempts,
+        int $decaySeconds = 60
+    )
     {
         $this->cache = $cache;
+        $this->clock = $clock;
         $this->key = sprintf("%s:%s", self::CACHE_KEY, $key);
         $this->maxAttempts = $maxAttempts;
         $this->decaySeconds = $decaySeconds;

--- a/src/Support/SystemClock.php
+++ b/src/Support/SystemClock.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SergiX44\Nutgram\Support;
+
+use DateTimeImmutable;
+use Psr\Clock\ClockInterface;
+
+class SystemClock implements ClockInterface
+{
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+}

--- a/src/Testing/FakeNutgram.php
+++ b/src/Testing/FakeNutgram.php
@@ -103,6 +103,7 @@ class FakeNutgram extends Nutgram
         $c = [
             'client' => ['handler' => $handlerStack, 'base_uri' => ''],
             'api_url' => '',
+            'clock' => TestClock::class,
         ];
 
         if ($config !== null) {

--- a/src/Testing/TestClock.php
+++ b/src/Testing/TestClock.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SergiX44\Nutgram\Testing;
+
+use DateInterval;
+use DateTimeImmutable;
+use InvalidArgumentException;
+use Psr\Clock\ClockInterface;
+use RuntimeException;
+use Throwable;
+
+class TestClock implements ClockInterface
+{
+    protected static DateTimeImmutable|null $testNow = null;
+
+    public function now(): DateTimeImmutable
+    {
+        return self::getFreezedTime() ?? new DateTimeImmutable();
+    }
+
+    public static function isFreezed(): bool
+    {
+        return self::$testNow !== null;
+    }
+
+    public static function getFreezedTime(): DateTimeImmutable|null
+    {
+        return self::$testNow;
+    }
+
+    public static function freeze(DateTimeImmutable|string $datetime = 'now'): void
+    {
+        if (is_string($datetime)) {
+            $datetime = new DateTimeImmutable($datetime);
+        }
+
+        self::$testNow = $datetime;
+    }
+
+    public static function unfreeze(): void
+    {
+        self::$testNow = null;
+    }
+
+    public static function sleep(int $seconds): void
+    {
+        if (!self::isFreezed()) {
+            throw new RuntimeException('Cannot sleep when clock is not freezed');
+        }
+
+        self::freeze(self::getFreezedTime()->add(new DateInterval("PT{$seconds}S")));
+    }
+
+    public static function modify(string $modifier): void
+    {
+        if (!self::isFreezed()) {
+            throw new RuntimeException('Cannot modify when clock is not freezed');
+        }
+
+        if (PHP_VERSION_ID < 80300) {
+            $modified = @self::getFreezedTime()->modify($modifier) ?: throw new InvalidArgumentException(
+                error_get_last()['message'] ?? sprintf('Invalid modifier: "%s". Could not modify MockClock.', $modifier)
+            );
+
+            self::freeze($modified);
+            return;
+        }
+
+        try {
+            self::freeze(self::getFreezedTime()->modify($modifier));
+        } catch (Throwable $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+}

--- a/tests/Feature/ConversationTest.php
+++ b/tests/Feature/ConversationTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use SergiX44\Nutgram\Cache\Adapters\ArrayCache;
 use SergiX44\Nutgram\Configuration;
 use SergiX44\Nutgram\Conversations\Conversation;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\RunningMode\Fake;
+use SergiX44\Nutgram\Testing\TestClock;
 use SergiX44\Nutgram\Tests\Fixtures\Conversations\ConversationEmpty;
 use SergiX44\Nutgram\Tests\Fixtures\Conversations\ConversationWithBeforeStep;
 use SergiX44\Nutgram\Tests\Fixtures\Conversations\ConversationWithClosing;
@@ -306,7 +306,7 @@ it('restarts the conversation with an expired cache', function ($update) {
     $bot->run();
     expect($bot->get('test'))->toBe(1);
 
-    ArrayCache::setTestNow(new DateTimeImmutable('+13 hours'));
+    TestClock::freeze('+13 hours');
 
     $bot->run();
     expect($bot->get('test'))->toBe(1);
@@ -321,7 +321,7 @@ it('works with ttl = null', function ($update) {
     $bot->run();
     expect($bot->get('test'))->toBe(1);
 
-    ArrayCache::setTestNow(new DateTimeImmutable('+100 hours'));
+    TestClock::freeze('+100 hours');
 
     $bot->run();
     expect($bot->get('test'))->toBe(2);
@@ -336,7 +336,7 @@ it('works with ttl as DateInterval', function ($update) {
     $bot->run();
     expect($bot->get('test'))->toBe(1);
 
-    ArrayCache::setTestNow(new DateTimeImmutable('+2 hours'));
+    TestClock::freeze('+2 hours');
 
     $bot->run();
     expect($bot->get('test'))->toBe(2);

--- a/tests/Feature/RateLimitTest.php
+++ b/tests/Feature/RateLimitTest.php
@@ -1,11 +1,10 @@
 <?php
 
-use SergiX44\Nutgram\Cache\Adapters\ArrayCache;
 use SergiX44\Nutgram\Nutgram;
-use SergiX44\Nutgram\Support\RateLimiter;
 use SergiX44\Nutgram\Telegram\Properties\ChatType;
 use SergiX44\Nutgram\Telegram\Types\Chat\Chat;
 use SergiX44\Nutgram\Telegram\Types\User\User;
+use SergiX44\Nutgram\Testing\TestClock;
 
 beforeEach(function () {
     $this->bot = Nutgram::fake();
@@ -33,16 +32,14 @@ it('throttles a handler', function () {
         $bot->sendMessage('Hello!');
     })->throttle(2);
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-01 01:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-01 01:00:00'));
+    TestClock::freeze();
 
     $this->bot->hearText('hi')->reply()->assertReplyText('Hello!');
     $this->bot->hearText('hi')->reply()->assertReplyText('Hello!');
     $this->bot->hearText('hi')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
     $this->bot->hearText('hi')->reply()->assertNoReply();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-01 02:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-01 02:00:00'));
+    TestClock::sleep(60);
 
     $this->bot->hearText('hi')->reply()->assertReplyText('Hello!');
 });
@@ -56,14 +53,12 @@ it('throttles with a custom warning message', function () {
         $bot->sendMessage('Hello!');
     })->throttle(2, warningCallback: $warningCallback);
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-02 01:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-02 01:00:00'));
+    TestClock::freeze();
 
     $this->bot->hearText('hi')->reply()->assertReplyText('Hello!');
     $this->bot->hearText('hi')->reply()->assertReplyText('Hello!');
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-02 01:00:10'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-02 01:00:10'));
+    TestClock::sleep(10);
 
     $this->bot->hearText('hi')->reply()->assertReplyText("You're sending too many messages. Please wait 50 seconds.");
 });
@@ -79,15 +74,18 @@ it('throttles a group', function () {
         });
     })->throttle(2);
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-03 01:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-03 01:00:00'));
+    TestClock::freeze();
 
     $this->bot->hearText('hello')->reply()->assertReplyText('world');
     $this->bot->hearText('foo')->reply()->assertReplyText('bar');
     $this->bot->hearText('hello')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
+    $this->bot->hearText('hello')->reply()->assertNoReply();
+    $this->bot->hearText('foo')->reply()->assertNoReply();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-03 02:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-03 02:00:00'));
+    TestClock::sleep(60);
+
+    $this->bot->hearText('hello')->reply()->assertReplyText('world');
+    $this->bot->hearText('foo')->reply()->assertReplyText('bar');
 });
 
 it('throttles globally', function () {
@@ -101,15 +99,17 @@ it('throttles globally', function () {
         $bot->sendMessage('bar');
     });
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-04 01:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-04 01:00:00'));
+    TestClock::freeze();
 
     $this->bot->hearText('hello')->reply()->assertReplyText('world');
     $this->bot->hearText('foo')->reply()->assertReplyText('bar');
     $this->bot->hearText('foo')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
+    $this->bot->hearText('foo')->reply()->assertNoReply();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-04 02:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-04 02:00:00'));
+    TestClock::sleep(60);
+
+    $this->bot->hearText('hello')->reply()->assertReplyText('world');
+    $this->bot->hearText('foo')->reply()->assertReplyText('bar');
 });
 
 it('throttles hard', function () {
@@ -151,39 +151,54 @@ it('throttles hard', function () {
         })->throttle(2);
     })->throttle(3);
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-05 00:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-05 00:00:00'));
+    TestClock::freeze();
 
     $this->bot->hearText('root_no')->reply()->assertReplyText('This is the root_no command');
     $this->bot->hearText('root_no')->reply()->assertReplyText('This is the root_no command');
     $this->bot->hearText('root_no')->reply()->assertReplyText('This is the root_no command');
     $this->bot->hearText('root_no')->reply()->assertReplyText('This is the root_no command');
     $this->bot->hearText('root_no')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
+    $this->bot->hearText('root_no')->reply()->assertNoReply();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-05 01:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-05 01:00:00'));
+    TestClock::sleep(60);
+
+    $this->bot->hearText('root_no')->reply()->assertReplyText('This is the root_no command');
+
+    // =======================================================
 
     $this->bot->hearText('root_yes')->reply()->assertReplyText('This is the root_yes command');
     $this->bot->hearText('root_yes')->reply()->assertReplyText('This is the root_yes command');
     $this->bot->hearText('root_yes')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
+    $this->bot->hearText('root_yes')->reply()->assertNoReply();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-05 02:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-05 02:00:00'));
+    TestClock::sleep(60);
+
+    $this->bot->hearText('root_yes')->reply()->assertReplyText('This is the root_yes command');
+
+    // =======================================================
 
     $this->bot->hearText('group_no')->reply()->assertReplyText('This is the group_no command');
     $this->bot->hearText('group_no')->reply()->assertReplyText('This is the group_no command');
     $this->bot->hearText('group_no')->reply()->assertReplyText('This is the group_no command');
     $this->bot->hearText('group_no')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
+    $this->bot->hearText('group_no')->reply()->assertNoReply();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-05 03:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-05 03:00:00'));
+    TestClock::sleep(60);
+
+    $this->bot->hearText('group_no')->reply()->assertReplyText('This is the group_no command');
+
+    // =======================================================
 
     $this->bot->hearText('group_yes_lower')->reply()->assertReplyText('This is the group_yes_lower command');
     $this->bot->hearText('group_yes_lower')->reply()->assertReplyText('This is the group_yes_lower command');
     $this->bot->hearText('group_yes_lower')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
+    $this->bot->hearText('group_yes_lower')->reply()->assertNoReply();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-05 04:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-05 04:00:00'));
+    TestClock::sleep(60);
+
+    $this->bot->hearText('group_yes_lower')->reply()->assertReplyText('This is the group_yes_lower command');
+
+    // =======================================================
 
     $this->bot->hearText('group_yes_higher')->reply()->assertReplyText('This is the group_yes_higher command');
     $this->bot->hearText('group_yes_higher')->reply()->assertReplyText('This is the group_yes_higher command');
@@ -191,27 +206,44 @@ it('throttles hard', function () {
     $this->bot->hearText('group_yes_higher')->reply()->assertReplyText('This is the group_yes_higher command');
     $this->bot->hearText('group_yes_higher')->reply()->assertReplyText('This is the group_yes_higher command');
     $this->bot->hearText('group_yes_higher')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
+    $this->bot->hearText('group_yes_higher')->reply()->assertNoReply();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-05 05:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-05 05:00:00'));
+    TestClock::sleep(60);
+
+    $this->bot->hearText('group_yes_higher')->reply()->assertReplyText('This is the group_yes_higher command');
+
+    // =======================================================
 
     $this->bot->hearText('nested_group_no')->reply()->assertReplyText('This is the nested_group_no command');
     $this->bot->hearText('nested_group_no')->reply()->assertReplyText('This is the nested_group_no command');
     $this->bot->hearText('nested_group_no')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
+    $this->bot->hearText('nested_group_no')->reply()->assertNoReply();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-05 06:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-05 06:00:00'));
+    TestClock::sleep(60);
+
+    $this->bot->hearText('nested_group_no')->reply()->assertReplyText('This is the nested_group_no command');
+
+    // =======================================================
 
     $this->bot->hearText('nested_group_yes_lower')->reply()->assertReplyText('This is the nested_group_yes_lower command');
     $this->bot->hearText('nested_group_yes_lower')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
+    $this->bot->hearText('nested_group_yes_lower')->reply()->assertNoReply();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-05 07:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-05 07:00:00'));
+    TestClock::sleep(60);
+
+    $this->bot->hearText('nested_group_yes_lower')->reply()->assertReplyText('This is the nested_group_yes_lower command');
+
+    // =======================================================
 
     $this->bot->hearText('nested_group_yes_higher')->reply()->assertReplyText('This is the nested_group_yes_higher command');
     $this->bot->hearText('nested_group_yes_higher')->reply()->assertReplyText('This is the nested_group_yes_higher command');
     $this->bot->hearText('nested_group_yes_higher')->reply()->assertReplyText('This is the nested_group_yes_higher command');
     $this->bot->hearText('nested_group_yes_higher')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
+    $this->bot->hearText('nested_group_yes_higher')->reply()->assertNoReply();
+
+    TestClock::sleep(60);
+
+    $this->bot->hearText('nested_group_yes_higher')->reply()->assertReplyText('This is the nested_group_yes_higher command');
 });
 
 it('does not throttle if the user or chat is not set', function ($update) {
@@ -250,28 +282,23 @@ it('does not throttle with withoutThrottle method', function () {
         })->throttle(1);
     })->withoutThrottle();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-06 01:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-06 01:00:00'));
+    TestClock::freeze();
 
     $this->bot->hearText('yes')->reply()->assertReplyText('yes');
     $this->bot->hearText('yes')->reply()->assertReplyText('Too many messages, please wait a bit. This message will only be sent once until the rate limit is reset.');
+    $this->bot->hearText('yes')->reply()->assertNoReply();
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-06 02:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-06 02:00:00'));
+    TestClock::sleep(60);
+
+    $this->bot->hearText('yes')->reply()->assertReplyText('yes');
 
     $this->bot->hearText('no')->reply()->assertReplyText('no');
     $this->bot->hearText('no')->reply()->assertReplyText('no');
     $this->bot->hearText('no')->reply()->assertReplyText('no');
 
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-06 03:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-06 03:00:00'));
-
     $this->bot->hearText('maybe')->reply()->assertReplyText('maybe');
     $this->bot->hearText('maybe')->reply()->assertReplyText('maybe');
     $this->bot->hearText('maybe')->reply()->assertReplyText('maybe');
-
-    ArrayCache::setTestNow(new DateTimeImmutable('2025-01-06 04:00:00'));
-    RateLimiter::setTestNow(new DateTimeImmutable('2025-01-06 04:00:00'));
 
     $this->bot->hearText('lol')->reply()->assertReplyText('lol');
     $this->bot->hearText('lol')->reply()->assertReplyText('lol');


### PR DESCRIPTION
This pull request introduces the use of the `ClockInterface` from the PSR standard to improve time handling across various components of the project. It includes changes to the configuration, caching, middleware, and testing to support this new interface.