### PR TITLE
Fix incorrect @param type in docblock

### DIFF
--- a/src/Cache/Adapters/ArrayCache.php
+++ b/src/Cache/Adapters/ArrayCache.php
@@ -75,7 +75,7 @@ class ArrayCache implements CacheInterface
      * @param  mixed  $default
      * @return array
      */
-    public function getMultiple($keys, mixed $default = null): array
+    public function getMultiple($keys, $default = null): array
     {
         $values = [];
 

--- a/src/Cache/Adapters/ArrayCache.php
+++ b/src/Cache/Adapters/ArrayCache.php
@@ -72,10 +72,10 @@ class ArrayCache implements CacheInterface
 
     /**
      * @param  iterable  $keys
-     * @param  null  $default
+     * @param  mixed  $default
      * @return array
      */
-    public function getMultiple($keys, $default = null): array
+    public function getMultiple($keys, mixed $default = null): array
     {
         $values = [];
 

--- a/src/Cache/UserCache.php
+++ b/src/Cache/UserCache.php
@@ -19,11 +19,11 @@ class UserCache extends BotCache
     /**
      * @param  int  $userId
      * @param  string  $key
-     * @param  null  $default
+     * @param  mixed  $default
      * @return mixed
      * @throws InvalidArgumentException
      */
-    public function get(int $userId, string $key, $default = null): mixed
+    public function get(int $userId, string $key, mixed $default = null): mixed
     {
         return $this->cache->get($this->makeKey($userId, $key), $default);
     }

--- a/src/Cache/UserCache.php
+++ b/src/Cache/UserCache.php
@@ -23,7 +23,7 @@ class UserCache extends BotCache
      * @return mixed
      * @throws InvalidArgumentException
      */
-    public function get(int $userId, string $key, mixed $default = null): mixed
+    public function get(int $userId, string $key, $default = null): mixed
     {
         return $this->cache->get($this->makeKey($userId, $key), $default);
     }

--- a/src/Proxies/GlobalCacheProxy.php
+++ b/src/Proxies/GlobalCacheProxy.php
@@ -18,7 +18,7 @@ trait GlobalCacheProxy
      * @return mixed
      * @throws InvalidArgumentException
      */
-    public function getGlobalData($key, mixed $default = null): mixed
+    public function getGlobalData($key, $default = null): mixed
     {
         return $this->globalCache->get($key, $default);
     }

--- a/src/Proxies/GlobalCacheProxy.php
+++ b/src/Proxies/GlobalCacheProxy.php
@@ -14,11 +14,11 @@ trait GlobalCacheProxy
 {
     /**
      * @param  $key
-     * @param  null  $default
+     * @param  mixed  $default
      * @return mixed
      * @throws InvalidArgumentException
      */
-    public function getGlobalData($key, $default = null): mixed
+    public function getGlobalData($key, mixed $default = null): mixed
     {
         return $this->globalCache->get($key, $default);
     }

--- a/src/Proxies/UserCacheProxy.php
+++ b/src/Proxies/UserCacheProxy.php
@@ -15,11 +15,11 @@ trait UserCacheProxy
     /**
      * @param  $key
      * @param  int|null  $userId
-     * @param  null  $default
+     * @param  mixed  $default
      * @return mixed
      * @throws InvalidArgumentException
      */
-    public function getUserData($key, ?int $userId = null, $default = null): mixed
+    public function getUserData($key, ?int $userId = null, mixed $default = null): mixed
     {
         $userId = $userId ?? $this->userId();
         return $this->userCache->get($userId, $key, $default);

--- a/src/Proxies/UserCacheProxy.php
+++ b/src/Proxies/UserCacheProxy.php
@@ -19,7 +19,7 @@ trait UserCacheProxy
      * @return mixed
      * @throws InvalidArgumentException
      */
-    public function getUserData($key, ?int $userId = null, mixed $default = null): mixed
+    public function getUserData($key, ?int $userId = null, $default = null): mixed
     {
         $userId = $userId ?? $this->userId();
         return $this->userCache->get($userId, $key, $default);


### PR DESCRIPTION
This PR fixes the issue in some cache files where the docblock incorrectly listed `@param null $default` which has been corrected to `mixed`.

Changes made:

- Fixed incorrect `@param` type for $default.

No breaking changes are expected.