### PR TITLE
Update to Bot API 9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://i.imgur.com/yrd8jr2.png" width="400px">
 </p>
 
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-9.0%09--%20April%2011,%202025-28a8ea.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-9.1%09--%20July%2011,%202025-28a8ea.svg?logo=telegram)](https://core.telegram.org/bots/api)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nutgram/nutgram.svg?label=composer&logo=composer)](https://packagist.org/packages/nutgram/nutgram)
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 ![License](https://img.shields.io/github/license/nutgram/nutgram)
@@ -105,11 +105,14 @@ Official Documentation on [https://nutgram.dev/](https://nutgram.dev)
 
 - AnonyMeet ([@AnonyMeetBot](https://t.me/AnonyMeetBot)) - Anonymous chat bot
 - File Converter ([@newfileconverterbot](https://t.me/newfileconverterbot)) - Convert files to other formats
-- [Sticker Optimizer](https://github.com/Lukasss93/telegram-stickeroptimizer) ([@NewStickerOptimizerBot](https://t.me/NewStickerOptimizerBot)) - Optimize images for the @stickers bot
+- [Sticker Optimizer](https://github.com/Lukasss93/telegram-stickeroptimizer) ([@NewStickerOptimizerBot](https://t.me/NewStickerOptimizerBot)) -
+  Optimize images for the @stickers bot
 - Stickerizer ([@StickerizerBot](https://t.me/StickerizerBot)) - Create stickers on the fly, via Telegram Mini App.
-- [Mermaid Generator](https://github.com/Lukasss93/telegram-mermaid) ([@newmermaidbot](https://t.me/newmermaidbot)) - Generate mermaid diagrams from text
+- [Mermaid Generator](https://github.com/Lukasss93/telegram-mermaid) ([@newmermaidbot](https://t.me/newmermaidbot)) -
+  Generate mermaid diagrams from text
 - Voice Transcriber ([@voicetranscriberobot](https://t.me/voicetranscriberobot)) - Transcribe audio messages to text
-- Effin Birds ([@effinbirdsbot](https://t.me/effinbirdsbot)) - Search and send in inline mode images made by https://twitter.com/EffinBirds
+- Effin Birds ([@effinbirdsbot](https://t.me/effinbirdsbot)) - Search and send in inline mode images made
+  by https://twitter.com/EffinBirds
 - Resizer Image ([@ResizerTool_bot](https://t.me/ResizerTool_bot))] - Resize an image easily
 
 ## ⚗️ Testing

--- a/src/Handlers/Listeners/MessageListeners.php
+++ b/src/Handlers/Listeners/MessageListeners.php
@@ -15,7 +15,7 @@ use SergiX44\Nutgram\Telegram\Properties\UpdateType;
 trait MessageListeners
 {
     /**
-     * @param  string  $command
+     * @param string $command
      * @param $callable
      * @return Command
      */
@@ -30,7 +30,7 @@ trait MessageListeners
     }
 
     /**
-     * @param  string|Command  $command
+     * @param string|Command $command
      * @return Command
      */
     public function registerCommand(string|Command $command, UpdateType $target = UpdateType::MESSAGE): Command
@@ -39,7 +39,8 @@ trait MessageListeners
         $target->validateMessageType();
         if (is_string($command)) {
             if (!is_subclass_of($command, Command::class)) {
-                throw new InvalidArgumentException(sprintf('You must provide subclass of the %s class or an instance.', Command::class));
+                throw new InvalidArgumentException(sprintf('You must provide subclass of the %s class or an instance.',
+                    Command::class));
             }
             $command = new $command();
         }
@@ -48,7 +49,7 @@ trait MessageListeners
     }
 
     /**
-     * @param  string  $pattern
+     * @param string $pattern
      * @param $callable
      * @return Handler
      */
@@ -371,7 +372,7 @@ trait MessageListeners
     }
 
     /**
-     * @param  string  $pattern
+     * @param string $pattern
      * @param $callable
      * @return Handler
      */
@@ -462,6 +463,12 @@ trait MessageListeners
     {
         $this->checkFinalized();
         return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::BOOST_ADDED->value][] = new Handler($callable);
+    }
+
+    public function onDirectMessagePriceChanged($callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::DIRECT_MESSAGE_PRICE_CHANGED->value][] = new Handler($callable);
     }
 
     /**

--- a/src/Handlers/Listeners/MessageListeners.php
+++ b/src/Handlers/Listeners/MessageListeners.php
@@ -471,6 +471,24 @@ trait MessageListeners
         return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::DIRECT_MESSAGE_PRICE_CHANGED->value][] = new Handler($callable);
     }
 
+    public function onChecklist($callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::CHECKLIST->value][] = new Handler($callable);
+    }
+
+    public function onChecklistTasksDone($callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::CHECKLIST_TASKS_DONE->value][] = new Handler($callable);
+    }
+
+    public function onChecklistTasksAdded($callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::CHECKLIST_TASKS_ADDED->value][] = new Handler($callable);
+    }
+
     /**
      * @param $callable
      * @return Handler

--- a/src/Proxies/UpdateProxy.php
+++ b/src/Proxies/UpdateProxy.php
@@ -11,6 +11,7 @@ use SergiX44\Nutgram\Telegram\Types\Business\BusinessMessagesDeleted;
 use SergiX44\Nutgram\Telegram\Types\Chat\Chat;
 use SergiX44\Nutgram\Telegram\Types\Chat\ChatJoinRequest;
 use SergiX44\Nutgram\Telegram\Types\Chat\ChatMemberUpdated;
+use SergiX44\Nutgram\Telegram\Types\Checklist\Checklist;
 use SergiX44\Nutgram\Telegram\Types\Common\Update;
 use SergiX44\Nutgram\Telegram\Types\Inline\CallbackQuery;
 use SergiX44\Nutgram\Telegram\Types\Inline\ChosenInlineResult;
@@ -223,5 +224,12 @@ trait UpdateProxy
     public function removedChatBoost(): ?ChatBoostRemoved
     {
         return $this->update?->removed_chat_boost;
+    }
+
+    public function checklist(): ?Checklist
+    {
+        return $this->message()?->checklist
+            ?? $this->message()?->checklist_tasks_done?->checklist_message?->checklist
+            ?? $this->message()?->checklist_tasks_added?->checklist_message?->checklist;
     }
 }

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -15,6 +15,7 @@ use SergiX44\Nutgram\Telegram\Types\Chat\ChatAdministratorRights;
 use SergiX44\Nutgram\Telegram\Types\Chat\ChatInviteLink;
 use SergiX44\Nutgram\Telegram\Types\Chat\ChatMember;
 use SergiX44\Nutgram\Telegram\Types\Chat\ChatPermissions;
+use SergiX44\Nutgram\Telegram\Types\Checklist\InputChecklist;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommand;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScope;
 use SergiX44\Nutgram\Telegram\Types\Command\MenuButton;
@@ -44,6 +45,7 @@ use SergiX44\Nutgram\Telegram\Types\Reaction\ReactionType;
 use SergiX44\Nutgram\Telegram\Types\Sticker\Sticker;
 use SergiX44\Nutgram\Telegram\Types\User\User;
 use SergiX44\Nutgram\Telegram\Types\User\UserProfilePhotos;
+use function SergiX44\Nutgram\Support\array_filter_null;
 
 /**
  * Trait AvailableMethods
@@ -1283,6 +1285,40 @@ trait AvailableMethods
             'options' => json_encode($options, JSON_THROW_ON_ERROR),
             ...$parameters,
         ], Message::class);
+    }
+
+    /**
+     * Use this method to send a checklist on behalf of a connected business account. On success, the sent Message is returned.
+     * @see https://core.telegram.org/bots/api#sendchecklist
+     * @param InputChecklist $checklist A JSON-serialized object for the checklist to send
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param int|null $chat_id Unique identifier for the target chat
+     * @param bool|null $disable_notification Sends the message silently. Users will receive a notification with no sound.
+     * @param bool|null $protect_content Protects the contents of the sent message from forwarding and saving
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message
+     * @param ReplyParameters|null $reply_parameters A JSON-serialized object for description of the message to reply to
+     * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an inline keyboard
+     * @return Message|null
+     */
+    public function sendChecklist(
+        InputChecklist $checklist,
+        ?string $business_connection_id = null,
+        ?int $chat_id = null,
+        ?bool $disable_notification = null,
+        ?bool $protect_content = null,
+        ?string $message_effect_id = null,
+        ?ReplyParameters $reply_parameters = null,
+        ?InlineKeyboardMarkup $reply_markup = null,
+    ): ?Message {
+        $chat_id ??= $this->chatId();
+        $business_connection_id ??= $this->businessConnectionId();
+        $parameters = compact('checklist', 'business_connection_id', 'chat_id', 'disable_notification', 'protect_content', 'message_effect_id', 'reply_parameters', 'reply_markup');
+        return $this->requestJson(__FUNCTION__, array_filter_null([
+            'checklist' => json_encode($checklist),
+            'reply_parameters' => $reply_parameters !== null ? json_encode($reply_parameters) : null,
+            'reply_markup' => $reply_markup !== null ? json_encode($reply_markup) : null,
+            ...$parameters,
+        ]), Message::class);
     }
 
     /**

--- a/src/Telegram/Endpoints/Payments.php
+++ b/src/Telegram/Endpoints/Payments.php
@@ -8,6 +8,7 @@ use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\Message\ReplyParameters;
 use SergiX44\Nutgram\Telegram\Types\Payment\LabeledPrice;
 use SergiX44\Nutgram\Telegram\Types\Payment\ShippingOption;
+use SergiX44\Nutgram\Telegram\Types\Payment\StarAmount;
 use SergiX44\Nutgram\Telegram\Types\Payment\StarTransactions;
 
 /**
@@ -248,6 +249,18 @@ trait Payments
         $parameters = compact('pre_checkout_query_id', 'ok', 'error_message');
 
         return $this->requestJson(__FUNCTION__, $parameters);
+    }
+
+    /**
+     * A method to get the current Telegram Stars balance of the bot.
+     * Requires no parameters.
+     * On success, returns a StarAmount object.
+     * @see https://core.telegram.org/bots/api#getmystarbalance
+     * @return StarAmount|null
+     */
+    public function getMyStarBalance(): ?StarAmount
+    {
+        return $this->requestJson(__FUNCTION__, mapTo: StarAmount::class);
     }
 
     /**

--- a/src/Telegram/Endpoints/UpdatesMessages.php
+++ b/src/Telegram/Endpoints/UpdatesMessages.php
@@ -4,6 +4,7 @@ namespace SergiX44\Nutgram\Telegram\Endpoints;
 
 use SergiX44\Nutgram\Telegram\Client;
 use SergiX44\Nutgram\Telegram\Properties\ParseMode;
+use SergiX44\Nutgram\Telegram\Types\Checklist\InputChecklist;
 use SergiX44\Nutgram\Telegram\Types\Input\InputMedia;
 use SergiX44\Nutgram\Telegram\Types\Input\InputProfilePhoto;
 use SergiX44\Nutgram\Telegram\Types\Input\InputStoryContent;
@@ -17,6 +18,7 @@ use SergiX44\Nutgram\Telegram\Types\Poll\Poll;
 use SergiX44\Nutgram\Telegram\Types\Sticker\AcceptedGiftTypes;
 use SergiX44\Nutgram\Telegram\Types\Sticker\OwnedGifts;
 use SergiX44\Nutgram\Telegram\Types\Story\StoryArea;
+use function SergiX44\Nutgram\Support\array_filter_null;
 
 /**
  * Trait UpdatesMessages
@@ -197,6 +199,34 @@ trait UpdatesMessages
 
         $this->setChatMessageOrInlineMessageId($parameters);
         return $this->requestJson(__FUNCTION__, $parameters, Message::class);
+    }
+
+    /**
+     * Use this method to edit a checklist on behalf of a connected business account. On success, the edited Message is returned.
+     * @see https://core.telegram.org/bots/api#editmessagechecklist
+     * @param InputChecklist|null $checklist A JSON-serialized object for the new checklist
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param int|null $chat_id Unique identifier for the target chat
+     * @param int|null $message_id Unique identifier for the target message
+     * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for the new inline keyboard for the message
+     * @return Message|null
+     */
+    public function editMessageChecklist(
+        InputChecklist $checklist = null,
+        ?string $business_connection_id = null,
+        ?int $chat_id = null,
+        ?int $message_id = null,
+        ?InlineKeyboardMarkup $reply_markup = null,
+    ): ?Message {
+        $business_connection_id ??= $this->businessConnectionId();
+        $chat_id ??= $this->chatId();
+        $message_id ??= $this->messageId();
+        $parameters = compact('checklist', 'business_connection_id', 'chat_id', 'message_id', 'reply_markup');
+        return $this->requestJson(__FUNCTION__, array_filter_null([
+            'checklist' => json_encode($checklist),
+            'reply_markup' => $reply_markup !== null ? json_encode($reply_markup) : null,
+            ...$parameters,
+        ]), Message::class);
     }
 
     /**

--- a/src/Telegram/Properties/MessageType.php
+++ b/src/Telegram/Properties/MessageType.php
@@ -13,6 +13,7 @@ enum MessageType: string
     case VIDEO = 'video';
     case VIDEO_NOTE = 'video_note';
     case VOICE = 'voice';
+    case CHECKLIST = 'checklist';
     case CONTACT = 'contact';
     case DICE = 'dice';
     case GAME = 'game';
@@ -43,6 +44,9 @@ enum MessageType: string
     case PASSPORT_DATA = 'passport_data';
     case PROXIMITY_ALERT_TRIGGERED = 'proximity_alert_triggered';
     case BOOST_ADDED = 'boost_added';
+    case CHECKLIST_TASKS_DONE = 'checklist_tasks_done';
+    case CHECKLIST_TASKS_ADDED = 'checklist_tasks_added';
+    case DIRECT_MESSAGE_PRICE_CHANGED = 'direct_message_price_changed';
     case FORUM_TOPIC_CREATED = 'forum_topic_created';
     case FORUM_TOPIC_EDITED = 'forum_topic_edited';
     case FORUM_TOPIC_CLOSED = 'forum_topic_closed';

--- a/src/Telegram/Types/Checklist/Checklist.php
+++ b/src/Telegram/Types/Checklist/Checklist.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Checklist;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
+
+/**
+ * Describes a checklist.
+ * @see https://core.telegram.org/bots/api#checklist
+ */
+class Checklist extends BaseType
+{
+    /**
+     * Title of the checklist
+     */
+    public string $title;
+
+    /**
+     * Optional. Special entities that appear in the checklist title
+     * @var MessageEntity[]|null
+     */
+    #[ArrayType(MessageEntity::class)]
+    public ?array $title_entities = null;
+
+    /**
+     * List of tasks in the checklist
+     * @var ChecklistTask[]
+     */
+    #[ArrayType(ChecklistTask::class)]
+    public array $tasks;
+
+    /**
+     * Optional. True, if users other than the creator of the list can add tasks to the list
+     */
+    public ?bool $others_can_add_tasks = null;
+
+    /**
+     * Optional. True, if users other than the creator of the list can mark tasks as done or not done
+     */
+    public ?bool $others_can_mark_tasks_as_done = null;
+}

--- a/src/Telegram/Types/Checklist/ChecklistTask.php
+++ b/src/Telegram/Types/Checklist/ChecklistTask.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Checklist;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
+use SergiX44\Nutgram\Telegram\Types\User\User;
+
+/**
+ * Describes a task in a checklist.
+ * @see https://core.telegram.org/bots/api#checklisttask
+ */
+class ChecklistTask extends BaseType
+{
+    /**
+     * Unique identifier of the task
+     */
+    public int $id;
+
+    /**
+     * Text of the task
+     */
+    public string $text;
+
+    /**
+     * Optional. Special entities that appear in the task text
+     * @var MessageEntity[]|null
+     */
+    #[ArrayType(MessageEntity::class)]
+    public ?array $text_entities = null;
+
+    /**
+     * Optional. User that completed the task; omitted if the task wasn't completed
+     */
+    public ?User $completed_by_user = null;
+
+    /**
+     * Optional. Point in time (Unix timestamp) when the task was completed; 0 if the task wasn't completed
+     */
+    public ?int $completion_date = null;
+}

--- a/src/Telegram/Types/Checklist/ChecklistTasksAdded.php
+++ b/src/Telegram/Types/Checklist/ChecklistTasksAdded.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Checklist;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Message\Message;
+
+class ChecklistTasksAdded extends BaseType
+{
+    /**
+     * Optional. Message containing the checklist to which the tasks were added.
+     * Note that the Message object in this field will not contain the reply_to_message field even if it itself is a reply.
+     */
+    public ?Message $checklist_message = null;
+
+    /**
+     * List of tasks added to the checklist
+     * @var ChecklistTask[]
+     */
+    #[ArrayType(ChecklistTask::class)]
+    public array $tasks;
+}

--- a/src/Telegram/Types/Checklist/ChecklistTasksDone.php
+++ b/src/Telegram/Types/Checklist/ChecklistTasksDone.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Checklist;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Message\Message;
+
+/**
+ * Describes a service message about checklist tasks marked as done or not done.
+ * @see https://core.telegram.org/bots/api#checklisttasksdone
+ */
+class ChecklistTasksDone extends BaseType
+{
+
+    /**
+     * Optional. Message containing the checklist whose tasks were marked as done or not done.
+     * Note that the Message object in this field will not contain the reply_to_message field even if it itself is a reply.
+     */
+    public ?Message $checklist_message = null;
+
+    /**
+     * Optional. Identifiers of the tasks that were marked as done
+     * @var int[]|null
+     */
+    public ?array $marked_as_done_task_ids = null;
+
+    /**
+     * Optional. Identifiers of the tasks that were marked as not done
+     * @var int[]|null
+     */
+    public ?array $marked_as_not_done_task_ids = null;
+}

--- a/src/Telegram/Types/Checklist/InputChecklist.php
+++ b/src/Telegram/Types/Checklist/InputChecklist.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Checklist;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\ParseMode;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
+
+/**
+ * Describes a checklist to create.
+ * @see https://core.telegram.org/bots/api#inputchecklist
+ */
+class InputChecklist extends BaseType
+{
+    /**
+     * Title of the checklist; 1-255 characters after entities parsing
+     */
+    public string $title;
+
+    /**
+     * Optional. Mode for parsing entities in the text.
+     * See {@see https://core.telegram.org/bots/api#formatting-options formatting options} for more details.
+     */
+    #[EnumOrScalar]
+    public ParseMode|string|null $parse_mode = null;
+
+    /**
+     * Optional. Special entities that appear in the checklist title
+     * @var MessageEntity[]|null
+     */
+    #[ArrayType(MessageEntity::class)]
+    public ?array $title_entities = null;
+
+    /**
+     * List of 1-30 tasks in the checklist
+     * @var InputChecklistTask[]
+     */
+    #[ArrayType(InputChecklistTask::class)]
+    public array $tasks;
+
+    /**
+     * Optional. Pass True if other users can add tasks to the checklist
+     */
+    public ?bool $others_can_add_tasks = null;
+
+    /**
+     * Optional. Pass True if other users can mark tasks as done or not done in the checklist
+     */
+    public ?bool $others_can_mark_tasks_as_done = null;
+
+    /**
+     * @param string $title
+     * @param InputChecklistTask[] $tasks
+     * @param ParseMode|string|null $parse_mode
+     * @param MessageEntity[]|null $title_entities
+     * @param bool|null $others_can_add_tasks
+     * @param bool|null $others_can_mark_tasks_as_done
+     */
+    public function __construct(
+        string $title,
+        array $tasks,
+        ParseMode|string|null $parse_mode = null,
+        ?array $title_entities = null,
+        ?bool $others_can_add_tasks = null,
+        ?bool $others_can_mark_tasks_as_done = null
+    ) {
+        parent::__construct();
+        $this->title = $title;
+        $this->tasks = $tasks;
+        $this->parse_mode = $parse_mode;
+        $this->title_entities = $title_entities;
+        $this->others_can_add_tasks = $others_can_add_tasks;
+        $this->others_can_mark_tasks_as_done = $others_can_mark_tasks_as_done;
+    }
+}

--- a/src/Telegram/Types/Checklist/InputChecklistTask.php
+++ b/src/Telegram/Types/Checklist/InputChecklistTask.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Checklist;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\ParseMode;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
+
+/**
+ * Describes a task to add to a checklist.
+ * @see https://core.telegram.org/bots/api#inputchecklisttask
+ */
+class InputChecklistTask extends BaseType
+{
+    /**
+     * Unique identifier of the task; must be positive and unique among all task identifiers currently present in the checklist
+     */
+    public int $id;
+
+    /**
+     * Text of the task; 1-100 characters after entities parsing
+     */
+    public string $text;
+
+    /**
+     * Optional. Mode for parsing entities in the text.
+     * See {@see https://core.telegram.org/bots/api#formatting-options formatting options} for more details.
+     */
+    #[EnumOrScalar]
+    public ParseMode|string|null $parse_mode = null;
+
+    /**
+     * Optional. Special entities that appear in the task text
+     * @var MessageEntity[]|null
+     */
+    #[ArrayType(MessageEntity::class)]
+    public ?array $text_entities = null;
+
+    /**
+     * @param int $id
+     * @param string $text
+     * @param ParseMode|string|null $parse_mode
+     * @param MessageEntity[]|null $text_entities
+     */
+    public function __construct(
+        int $id,
+        string $text,
+        ParseMode|string|null $parse_mode = null,
+        ?array $text_entities = null,
+    ) {
+        parent::__construct();
+        $this->id = $id;
+        $this->text = $text;
+        $this->parse_mode = $parse_mode;
+        $this->text_entities = $text_entities;
+    }
+}

--- a/src/Telegram/Types/Keyboard/ExternalReplyInfo.php
+++ b/src/Telegram/Types/Keyboard/ExternalReplyInfo.php
@@ -5,6 +5,7 @@ namespace SergiX44\Nutgram\Telegram\Types\Keyboard;
 use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Nutgram\Telegram\Types\BaseType;
 use SergiX44\Nutgram\Telegram\Types\Chat\Chat;
+use SergiX44\Nutgram\Telegram\Types\Checklist\Checklist;
 use SergiX44\Nutgram\Telegram\Types\Game\Game;
 use SergiX44\Nutgram\Telegram\Types\Giveaway\Giveaway;
 use SergiX44\Nutgram\Telegram\Types\Giveaway\GiveawayWinners;
@@ -122,6 +123,11 @@ class ExternalReplyInfo extends BaseType
      * @var bool|null
      */
     public ?bool $has_media_spoiler = null;
+
+    /**
+     * Optional. Message is a checklist
+     */
+    public ?Checklist $checklist = null;
 
     /**
      * Optional. Message is a shared contact, information about the contact

--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -8,6 +8,9 @@ use SergiX44\Nutgram\Telegram\Properties\ParseMode;
 use SergiX44\Nutgram\Telegram\Types\BaseType;
 use SergiX44\Nutgram\Telegram\Types\Boost\ChatBoostAdded;
 use SergiX44\Nutgram\Telegram\Types\Chat\Chat;
+use SergiX44\Nutgram\Telegram\Types\Checklist\Checklist;
+use SergiX44\Nutgram\Telegram\Types\Checklist\ChecklistTasksAdded;
+use SergiX44\Nutgram\Telegram\Types\Checklist\ChecklistTasksDone;
 use SergiX44\Nutgram\Telegram\Types\Forum\ForumTopicClosed;
 use SergiX44\Nutgram\Telegram\Types\Forum\ForumTopicCreated;
 use SergiX44\Nutgram\Telegram\Types\Forum\ForumTopicEdited;
@@ -39,6 +42,7 @@ use SergiX44\Nutgram\Telegram\Types\Media\Video;
 use SergiX44\Nutgram\Telegram\Types\Media\VideoNote;
 use SergiX44\Nutgram\Telegram\Types\Media\Voice;
 use SergiX44\Nutgram\Telegram\Types\Passport\PassportData;
+use SergiX44\Nutgram\Telegram\Types\Payment\DirectMessagePriceChanged;
 use SergiX44\Nutgram\Telegram\Types\Payment\Invoice;
 use SergiX44\Nutgram\Telegram\Types\Payment\PaidMediaInfo;
 use SergiX44\Nutgram\Telegram\Types\Payment\PaidMessagePriceChanged;
@@ -352,6 +356,10 @@ class Message extends BaseType
     public ?bool $has_media_spoiler = null;
 
     /**
+     * Optional. Message is a checklist
+     */
+    public ?Checklist $checklist = null;
+    /**
      * Optional.
      * Message is a shared contact, information about the contact
      */
@@ -556,6 +564,22 @@ class Message extends BaseType
     public ?ChatBackground $chat_background_set = null;
 
     /**
+     * Optional. Service message: some tasks in a checklist were marked as done or not done
+     */
+    public ?ChecklistTasksDone $checklist_tasks_done = null;
+
+    /**
+     * Optional. Service message: tasks were added to a checklist
+     */
+    public ?ChecklistTasksAdded $checklist_tasks_added = null;
+
+    /**
+     * Optional.
+     * Service message: the price for paid messages in the corresponding direct messages chat of a channel has changed
+     */
+    public ?DirectMessagePriceChanged $direct_message_price_changed = null;
+
+    /**
      * Optional.
      * Service message: forum topic created
      */
@@ -697,6 +721,7 @@ class Message extends BaseType
             $this->video !== null => MessageType::VIDEO,
             $this->voice !== null => MessageType::VOICE,
             $this->video_note !== null => MessageType::VIDEO_NOTE,
+            $this->checklist !== null => MessageType::CHECKLIST,
             $this->contact !== null => MessageType::CONTACT,
             $this->venue !== null => MessageType::VENUE,
             $this->location !== null => MessageType::LOCATION,
@@ -726,6 +751,9 @@ class Message extends BaseType
             $this->passport_data !== null => MessageType::PASSPORT_DATA,
             $this->proximity_alert_triggered !== null => MessageType::PROXIMITY_ALERT_TRIGGERED,
             $this->boost_added !== null => MessageType::BOOST_ADDED,
+            $this->checklist_tasks_done !== null => MessageType::CHECKLIST_TASKS_DONE,
+            $this->checklist_tasks_added !== null => MessageType::CHECKLIST_TASKS_ADDED,
+            $this->direct_message_price_changed !== null => MessageType::DIRECT_MESSAGE_PRICE_CHANGED,
             $this->forum_topic_created !== null => MessageType::FORUM_TOPIC_CREATED,
             $this->forum_topic_edited !== null => MessageType::FORUM_TOPIC_EDITED,
             $this->forum_topic_closed !== null => MessageType::FORUM_TOPIC_CLOSED,

--- a/src/Telegram/Types/Payment/DirectMessagePriceChanged.php
+++ b/src/Telegram/Types/Payment/DirectMessagePriceChanged.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * Describes a service message about a change in the price of direct messages sent to a channel chat.
+ * @see https://core.telegram.org/bots/api#directmessagepricechanged
+ */
+class DirectMessagePriceChanged extends BaseType
+{
+    /**
+     * True, if direct messages are enabled for the channel chat; false otherwise
+     */
+    public bool $are_direct_messages_enabled;
+
+    /**
+     * Optional. The new number of Telegram Stars that must be paid by users for each direct message sent to the channel.
+     * Does not apply to users who have been exempted by administrators. Defaults to 0.
+     */
+    public ?int $direct_message_star_count = null;
+}

--- a/src/Telegram/Types/Sticker/OwnedGiftUnique.php
+++ b/src/Telegram/Types/Sticker/OwnedGiftUnique.php
@@ -35,5 +35,5 @@ class OwnedGiftUnique extends OwnedGift
     /**
      * Optional. Point in time (Unix timestamp) when the gift can be transferred. If it is in the past, then the gift can be transferred now
      */
-    public ?string $next_transfer_date = null;
+    public ?int $next_transfer_date = null;
 }

--- a/src/Telegram/Types/Sticker/OwnedGiftUnique.php
+++ b/src/Telegram/Types/Sticker/OwnedGiftUnique.php
@@ -31,4 +31,9 @@ class OwnedGiftUnique extends OwnedGift
      * Optional. Number of Telegram Stars that must be paid to transfer the gift; omitted if the bot cannot transfer the gift
      */
     public ?int $transfer_star_count = null;
+
+    /**
+     * Optional. Point in time (Unix timestamp) when the gift can be transferred. If it is in the past, then the gift can be transferred now
+     */
+    public ?string $next_transfer_date = null;
 }

--- a/src/Telegram/Types/Sticker/UniqueGiftInfo.php
+++ b/src/Telegram/Types/Sticker/UniqueGiftInfo.php
@@ -16,9 +16,17 @@ class UniqueGiftInfo extends BaseType
     public UniqueGift $gift;
 
     /**
-     * Origin of the gift. Currently, either “upgrade” or “transfer”
+     * Origin of the gift. Currently, either
+     * “upgrade” for gifts upgraded from regular gifts,
+     * “transfer” for gifts transferred from other users or channels, or
+     * “resale” for gifts bought from other users
      */
     public string $origin;
+
+    /**
+     * Optional. For gifts bought from other users, the price paid for the gift
+     */
+    public ?int $last_resale_star_count = null;
 
     /**
      * Optional. Unique identifier of the received gift for the bot; only present for gifts received on behalf of business accounts
@@ -29,4 +37,9 @@ class UniqueGiftInfo extends BaseType
      * Optional. Number of Telegram Stars that must be paid to transfer the gift; omitted if the bot cannot transfer the gift
      */
     public ?int $transfer_star_count = null;
+
+    /**
+     * Optional. Point in time (Unix timestamp) when the gift can be transferred. If it is in the past, then the gift can be transferred now
+     */
+    public ?string $next_transfer_date = null;
 }

--- a/src/Telegram/Types/Sticker/UniqueGiftInfo.php
+++ b/src/Telegram/Types/Sticker/UniqueGiftInfo.php
@@ -41,5 +41,5 @@ class UniqueGiftInfo extends BaseType
     /**
      * Optional. Point in time (Unix timestamp) when the gift can be transferred. If it is in the past, then the gift can be transferred now
      */
-    public ?string $next_transfer_date = null;
+    public ?int $next_transfer_date = null;
 }

--- a/tests/Datasets/checklist.php
+++ b/tests/Datasets/checklist.php
@@ -1,0 +1,7 @@
+<?php
+
+dataset('checklist', function () {
+    $file = file_get_contents(__DIR__.'/../Fixtures/Updates/checklist.json');
+
+    return [json_decode($file)];
+});

--- a/tests/Datasets/checklist_tasks_added.php
+++ b/tests/Datasets/checklist_tasks_added.php
@@ -1,0 +1,7 @@
+<?php
+
+dataset('checklist_tasks_added', function () {
+    $file = file_get_contents(__DIR__.'/../Fixtures/Updates/checklist_tasks_added.json');
+
+    return [json_decode($file)];
+});

--- a/tests/Datasets/checklist_tasks_done.php
+++ b/tests/Datasets/checklist_tasks_done.php
@@ -1,0 +1,7 @@
+<?php
+
+dataset('checklist_tasks_done', function () {
+    $file = file_get_contents(__DIR__.'/../Fixtures/Updates/checklist_tasks_done.json');
+
+    return [json_decode($file)];
+});

--- a/tests/Datasets/direct_message_price_changed.php
+++ b/tests/Datasets/direct_message_price_changed.php
@@ -1,0 +1,7 @@
+<?php
+
+dataset('direct_message_price_changed', function () {
+    $file = file_get_contents(__DIR__.'/../Fixtures/Updates/direct_message_price_changed.json');
+
+    return [json_decode($file)];
+});

--- a/tests/Feature/Listeners/MessageListenersTest.php
+++ b/tests/Feature/Listeners/MessageListenersTest.php
@@ -526,6 +526,18 @@ it('calls onBoostAdded() handler', function ($update) {
     expect($bot->get('called'))->toBeTrue();
 })->with('message_boost_added');
 
+it('calls onDirectMessagePriceChanged', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onDirectMessagePriceChanged(function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called'))->toBeTrue();
+})->with('direct_message_price_changed');
+
 it('calls onForumTopicCreated handler', function ($update) {
     $bot = Nutgram::fake($update);
 

--- a/tests/Feature/Listeners/MessageListenersTest.php
+++ b/tests/Feature/Listeners/MessageListenersTest.php
@@ -526,7 +526,7 @@ it('calls onBoostAdded() handler', function ($update) {
     expect($bot->get('called'))->toBeTrue();
 })->with('message_boost_added');
 
-it('calls onDirectMessagePriceChanged', function ($update) {
+it('calls onDirectMessagePriceChanged handler', function ($update) {
     $bot = Nutgram::fake($update);
 
     $bot->onDirectMessagePriceChanged(function (Nutgram $bot) {
@@ -537,6 +537,42 @@ it('calls onDirectMessagePriceChanged', function ($update) {
 
     expect($bot->get('called'))->toBeTrue();
 })->with('direct_message_price_changed');
+
+it('calls onChecklist handler', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onChecklist(function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called'))->toBeTrue();
+})->with('checklist');
+
+it('calls onChecklistTasksDone handler', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onChecklistTasksDone(function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called'))->toBeTrue();
+})->with('checklist_tasks_done');
+
+it('calls onChecklistTasksAdded handler', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onChecklistTasksAdded(function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called'))->toBeTrue();
+})->with('checklist_tasks_added');
 
 it('calls onForumTopicCreated handler', function ($update) {
     $bot = Nutgram::fake($update);

--- a/tests/Feature/Proxies/UpdateProxyTest.php
+++ b/tests/Feature/Proxies/UpdateProxyTest.php
@@ -4,6 +4,7 @@ use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Types\Chat\Chat;
 use SergiX44\Nutgram\Telegram\Types\Chat\ChatJoinRequest;
 use SergiX44\Nutgram\Telegram\Types\Chat\ChatMemberUpdated;
+use SergiX44\Nutgram\Telegram\Types\Checklist\Checklist;
 use SergiX44\Nutgram\Telegram\Types\Common\Update;
 use SergiX44\Nutgram\Telegram\Types\Inline\CallbackQuery;
 use SergiX44\Nutgram\Telegram\Types\Inline\ChosenInlineResult;
@@ -214,3 +215,11 @@ test('isCommand() returns false on text', function ($update) {
 
     expect($bot->isCommand())->toBeFalse();
 })->with('text');
+
+test('checklist() returns Checklist object', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->run();
+
+    expect($bot->checklist())->toBeInstanceOf(Checklist::class);
+})->with('checklist');

--- a/tests/Fixtures/Updates/checklist.json
+++ b/tests/Fixtures/Updates/checklist.json
@@ -1,0 +1,42 @@
+{
+  "update_id": 123456789,
+  "message": {
+    "message_id": 123456,
+    "from": {
+      "id": 12345,
+      "is_bot": false,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "language_code": "it",
+      "is_premium": false
+    },
+    "chat": {
+      "id": 12345,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "type": "private"
+    },
+    "date": 1668633998,
+    "checklist": {
+      "title": "Daily Tasks",
+      "tasks": [
+        {
+          "id": 1,
+          "text": "Apples"
+        },
+        {
+          "id": 2,
+          "text": "Bananas"
+        },
+        {
+          "id": 3,
+          "text": "Oranges"
+        }
+      ],
+      "others_can_add_tasks": true,
+      "others_can_mark_tasks_as_done": true
+    }
+  }
+}

--- a/tests/Fixtures/Updates/checklist_tasks_added.json
+++ b/tests/Fixtures/Updates/checklist_tasks_added.json
@@ -1,0 +1,70 @@
+{
+  "update_id": 123456789,
+  "message": {
+    "message_id": 123456,
+    "from": {
+      "id": 12345,
+      "is_bot": false,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "language_code": "it",
+      "is_premium": false
+    },
+    "chat": {
+      "id": 12345,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "type": "private"
+    },
+    "date": 1668633998,
+    "checklist_tasks_added": {
+      "checklist_message": {
+        "message_id": 123456,
+        "from": {
+          "id": 12345,
+          "is_bot": false,
+          "first_name": "Mario",
+          "last_name": "Bros",
+          "username": "MarioBros",
+          "language_code": "it",
+          "is_premium": false
+        },
+        "chat": {
+          "id": 12345,
+          "first_name": "Mario",
+          "last_name": "Bros",
+          "username": "MarioBros",
+          "type": "private"
+        },
+        "date": 1668633998,
+        "checklist": {
+          "title": "Daily Tasks",
+          "tasks": [
+            {
+              "id": 1,
+              "text": "Apples"
+            },
+            {
+              "id": 2,
+              "text": "Bananas"
+            },
+            {
+              "id": 3,
+              "text": "Oranges"
+            }
+          ],
+          "others_can_add_tasks": true,
+          "others_can_mark_tasks_as_done": true
+        }
+      },
+      "tasks": [
+        {
+          "id": 3,
+          "text": "Oranges"
+        }
+      ]
+    }
+  }
+}

--- a/tests/Fixtures/Updates/checklist_tasks_done.json
+++ b/tests/Fixtures/Updates/checklist_tasks_done.json
@@ -1,0 +1,64 @@
+{
+  "update_id": 123456789,
+  "message": {
+    "message_id": 123456,
+    "from": {
+      "id": 12345,
+      "is_bot": false,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "language_code": "it",
+      "is_premium": false
+    },
+    "chat": {
+      "id": 12345,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "type": "private"
+    },
+    "date": 1668633998,
+    "checklist_tasks_done": {
+      "checklist_message": {
+        "message_id": 123456,
+        "from": {
+          "id": 12345,
+          "is_bot": false,
+          "first_name": "Mario",
+          "last_name": "Bros",
+          "username": "MarioBros",
+          "language_code": "it",
+          "is_premium": false
+        },
+        "chat": {
+          "id": 12345,
+          "first_name": "Mario",
+          "last_name": "Bros",
+          "username": "MarioBros",
+          "type": "private"
+        },
+        "date": 1668633998,
+        "checklist": {
+          "title": "Daily Tasks",
+          "tasks": [
+            {
+              "id": 1,
+              "text": "Apples"
+            },
+            {
+              "id": 2,
+              "text": "Bananas"
+            },
+            {
+              "id": 3,
+              "text": "Oranges"
+            }
+          ],
+          "others_can_add_tasks": true,
+          "others_can_mark_tasks_as_done": true
+        }
+      }
+    }
+  }
+}

--- a/tests/Fixtures/Updates/direct_message_price_changed.json
+++ b/tests/Fixtures/Updates/direct_message_price_changed.json
@@ -1,0 +1,24 @@
+{
+  "update_id": 144011148,
+  "message": {
+    "message_id": 456901,
+    "from": {
+      "id": 11111111,
+      "is_bot": false,
+      "first_name": "Mario",
+      "username": "Bros",
+      "language_code": "it"
+    },
+    "chat": {
+      "id": 11111111,
+      "first_name": "Mario",
+      "username": "Bros",
+      "type": "private"
+    },
+    "date": 1614555305,
+    "direct_message_price_changed": {
+      "are_direct_messages_enabled": true,
+      "direct_message_star_count": 123
+    }
+  }
+}


### PR DESCRIPTION
#### [July 3, 2025](https://core.telegram.org/bots/api#july-3-2025)

**Bot API 9.1**

**Checklists**
- [x] Added the class [ChecklistTask](https://core.telegram.org/bots/api#message#checklisttask) representing a task in a checklist.
- [x] Added the class [Checklist](https://core.telegram.org/bots/api#message#checklist) representing a checklist.
- [x] Added the class [InputChecklistTask](https://core.telegram.org/bots/api#message#inputchecklisttask) representing a task to add to a checklist.
- [x] Added the class [InputChecklist](https://core.telegram.org/bots/api#message#inputchecklist) representing a checklist to create.
- [x] Added the field _checklist_ to the classes [Message](https://core.telegram.org/bots/api#message#message) and [ExternalReplyInfo](https://core.telegram.org/bots/api#message#externalreplyinfo), describing a checklist in a message.
- [x] Added the class [ChecklistTasksDone](https://core.telegram.org/bots/api#message#checklisttasksdone) and the field _checklist\_tasks\_done_ to the class [Message](https://core.telegram.org/bots/api#message#message), describing a service message about status changes for tasks in a checklist (i.e., marked as done/not done).
- [x] Added the class [ChecklistTasksAdded](https://core.telegram.org/bots/api#message#checklisttasksadded) and the field _checklist\_tasks\_added_ to the class [Message](https://core.telegram.org/bots/api#message#message), describing a service message about the addition of new tasks to a checklist.
- [x] Added the method [sendChecklist](https://core.telegram.org/bots/api#message#sendchecklist), allowing bots to send a checklist on behalf of a business account.
- [x] Added the method [editMessageChecklist](https://core.telegram.org/bots/api#message#editmessagechecklist), allowing bots to edit a checklist on behalf of a business account.

**Gifts**

- [x] Added the field _next\_transfer\_date_ to the classes [OwnedGiftUnique](https://core.telegram.org/bots/api#message#ownedgiftunique) and [UniqueGiftInfo](https://core.telegram.org/bots/api#message#uniquegiftinfo).
- [x] Added the field _last\_resale\_star\_count_ to the class [UniqueGiftInfo](https://core.telegram.org/bots/api#message#uniquegiftinfo).
- [x] Added “resale” as the possible value of the field _origin_ in the class [UniqueGiftInfo](https://core.telegram.org/bots/api#message#uniquegiftinfo).

**General**

- [x] Increased the maximum number of options in a poll to 12.
- [x] Added the method [getMyStarBalance](https://core.telegram.org/bots/api#message#getmystarbalance), allowing bots to get their current balance of Telegram Stars.
- [x] Added the class [DirectMessagePriceChanged](https://core.telegram.org/bots/api#message#directmessagepricechanged) and the field _direct\_message\_price\_changed_ to the class [Message](https://core.telegram.org/bots/api#message#message), describing a service message about a price change for direct messages sent to the channel chat.
- [x] Added the method _hideKeyboard_ to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).

**Library**
- [x] Update badge
- [x] Add `onDirectMessagePriceChanged` listener
- [x] Add `onChecklist` listener
- [x] Add `onChecklistTasksDone` listener
- [x] Add `onChecklistTasksAdded` listener
- [x] Add `checklist` proxy method