### PR TITLE
Fixed setWebhook method to use request  multipart

### DIFF
--- a/src/Telegram/Endpoints/UpdateMethods.php
+++ b/src/Telegram/Endpoints/UpdateMethods.php
@@ -64,7 +64,7 @@ trait UpdateMethods
         ?bool $drop_pending_updates = null,
         ?string $secret_token = null
     ): ?bool {
-        return $this->requestJson(__FUNCTION__, compact(
+        return $this->requestMultipart(__FUNCTION__, compact(
             'url',
             'certificate',
             'ip_address',


### PR DESCRIPTION
Unable to install a certificate in the setWebhook request's parameters.

This is due to the content-type used when requesting a certificate file. According to the documentation, if a certificate file is present, it should be `multipart/form-data` https://core.telegram.org/bots/api#inputfile