### PR TITLE
Improve exit message formatting for graceful shutdown

### DIFF
--- a/src/RunningMode/Polling.php
+++ b/src/RunningMode/Polling.php
@@ -58,7 +58,7 @@ class Polling implements RunningMode
             pcntl_async_signals(true);
 
             $killMe = static function () {
-                exit('Goodbye!');
+                exit("\nGoodbye!\n");
             };
 
             $exitGracefully = static function () {


### PR DESCRIPTION
**Before**
<img width="568" height="82" alt="immagine" src="https://github.com/user-attachments/assets/29fe04e0-7efe-4c8e-a1f6-b6d25026ab6f" />


**After**
<img width="437" height="143" alt="immagine" src="https://github.com/user-attachments/assets/a85abd4f-12e6-44de-a920-35123bb0c905" />
