### PR TITLE
[5.x] Add MaybeInaccessibleMessage support for Telegram message types

### DIFF
--- a/src/Proxies/UpdateProxy.php
+++ b/src/Proxies/UpdateProxy.php
@@ -17,6 +17,7 @@ use SergiX44\Nutgram\Telegram\Types\Common\Update;
 use SergiX44\Nutgram\Telegram\Types\Inline\CallbackQuery;
 use SergiX44\Nutgram\Telegram\Types\Inline\ChosenInlineResult;
 use SergiX44\Nutgram\Telegram\Types\Inline\InlineQuery;
+use SergiX44\Nutgram\Telegram\Types\Message\MaybeInaccessibleMessage;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
 use SergiX44\Nutgram\Telegram\Types\Payment\PaidMediaPurchased;
@@ -162,7 +163,7 @@ trait UpdateProxy
     |--------------------------------------------------------------------------
     */
 
-    public function message(): ?Message
+    public function message(): ?MaybeInaccessibleMessage
     {
         return $this->update?->getMessage();
     }

--- a/src/Proxies/UpdateProxy.php
+++ b/src/Proxies/UpdateProxy.php
@@ -163,7 +163,7 @@ trait UpdateProxy
     |--------------------------------------------------------------------------
     */
 
-    public function message(): ?MaybeInaccessibleMessage
+    public function message(): ?Message
     {
         return $this->update?->getMessage();
     }

--- a/src/Telegram/Types/Common/Update.php
+++ b/src/Telegram/Types/Common/Update.php
@@ -362,7 +362,7 @@ class Update extends BaseType
         };
     }
 
-    public function getMessage(): ?MaybeInaccessibleMessage
+    public function getMessage(): ?Message
     {
         return match (true) {
             $this->message !== null => $this->message,
@@ -371,7 +371,7 @@ class Update extends BaseType
             $this->edited_channel_post !== null => $this->edited_channel_post,
             $this->business_message !== null => $this->business_message,
             $this->edited_business_message !== null => $this->edited_business_message,
-            $this->callback_query !== null => $this->callback_query->message,
+            $this->callback_query !== null => $this->callback_query->message !== null && !$this->callback_query->message->isInaccessible() ? $this->callback_query->message : null,
             default => null
         };
     }

--- a/src/Telegram/Types/Common/Update.php
+++ b/src/Telegram/Types/Common/Update.php
@@ -18,6 +18,7 @@ use SergiX44\Nutgram\Telegram\Types\Inline\CallbackQuery;
 use SergiX44\Nutgram\Telegram\Types\Inline\ChosenInlineResult;
 use SergiX44\Nutgram\Telegram\Types\Inline\InlineQuery;
 use SergiX44\Nutgram\Telegram\Types\ManagedBot\ManagedBotUpdated;
+use SergiX44\Nutgram\Telegram\Types\Message\MaybeInaccessibleMessage;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\Payment\PaidMediaPurchased;
 use SergiX44\Nutgram\Telegram\Types\Payment\PreCheckoutQuery;
@@ -361,7 +362,7 @@ class Update extends BaseType
         };
     }
 
-    public function getMessage(): ?Message
+    public function getMessage(): ?MaybeInaccessibleMessage
     {
         return match (true) {
             $this->message !== null => $this->message,

--- a/src/Telegram/Types/Inline/CallbackQuery.php
+++ b/src/Telegram/Types/Inline/CallbackQuery.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SergiX44\Nutgram\Telegram\Types\Inline;
 
 use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Message\MaybeInaccessibleMessage;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\User\User;
 
@@ -25,10 +26,9 @@ class CallbackQuery extends BaseType
 
     /**
      * Optional.
-     * Message with the callback button that originated the query.
-     * Note that message content and message date will not be available if the message is too old
+     * Message sent by the bot with the callback button that originated the query
      */
-    public ?Message $message = null;
+    public ?MaybeInaccessibleMessage $message = null;
 
     /**
      * Optional.

--- a/src/Telegram/Types/Internal/Resolvers/MaybeInaccessibleMessageResolver.php
+++ b/src/Telegram/Types/Internal/Resolvers/MaybeInaccessibleMessageResolver.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SergiX44\Nutgram\Telegram\Types\Internal\Resolvers;
+
+use Attribute;
+use SergiX44\Hydrator\Annotation\ConcreteResolver;
+use SergiX44\Nutgram\Telegram\Types\Message\InaccessibleMessage;
+use SergiX44\Nutgram\Telegram\Types\Message\Message;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class MaybeInaccessibleMessageResolver extends ConcreteResolver
+{
+    protected static array $concreteTypes = [
+        Message::class,
+        InaccessibleMessage::class,
+    ];
+
+    public function concreteFor(array $data, array $all): ?string
+    {
+        return $data['date'] === 0
+            ? InaccessibleMessage::class
+            : Message::class;
+    }
+}

--- a/src/Telegram/Types/Message/InaccessibleMessage.php
+++ b/src/Telegram/Types/Message/InaccessibleMessage.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Nutgram\Telegram\Types\Chat\Chat;
+
+/**
+ * This object describes a message that was deleted or is otherwise inaccessible to the bot.
+ * @see https://core.telegram.org/bots/api#inaccessiblemessage
+ */
+class InaccessibleMessage extends MaybeInaccessibleMessage
+{
+    /**
+     * Conversation the message belongs to
+     */
+    public Chat $chat;
+
+    /**
+     * Unique message identifier inside this chat
+     */
+    public int $message_id;
+
+    /**
+     * Date the message was sent in Unix time
+     */
+    public int $date;
+}

--- a/src/Telegram/Types/Message/MaybeInaccessibleMessage.php
+++ b/src/Telegram/Types/Message/MaybeInaccessibleMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SergiX44\Nutgram\Telegram\Types\Message;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Chat\Chat;
+use SergiX44\Nutgram\Telegram\Types\Internal\Resolvers\MaybeInaccessibleMessageResolver;
+
+/**
+ * This object describes a message that can be inaccessible to the bot. It can be one of
+ * - {@see Message}
+ * - {@see InaccessibleMessage}
+ * @see https://core.telegram.org/bots/api#maybeinaccessiblemessage
+ */
+#[MaybeInaccessibleMessageResolver]
+abstract class MaybeInaccessibleMessage extends BaseType
+{
+    public Chat $chat;
+    public int $message_id;
+    public int $date;
+
+    /**
+     * Check if this message is deleted or is inaccessible to the bot.
+     * @return bool
+     */
+    public function isInaccessible(): bool
+    {
+        return $this->date === 0;
+    }
+}

--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -79,7 +79,7 @@ use SergiX44\Nutgram\Telegram\Types\WebApp\WebAppData;
  * This object represents a message.
  * @see https://core.telegram.org/bots/api#message
  */
-class Message extends BaseType
+class Message extends MaybeInaccessibleMessage
 {
     /** Unique message identifier inside this chat */
     public int $message_id;
@@ -492,9 +492,10 @@ class Message extends BaseType
     /**
      * Optional.
      * Specified message was pinned.
-     * Note that the Message object in this field will not contain further reply_to_message fields even if it is itself a reply.
+     * Note that the {@see https://core.telegram.org/bots/api#message Message}
+     * object in this field will not contain further reply_to_message fields even if it is itself a reply.
      */
-    public ?Message $pinned_message = null;
+    public ?MaybeInaccessibleMessage $pinned_message = null;
 
     /**
      * Optional.
@@ -989,15 +990,6 @@ class Message extends BaseType
             disable_notification: $disable_notification,
             protect_content: $protect_content,
         );
-    }
-
-    /**
-     * Check if this message is deleted or is inaccessible to the bot.
-     * @return bool
-     */
-    public function isInaccessible(): bool
-    {
-        return $this->date === 0;
     }
 
     /**

--- a/src/Telegram/Types/Poll/PollOptionAdded.php
+++ b/src/Telegram/Types/Poll/PollOptionAdded.php
@@ -6,6 +6,7 @@ namespace SergiX44\Nutgram\Telegram\Types\Poll;
 
 use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Message\MaybeInaccessibleMessage;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
 
@@ -20,19 +21,16 @@ class PollOptionAdded extends BaseType
      * Message containing the poll to which the option was added, if known.
      * Note that the Message object in this field will not contain
      * the reply_to_message field even if it itself is a reply.
-     * @var Message|null
      */
-    public ?Message $poll_message = null;
+    public ?MaybeInaccessibleMessage $poll_message = null;
 
     /**
      * Unique identifier of the added option
-     * @var string
      */
     public string $option_persistent_id;
 
     /**
      * Option text
-     * @var string
      */
     public string $option_text;
 

--- a/src/Telegram/Types/Poll/PollOptionDeleted.php
+++ b/src/Telegram/Types/Poll/PollOptionDeleted.php
@@ -6,6 +6,7 @@ namespace SergiX44\Nutgram\Telegram\Types\Poll;
 
 use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Message\MaybeInaccessibleMessage;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
 
@@ -21,7 +22,7 @@ class PollOptionDeleted extends BaseType
      * Note that the Message object in this field will not contain
      * the reply_to_message field even if it itself is a reply.
      */
-    public ?Message $poll_message = null;
+    public ?MaybeInaccessibleMessage $poll_message = null;
 
     /**
      * Unique identifier of the deleted option

--- a/tests/Feature/Listeners/UpdateListenersTest.php
+++ b/tests/Feature/Listeners/UpdateListenersTest.php
@@ -10,6 +10,7 @@ use SergiX44\Nutgram\Telegram\Types\Business\BusinessConnection;
 use SergiX44\Nutgram\Telegram\Types\Business\BusinessMessagesDeleted;
 use SergiX44\Nutgram\Telegram\Types\ManagedBot\ManagedBotUpdated;
 use SergiX44\Nutgram\Telegram\Types\Message\InaccessibleMessage;
+use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageOriginUser;
 use SergiX44\Nutgram\Telegram\Types\Reaction\MessageReactionCountUpdated;
 use SergiX44\Nutgram\Telegram\Types\Reaction\MessageReactionUpdated;
@@ -246,6 +247,10 @@ it('calls onCallbackQuery() handler', function ($update) {
     $bot->onCallbackQuery(function (Nutgram $bot) {
         $bot->set('called', true);
         expect($bot->message()->isInaccessible())->toBeFalse();
+
+        expect($bot->update()->callback_query?->message?->isInaccessible())->toBeFalse();
+        expect($bot->update()->callback_query?->message)->toBeInstanceOf(Message::class);
+        expect($bot->message())->toBeInstanceOf(Message::class);
     });
 
     $bot->run();
@@ -270,8 +275,9 @@ it('calls onCallbackQuery() handler with inaccessible message', function ($updat
 
     $bot->onCallbackQuery(function (Nutgram $bot) {
         $bot->set('called', true);
-        expect($bot->message()->isInaccessible())->toBeTrue();
-        expect($bot->message())->toBeInstanceOf(InaccessibleMessage::class);
+        expect($bot->update()->callback_query?->message?->isInaccessible())->toBeTrue();
+        expect($bot->update()->callback_query?->message)->toBeInstanceOf(InaccessibleMessage::class);
+        expect($bot->message())->toBeNull();
     });
 
     $bot->run();

--- a/tests/Feature/Listeners/UpdateListenersTest.php
+++ b/tests/Feature/Listeners/UpdateListenersTest.php
@@ -9,6 +9,7 @@ use SergiX44\Nutgram\Telegram\Types\Boost\ChatBoostUpdated;
 use SergiX44\Nutgram\Telegram\Types\Business\BusinessConnection;
 use SergiX44\Nutgram\Telegram\Types\Business\BusinessMessagesDeleted;
 use SergiX44\Nutgram\Telegram\Types\ManagedBot\ManagedBotUpdated;
+use SergiX44\Nutgram\Telegram\Types\Message\InaccessibleMessage;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageOriginUser;
 use SergiX44\Nutgram\Telegram\Types\Reaction\MessageReactionCountUpdated;
 use SergiX44\Nutgram\Telegram\Types\Reaction\MessageReactionUpdated;
@@ -270,6 +271,7 @@ it('calls onCallbackQuery() handler with inaccessible message', function ($updat
     $bot->onCallbackQuery(function (Nutgram $bot) {
         $bot->set('called', true);
         expect($bot->message()->isInaccessible())->toBeTrue();
+        expect($bot->message())->toBeInstanceOf(InaccessibleMessage::class);
     });
 
     $bot->run();


### PR DESCRIPTION
This PR introduces support for Telegram’s `MaybeInaccessibleMessage` abstraction, aligning the project with the latest Bot API behavior for messages that may be unavailable to the bot.