### PR TITLE
Update to Bot API 10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://i.imgur.com/yrd8jr2.png" width="400px">
 </p>
 
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-10.0%09--%20May%208,%202026-28a8ea.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-10.1%09--%20June%2011,%202026-28a8ea.svg?logo=telegram)](https://core.telegram.org/bots/api)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nutgram/nutgram.svg?label=composer&logo=composer)](https://packagist.org/packages/nutgram/nutgram)
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 ![License](https://img.shields.io/github/license/nutgram/nutgram)

--- a/src/Handlers/Listeners/UpdateListeners.php
+++ b/src/Handlers/Listeners/UpdateListeners.php
@@ -312,6 +312,17 @@ trait UpdateListeners
     }
 
     /**
+     * @param string $pattern
+     * @param callable|class-string|array $callable
+     * @return Handler
+     */
+    public function onChatJoinRequestQuery(string $pattern, $callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::CHAT_JOIN_REQUEST->value][$pattern] = new Handler($callable, $pattern);
+    }
+
+    /**
      * @param callable|class-string|array $callable
      * @return Handler
      */

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -115,7 +115,7 @@ abstract class ResolveHandlers extends CollectHandlers
         } elseif ($updateType === UpdateType::PURCHASED_PAID_MEDIA) {
             $data = $this->update->purchased_paid_media?->paid_media_payload;
             $this->addHandlersBy($resolvedHandlers, $updateType->value, value: $data);
-        } elseif($updateType === UpdateType::CHAT_JOIN_REQUEST) {
+        } elseif ($updateType === UpdateType::CHAT_JOIN_REQUEST) {
             $data = $this->update->chat_join_request?->query_id;
             $this->addHandlersBy($resolvedHandlers, $updateType->value, value: $data);
         }

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -115,6 +115,9 @@ abstract class ResolveHandlers extends CollectHandlers
         } elseif ($updateType === UpdateType::PURCHASED_PAID_MEDIA) {
             $data = $this->update->purchased_paid_media?->paid_media_payload;
             $this->addHandlersBy($resolvedHandlers, $updateType->value, value: $data);
+        } elseif($updateType === UpdateType::CHAT_JOIN_REQUEST) {
+            $data = $this->update->chat_join_request?->query_id;
+            $this->addHandlersBy($resolvedHandlers, $updateType->value, value: $data);
         }
 
         if (empty($resolvedHandlers) && $updateType !== null) {

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -4,6 +4,7 @@ namespace SergiX44\Nutgram\Telegram\Endpoints;
 
 use SergiX44\Nutgram\Telegram\Client;
 use SergiX44\Nutgram\Telegram\Properties\ChatAction;
+use SergiX44\Nutgram\Telegram\Properties\ChatJoinRequestResult;
 use SergiX44\Nutgram\Telegram\Properties\DiceEmoji;
 use SergiX44\Nutgram\Telegram\Properties\ForumIconColor;
 use SergiX44\Nutgram\Telegram\Properties\ParseMode;
@@ -52,6 +53,7 @@ use SergiX44\Nutgram\Telegram\Types\Message\ReplyParameters;
 use SergiX44\Nutgram\Telegram\Types\Message\SentGuestMessage;
 use SergiX44\Nutgram\Telegram\Types\Poll\InputPollOption;
 use SergiX44\Nutgram\Telegram\Types\Reaction\ReactionType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichMessage;
 use SergiX44\Nutgram\Telegram\Types\Sticker\OwnedGifts;
 use SergiX44\Nutgram\Telegram\Types\Sticker\Sticker;
 use SergiX44\Nutgram\Telegram\Types\SuggestedPost\SuggestedPostParameters;
@@ -175,6 +177,63 @@ trait AvailableMethods
             'direct_messages_topic_id',
             'suggested_post_parameters',
         );
+
+        return $this->requestJson(__FUNCTION__, $parameters, Message::class);
+    }
+
+    /**
+     * Use this method to send rich messages.
+     * If the message contains a block with a media element, then the bot must have the right to send the media to the chat.
+     * On success, the sent {@see https://core.telegram.org/bots/api#message Message} is returned.
+     * @param InputRichMessage $rich_message The message to be sent
+     * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message will be sent
+     * @param int|string|null $chat_id Unique identifier for the target chat or username of the target bot, supergroup or channel in the format &#64;username
+     * @param int|null $message_thread_id Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only
+     * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
+     * @param bool|null $disable_notification Sends the message {@see https://telegram.org/blog/channels-2-0#silent-messages silently}. Users will receive a notification with no sound.
+     * @param bool|null $protect_content Protects the contents of the sent message from forwarding and saving
+     * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance.
+     * @param string|null $message_effect_id Unique identifier of the message effect to be added to the message; for private chats only
+     * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param ReplyParameters|null $reply_parameters Description of the message to reply to
+     * @param InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup Additional interface options. A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}, {@see https://core.telegram.org/bots/features#keyboards custom reply keyboard}, instructions to remove a reply keyboard or to force a reply from the user.
+     * @return Message|null
+     * @see https://core.telegram.org/bots/api#sendrichmessage
+     *
+     */
+    public function sendRichMessage(
+        InputRichMessage $rich_message,
+        ?string $business_connection_id = null,
+        int|string|null $chat_id = null,
+        ?int $message_thread_id = null,
+        ?int $direct_messages_topic_id = null,
+        ?bool $disable_notification = null,
+        ?bool $protect_content = null,
+        ?bool $allow_paid_broadcast = null,
+        ?string $message_effect_id = null,
+        ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?ReplyParameters $reply_parameters = null,
+        InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
+    ): ?Message
+    {
+        $parameters = compact(
+            'rich_message',
+            'business_connection_id',
+            'chat_id',
+            'message_thread_id',
+            'direct_messages_topic_id',
+            'disable_notification',
+            'protect_content',
+            'allow_paid_broadcast',
+            'message_effect_id',
+            'suggested_post_parameters',
+            'reply_parameters',
+            'reply_markup',
+        );
+        $parameters['business_connection_id'] ??= $this->businessConnectionId();
+        $parameters['chat_id'] ??= $this->chatId();
+        $parameters['message_thread_id'] ??= $this->messageThreadId();
+        $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
         return $this->requestJson(__FUNCTION__, $parameters, Message::class);
     }
@@ -1644,6 +1703,33 @@ trait AvailableMethods
     }
 
     /**
+     * Use this method to stream a partial rich message to a user while the message is being generated.
+     * Note that the streamed draft is ephemeral and acts as a temporary 30-second preview - once the output is finalized,
+     * you must call {@see https://core.telegram.org/bots/api#sendrichmessage sendRichMessage}
+     * with the complete message to persist it in the user's chat.
+     * Returns True on success.
+     * @param int $draft_id Unique identifier of the message draft; must be non-zero. Changes to drafts with the same identifier are animated.
+     * @param InputRichMessage $rich_message The partial message to be streamed
+     * @param int|null $chat_id Unique identifier for the target private chat
+     * @param int|null $message_thread_id Unique identifier for the target message thread
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#sendrichmessagedraft
+     */
+    public function sendRichMessageDraft(
+        int $draft_id,
+        InputRichMessage $rich_message,
+        ?int $chat_id = null,
+        ?int $message_thread_id = null,
+    ): ?bool
+    {
+        $parameters = compact('draft_id', 'rich_message', 'chat_id', 'message_thread_id');
+        $parameters['chat_id'] ??= $this->chatId();
+        $parameters['message_thread_id'] ??= $this->messageThreadId();
+
+        return $this->requestJson(__FUNCTION__, $parameters);
+    }
+
+    /**
      * Use this method when you need to tell the user that something is happening on the bot's side.
      * The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status).
      * Returns True on success.
@@ -2186,6 +2272,38 @@ trait AvailableMethods
     public function declineChatJoinRequest(int|string $chat_id, int $user_id): ?bool
     {
         return $this->requestJson(__FUNCTION__, compact('chat_id', 'user_id'));
+    }
+
+    /**
+     * Use this method to process a received chat join request query.
+     * Returns True on success.
+     * @param ChatJoinRequestResult|string $result Result of the query. Must be either “approve” to allow the user to join the chat, “decline” to disallow the user to join the chat, or “queue” to leave the decision to other administrators.
+     * @param string|null $chat_join_request_query_id Unique identifier of the join request query
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#answerchatjoinrequestquery
+     */
+    public function answerChatJoinRequestQuery(ChatJoinRequestResult|string $result, ?string $chat_join_request_query_id = null): ?bool
+    {
+        $parameters = compact('result', 'chat_join_request_query_id');
+        $parameters['chat_join_request_query_id'] ??= $this->chatJoinRequest()->query_id;
+
+        return $this->requestJson(__FUNCTION__, $parameters);
+    }
+
+    /**
+     * Use this method to process a received chat join request query by showing a Mini App to the user before deciding the outcome.
+     * Returns True on success.
+     * @param string $web_app_url The URL of the Mini App to be opened
+     * @param string|null $chat_join_request_query_id Unique identifier of the join request query
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#sendchatjoinrequestwebapp
+     */
+    public function sendChatJoinRequestWebApp(string $web_app_url, ?string $chat_join_request_query_id = null): ?bool
+    {
+        $parameters = compact('web_app_url', 'chat_join_request_query_id');
+        $parameters['chat_join_request_query_id'] ??= $this->chatJoinRequest()->query_id;
+
+        return $this->requestJson(__FUNCTION__, $parameters);
     }
 
     /**

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -214,8 +214,7 @@ trait AvailableMethods
         ?SuggestedPostParameters $suggested_post_parameters = null,
         ?ReplyParameters $reply_parameters = null,
         InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply|null $reply_markup = null,
-    ): ?Message
-    {
+    ): ?Message {
         $parameters = compact(
             'rich_message',
             'business_connection_id',
@@ -1720,8 +1719,7 @@ trait AvailableMethods
         InputRichMessage $rich_message,
         ?int $chat_id = null,
         ?int $message_thread_id = null,
-    ): ?bool
-    {
+    ): ?bool {
         $parameters = compact('draft_id', 'rich_message', 'chat_id', 'message_thread_id');
         $parameters['chat_id'] ??= $this->chatId();
         $parameters['message_thread_id'] ??= $this->messageThreadId();

--- a/src/Telegram/Endpoints/UpdatesMessages.php
+++ b/src/Telegram/Endpoints/UpdatesMessages.php
@@ -15,6 +15,7 @@ use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
 use SergiX44\Nutgram\Telegram\Types\Payment\StarAmount;
 use SergiX44\Nutgram\Telegram\Types\Poll\Poll;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichMessage;
 use SergiX44\Nutgram\Telegram\Types\Sticker\AcceptedGiftTypes;
 use SergiX44\Nutgram\Telegram\Types\Sticker\OwnedGifts;
 use SergiX44\Nutgram\Telegram\Types\Story\StoryArea;
@@ -28,10 +29,10 @@ use function SergiX44\Nutgram\Support\array_filter_null;
 trait UpdatesMessages
 {
     /**
-     * Use this method to edit text and {@see https://core.telegram.org/bots/api#games game} messages.
+     * Use this method to edit text, rich and {@see https://core.telegram.org/bots/api#games game} messages.
      * On success, if the edited message is not an inline message, the edited {@see https://core.telegram.org/bots/api#message Message} is returned, otherwise True is returned.
      * @see https://core.telegram.org/bots/api#editmessagetext
-     * @param string $text New text of the message, 1-4096 characters after entities parsing
+     * @param string|null $text New text of the message, 1-4096 characters after entity parsing; required if rich_message isn't specified
      * @param int|string|null $chat_id Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format &#64;channelusername)
      * @param int|null $message_id Required if inline_message_id is not specified. Identifier of the message to edit
      * @param string|null $inline_message_id Required if chat_id and message_id are not specified. Identifier of the inline message
@@ -41,10 +42,11 @@ trait UpdatesMessages
      * @param LinkPreviewOptions|null $link_preview_options Link preview generation options for the message
      * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}.
      * @param string|null $business_connection_id Unique identifier of the business connection on behalf of which the message to be edited was sent
+     * @param InputRichMessage|null $rich_message New rich content of the message; required if text isn't specified
      * @return Message|bool|null
      */
     public function editMessageText(
-        string $text,
+        ?string $text = null,
         int|string|null $chat_id = null,
         ?int $message_id = null,
         ?string $inline_message_id = null,
@@ -54,6 +56,7 @@ trait UpdatesMessages
         ?LinkPreviewOptions $link_preview_options = null,
         ?InlineKeyboardMarkup $reply_markup = null,
         ?string $business_connection_id = null,
+        ?InputRichMessage $rich_message = null,
     ): Message|bool|null {
         $parameters = compact(
             'chat_id',
@@ -66,6 +69,7 @@ trait UpdatesMessages
             'link_preview_options',
             'reply_markup',
             'business_connection_id',
+            'rich_message',
         );
         $this->setChatMessageOrInlineMessageId($parameters);
 

--- a/src/Telegram/Properties/ChatJoinRequestResult.php
+++ b/src/Telegram/Properties/ChatJoinRequestResult.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum ChatJoinRequestResult: string
+{
+    case APPROVE = 'approve';
+    case DECLINE = 'decline';
+    case QUEUE = 'queue';
+}

--- a/src/Telegram/Properties/InputMediaType.php
+++ b/src/Telegram/Properties/InputMediaType.php
@@ -7,6 +7,8 @@ enum InputMediaType: string
     case ANIMATION = 'animation';
     case AUDIO = 'audio';
     case DOCUMENT = 'document';
+
+    case LINK = 'link';
     case LIVE_PHOTO = 'live_photo';
     case LOCATION = 'location';
     case PHOTO = 'photo';

--- a/src/Telegram/Properties/RichBlockListItemType.php
+++ b/src/Telegram/Properties/RichBlockListItemType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum RichBlockListItemType: string
+{
+    case LOWERCASE_LETTERS = 'a';
+    case UPPERCASE_LETTERS = 'A';
+    case LOWERCASE_ROMAN_NUMERALS = 'i';
+    case UPPERCASE_ROMAN_NUMERALS = 'I';
+    case DECIMAL_NUMBERS = '1';
+}

--- a/src/Telegram/Properties/RichBlockTableCellAlign.php
+++ b/src/Telegram/Properties/RichBlockTableCellAlign.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum RichBlockTableCellAlign: string
+{
+    case LEFT = 'left';
+    case CENTER = 'center';
+    case RIGHT = 'right';
+}

--- a/src/Telegram/Properties/RichBlockTableCellValign.php
+++ b/src/Telegram/Properties/RichBlockTableCellValign.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum RichBlockTableCellValign: string
+{
+    case TOP = 'top';
+    case MIDDLE = 'middle';
+    case BOTTOM = 'bottom';
+}

--- a/src/Telegram/Properties/RichBlockType.php
+++ b/src/Telegram/Properties/RichBlockType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum RichBlockType: string
+{
+    case PARAGRAPH = 'paragraph';
+    case HEADING = 'heading';
+    case PRE = 'pre';
+    case FOOTER = 'footer';
+    case DIVIDER = 'divider';
+    case MATHEMATICAL_EXPRESSION = 'mathematical_expression';
+    case ANCHOR = 'anchor';
+    case LIST = 'list';
+    case BLOCKQUOTE = 'blockquote';
+    case PULLQUOTE = 'pullquote';
+    case COLLAGE = 'collage';
+    case SLIDESHOW = 'slideshow';
+    case TABLE = 'table';
+    case DETAILS = 'details';
+    case MAP = 'map';
+    case ANIMATION = 'animation';
+    case AUDIO = 'audio';
+    case PHOTO = 'photo';
+    case VIDEO = 'video';
+    case VOICE_NOTE = 'voice_note';
+    case THINKING = 'thinking';
+}

--- a/src/Telegram/Properties/RichTextType.php
+++ b/src/Telegram/Properties/RichTextType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum RichTextType: string
+{
+    case BOLD = 'bold';
+    case ITALIC = 'italic';
+    case UNDERLINE = 'underline';
+    case STRIKETHROUGH = 'strikethrough';
+    case SPOILER = 'spoiler';
+    case DATETIME = 'date_time';
+    case TEXT_MENTION = 'text_mention';
+    case SUBSCRIPT = 'subscript';
+    case SUPERSCRIPT = 'superscript';
+    case MARKED = 'marked';
+    case CODE = 'code';
+    case CUSTOM_EMOJI = 'custom_emoji';
+    case MATHEMATICAL_EXPRESSION = 'mathematical_expression';
+    case URL = 'url';
+    case EMAIL_ADDRESS = 'email_address';
+    case PHONE_NUMBER = 'phone_number';
+    case BANK_CARD_NUMBER = 'bank_card_number';
+    case MENTION = 'mention';
+    case HASHTAG = 'hashtag';
+    case CASHTAG = 'cashtag';
+    case BOT_COMMAND = 'bot_command';
+    case ANCHOR = 'anchor';
+    case ANCHOR_LINK = 'anchor_link';
+    case REFERENCE = 'reference';
+    case REFERENCE_LINK = 'reference_link';
+}

--- a/src/Telegram/Types/Chat/Chat.php
+++ b/src/Telegram/Types/Chat/Chat.php
@@ -15,6 +15,7 @@ use SergiX44\Nutgram\Telegram\Types\Reaction\ReactionType;
 use SergiX44\Nutgram\Telegram\Types\Sticker\AcceptedGiftTypes;
 use SergiX44\Nutgram\Telegram\Types\Sticker\UniqueGiftColors;
 use SergiX44\Nutgram\Telegram\Types\User\Birthdate;
+use SergiX44\Nutgram\Telegram\Types\User\User;
 use SergiX44\Nutgram\Telegram\Types\User\UserRating;
 
 /**
@@ -391,6 +392,8 @@ class Chat extends BaseType
      */
     public ?int $paid_message_star_count = null;
 
+    public ?User $guard_bot = null;
+
     public static function make(
         int $id,
         ChatType|string $type,
@@ -426,8 +429,9 @@ class Chat extends BaseType
         ?UserRating $rating = null,
         ?UniqueGiftColors $unique_gift_colors = null,
         ?int $paid_message_star_count = null,
-        ?Audio $first_profile_audio = null
-    ): Chat {
+        ?Audio $first_profile_audio = null,
+        ?User $guard_bot = null,
+        ): Chat {
         $chat = new self();
         $chat->id = $id;
         $chat->type = $type;
@@ -464,6 +468,7 @@ class Chat extends BaseType
         $chat->unique_gift_colors = $unique_gift_colors;
         $chat->paid_message_star_count = $paid_message_star_count;
         $chat->first_profile_audio = $first_profile_audio;
+        $chat->guard_bot = $guard_bot;
         return $chat;
     }
 

--- a/src/Telegram/Types/Chat/Chat.php
+++ b/src/Telegram/Types/Chat/Chat.php
@@ -431,7 +431,7 @@ class Chat extends BaseType
         ?int $paid_message_star_count = null,
         ?Audio $first_profile_audio = null,
         ?User $guard_bot = null,
-        ): Chat {
+    ): Chat {
         $chat = new self();
         $chat->id = $id;
         $chat->type = $type;

--- a/src/Telegram/Types/Chat/ChatJoinRequest.php
+++ b/src/Telegram/Types/Chat/ChatJoinRequest.php
@@ -39,4 +39,13 @@ class ChatJoinRequest extends BaseType
      * Chat invite link that was used by the user to send the join request
      */
     public ?ChatInviteLink $invite_link = null;
+
+    /**
+     * Optional. Identifier of the join request query.
+     * If present, then the bot must call
+     * {@see https://core.telegram.org/bots/api#sendchatjoinrequestwebapp sendChatJoinRequestWebApp}
+     * or directly call {@see https://core.telegram.org/bots/api#answerchatjoinrequestquery answerChatJoinRequestQuery}
+     * within 10 seconds.
+     */
+    public ?string $query_id = null;
 }

--- a/src/Telegram/Types/Input/InputMediaLink.php
+++ b/src/Telegram/Types/Input/InputMediaLink.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Input;
+
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputMediaType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * Represents a general file to be sent.
+ * @see https://core.telegram.org/bots/api#inputmediadocument
+ */
+#[SkipConstructor]
+class InputMediaLink extends BaseType implements InputPollOptionMedia
+{
+    /**
+     * Type of the result, must be link
+     */
+    #[EnumOrScalar]
+    public InputMediaType|string $type = InputMediaType::LINK;
+
+    /**
+     * HTTP URL of the link
+     */
+    public string $url;
+
+
+    public function __construct(string $url)
+    {
+        parent::__construct();
+        $this->url = $url;
+    }
+
+    public static function make(string $url): self
+    {
+        return new self($url);
+    }
+}

--- a/src/Telegram/Types/Input/InputMessageContent.php
+++ b/src/Telegram/Types/Input/InputMessageContent.php
@@ -9,6 +9,7 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
  * This object represents the content of a message to be sent as a result of an inline query.
  * Telegram clients currently support the following 5 types:
  * - {@see InputTextMessageContent InputTextMessageContent}
+ * - {@see InputRichMessageContent InputRichMessageContent}
  * - {@see InputLocationMessageContent InputLocationMessageContent}
  * - {@see InputVenueMessageContent InputVenueMessageContent}
  * - {@see InputContactMessageContent InputContactMessageContent}

--- a/src/Telegram/Types/Media/Link.php
+++ b/src/Telegram/Types/Media/Link.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Media;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * Represents an HTTP link.
+ * @see https://core.telegram.org/bots/api#link
+ */
+class Link extends BaseType
+{
+    /**
+     * URL of the link
+     */
+    public string $url;
+}

--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -56,6 +56,7 @@ use SergiX44\Nutgram\Telegram\Types\Poll\Poll;
 use SergiX44\Nutgram\Telegram\Types\Poll\PollOptionAdded;
 use SergiX44\Nutgram\Telegram\Types\Poll\PollOptionDeleted;
 use SergiX44\Nutgram\Telegram\Types\Reaction\ReactionType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichMessage;
 use SergiX44\Nutgram\Telegram\Types\Shared\ChatShared;
 use SergiX44\Nutgram\Telegram\Types\Shared\UserShared;
 use SergiX44\Nutgram\Telegram\Types\Shared\UsersShared;
@@ -329,6 +330,12 @@ class Message extends BaseType
      * Optional. Unique identifier of the message effect added to the message
      */
     public ?string $effect_id = null;
+
+    /**
+     * Optional. Message is a rich formatted message
+     */
+    public ?RichMessage $rich_message = null;
+
     /**
      * Optional.
      * Message is an animation, information about the animation.

--- a/src/Telegram/Types/Poll/PollMedia.php
+++ b/src/Telegram/Types/Poll/PollMedia.php
@@ -9,6 +9,7 @@ use SergiX44\Nutgram\Telegram\Types\Location\Venue;
 use SergiX44\Nutgram\Telegram\Types\Media\Animation;
 use SergiX44\Nutgram\Telegram\Types\Media\Audio;
 use SergiX44\Nutgram\Telegram\Types\Media\Document;
+use SergiX44\Nutgram\Telegram\Types\Media\Link;
 use SergiX44\Nutgram\Telegram\Types\Media\LivePhoto;
 use SergiX44\Nutgram\Telegram\Types\Media\PhotoSize;
 use SergiX44\Nutgram\Telegram\Types\Media\Video;
@@ -34,6 +35,11 @@ class PollMedia extends BaseType
      * Optional. Media is a general file, information about the file; currently, can't be received in a poll option
      */
     public ?Document $document = null;
+
+    /**
+     * Optional. The HTTP link attached to the poll option
+     */
+    public ?Link $link = null;
 
     /**
      * Optional. Media is a live photo, information about the live photo

--- a/src/Telegram/Types/RichMessage/InputRichMessage.php
+++ b/src/Telegram/Types/RichMessage/InputRichMessage.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage;
+
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * Describes a rich message to be sent.
+ * Exactly one of the fields html or markdown must be used.
+ * @see https://core.telegram.org/bots/api#inputrichmessage
+ */
+#[SkipConstructor]
+class InputRichMessage extends BaseType
+{
+    /**
+     * Optional. Content of the rich message to send described using HTML formatting.
+     * See {@see https://core.telegram.org/bots/api#rich-message-formatting-options rich message formatting options} for more details.
+     */
+    public ?string $html = null;
+
+    /**
+     * Optional. Content of the rich message to send described using Markdown formatting.
+     * See {@see https://core.telegram.org/bots/api#rich-message-formatting-options rich message formatting options} for more details.
+     */
+    public ?string $markdown = null;
+
+    /**
+     * Optional. Pass True if the rich message must be shown right-to-left
+     */
+    public ?bool $is_rtl = null;
+
+    /**
+     * Optional. Pass True to skip automatic detection of entities
+     * (e.g., URLs, email addresses, username mentions, hashtags, cashtags, bot commands, or phone numbers) in the text
+     */
+    public ?bool $skip_entity_detection = null;
+
+    public function __construct(
+        ?string $html = null,
+        ?string $markdown = null,
+        ?bool $is_rtl = null,
+        ?bool $skip_entity_detection = null,
+    )
+    {
+        parent::__construct();
+        $this->html = $html;
+        $this->markdown = $markdown;
+        $this->is_rtl = $is_rtl;
+        $this->skip_entity_detection = $skip_entity_detection;
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichMessage.php
+++ b/src/Telegram/Types/RichMessage/InputRichMessage.php
@@ -41,8 +41,7 @@ class InputRichMessage extends BaseType
         ?string $markdown = null,
         ?bool $is_rtl = null,
         ?bool $skip_entity_detection = null,
-    )
-    {
+    ) {
         parent::__construct();
         $this->html = $html;
         $this->markdown = $markdown;

--- a/src/Telegram/Types/RichMessage/InputRichMessageContent.php
+++ b/src/Telegram/Types/RichMessage/InputRichMessageContent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage;
+
+use SergiX44\Nutgram\Telegram\Types\Input\InputMessageContent;
+
+/**
+ * Represents the {@see https://core.telegram.org/bots/api#inputmessagecontent content}
+ * of a rich message to be sent as the result of an inline query.
+ */
+class InputRichMessageContent extends InputMessageContent
+{
+    /**
+     * The message to be sent
+     */
+    public InputRichMessage $rich_message;
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'rich_message' => $this->rich_message,
+        ];
+    }
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlock.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlock.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+/**
+ * This object represents a block in a rich formatted message. Currently, it can be any of the following types:
+ * {@see RichBlockParagraph}
+ * {@see RichBlockSectionHeading}
+ * {@see RichBlockPreformatted}
+ * {@see RichBlockFooter}
+ * {@see RichBlockDivider}
+ * {@see RichBlockMathematicalExpression}
+ * {@see RichBlockAnchor}
+ * {@see RichBlockList}
+ * {@see RichBlockBlockQuotation}
+ * {@see RichBlockPullQuotation}
+ * {@see RichBlockCollage}
+ * {@see RichBlockSlideshow}
+ * {@see RichBlockTable}
+ * {@see RichBlockDetails}
+ * {@see RichBlockMap}
+ * {@see RichBlockAnimation}
+ * {@see RichBlockAudio}
+ * {@see RichBlockPhoto}
+ * {@see RichBlockVideo}
+ * {@see RichBlockVoiceNote}
+ * {@see RichBlockThinking}
+ * @see https://core.telegram.org/bots/api#richblock
+ */
+interface RichBlock
+{
+    // nothing here, this interface is only for type hinting
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockAnchor.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockAnchor.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A block with an anchor, corresponding to the HTML tag <code><a></code> with the attribute name.
+ * @see https://core.telegram.org/bots/api#richblockanchor
+ */
+class RichBlockAnchor extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “anchor”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::ANCHOR;
+
+    /**
+     * The name of the anchor
+     */
+    public string $name;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockAnimation.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockAnimation.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Media\Animation;
+
+/**
+ * A block with an animation, corresponding to the HTML tag <code><video></code>.
+ * @see https://core.telegram.org/bots/api#richblockanimation
+ */
+class RichBlockAnimation extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “animation”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::ANIMATION;
+
+    /**
+     * The animation
+     */
+    public Animation $animation;
+
+    /**
+     * Optional. True, if the media preview is covered by a spoiler animation
+     */
+    public ?bool $has_spoiler;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockAudio.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockAudio.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Media\Audio;
+
+/**
+ * A block with a music file, corresponding to the HTML tag <code><audio></code>.
+ * @see https://core.telegram.org/bots/api#richblockaudio
+ */
+class RichBlockAudio extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “audio”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::AUDIO;
+
+    /**
+     * The audio
+     */
+    public Audio $audio;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockBlockQuotation.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockBlockQuotation.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A block quotation, corresponding to the HTML tag <code><blockquote></code>.
+ * @see https://core.telegram.org/bots/api#richblockblockquotation
+ */
+class RichBlockBlockQuotation extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “blockquote”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::BLOCKQUOTE;
+
+    /**
+     * Content of the block
+     * @var RichBlock[]
+     */
+    #[ArrayType(RichBlock::class)]
+    public array $blocks;
+
+    /**
+     * Optional. Credit of the block
+     * @var string|RichText[]|RichText|null
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText|null $credit = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockCaption.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockCaption.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * Caption of a rich formatted block.
+ * @see https://core.telegram.org/bots/api#richblockcaption
+ */
+class RichBlockCaption extends BaseType
+{
+    /**
+     * Block caption
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * Optional. Block credit which corresponds to the HTML tag <cite>
+     * @var string|RichText[]|RichText|null
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText|null $credit = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockCollage.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockCollage.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A collage, corresponding to the custom HTML tag <code><tg-collage></code>.
+ * @see https://core.telegram.org/bots/api#richblockcollage
+ */
+class RichBlockCollage extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “collage”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::COLLAGE;
+
+    /**
+     * Elements of the collage
+     * @var RichBlock[]
+     */
+    #[ArrayType(RichBlock::class)]
+    public array $blocks;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public RichBlockCaption|null $caption = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockDetails.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockDetails.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * An expandable block for details disclosure, corresponding to the HTML tag <code><details></code>.
+ * @see https://core.telegram.org/bots/api#richblockdetails
+ */
+class RichBlockDetails extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “details”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::DETAILS;
+
+    /**
+     * Always shown summary of the block
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $summary;
+
+    /**
+     * Content of the block
+     * @var RichBlock[]
+     */
+    #[ArrayType(RichBlock::class)]
+    public array $blocks;
+
+    /**
+     * Optional. True, if the content of the block is visible by default
+     */
+    public ?bool $is_open = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockDivider.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockDivider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A divider, corresponding to the HTML tag <code><hr/></code>.
+ * @see https://core.telegram.org/bots/api#richblockdivider
+ */
+class RichBlockDivider extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “divider”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::DIVIDER;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockFooter.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockFooter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A footer, corresponding to the HTML tag <code><footer></code>.
+ * @see https://core.telegram.org/bots/api#richblockfooter
+ */
+class RichBlockFooter extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “footer”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::FOOTER;
+
+    /**
+     * Text of the block
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockList.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockList.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A list of blocks, corresponding to the HTML tag <code><ul></code> or <code><ol></code> with multiple nested tags <code><li></code>.
+ * @see https://core.telegram.org/bots/api#richblocklist
+ */
+class RichBlockList extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “list”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::LIST;
+
+    /**
+     * Items of the list
+     * @var RichBlockListItem[]
+     */
+    #[ArrayType(RichBlockListItem::class)]
+    public array $items;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockListItem.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockListItem.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockListItemType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * An item of a list.
+ * @see https://core.telegram.org/bots/api#richblocklistitem
+ */
+class RichBlockListItem extends BaseType
+{
+    /**
+     * Label of the item
+     */
+    public string $label;
+
+    /**
+     * The content of the item
+     * @var RichBlock[]
+     */
+    #[ArrayType(RichBlock::class)]
+    public array $blocks;
+
+    /**
+     * Optional. True, if the item has a checkbox
+     */
+    public ?bool $has_checkbox = null;
+
+    /**
+     * Optional. True, if the item has a checked checkbox
+     */
+    public ?bool $is_checked = null;
+
+    /**
+     * Optional. For ordered lists, the numeric value of the item label
+     */
+    public ?int $value = null;
+
+    /**
+     * Optional. For ordered lists, the type of the item label; must be one of
+     * - “a” for lowercase letters,
+     * - “A” for uppercase letters,
+     * - “i” for lowercase Roman numerals,
+     * - “I” for uppercase Roman numerals, or
+     * - “1” for decimal numbers
+     */
+    #[EnumOrScalar]
+    public RichBlockListItemType|string|null $type = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockMap.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockMap.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Location\Location;
+
+/**
+ * A block with a map, corresponding to the custom HTML tag <code><tg-map></code>.
+ * @see https://core.telegram.org/bots/api#richblockmap
+ */
+class RichBlockMap extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “map”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::MAP;
+
+    /**
+     * Location of the center of the map
+     */
+    public Location $location;
+
+    /**
+     * Map zoom level; 13-20
+     */
+    public int $zoom;
+
+    /**
+     * Expected width of the map
+     */
+    public int $width;
+
+    /**
+     * Expected height of the map
+     */
+    public int $height;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockMathematicalExpression.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockMathematicalExpression.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A block with a mathematical expression in LaTeX format, corresponding to the custom HTML tag <code><tg-math-block></code>.
+ * @see https://core.telegram.org/bots/api#richblockmathematicalexpression
+ */
+class RichBlockMathematicalExpression extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “mathematical_expression”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::MATHEMATICAL_EXPRESSION;
+
+    /**
+     * The mathematical expression in LaTeX format
+     */
+    public string $expression;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockParagraph.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockParagraph.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A text paragraph, corresponding to the HTML tag <code><p></code>.
+ * @see https://core.telegram.org/bots/api#richblockparagraph
+ */
+class RichBlockParagraph extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “paragraph”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::PARAGRAPH;
+
+    /**
+     * Text of the block
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockPhoto.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockPhoto.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Media\PhotoSize;
+
+/**
+ * A block with a photo, corresponding to the HTML tag <code><photo></code>.
+ * @see https://core.telegram.org/bots/api#richblockphoto
+ */
+class RichBlockPhoto extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “photo”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::PHOTO;
+
+    /**
+     * Available sizes of the photo
+     * @var PhotoSize[] $photo
+     */
+    #[ArrayType(PhotoSize::class)]
+    public array $photo;
+
+    /**
+     * Optional. True, if the media preview is covered by a spoiler animation
+     */
+    public ?bool $has_spoiler;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockPreformatted.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockPreformatted.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A preformatted text block, corresponding to the nested HTML tags <code><pre></code> and <code><code></code>.
+ * @see https://core.telegram.org/bots/api#richblockpreformatted
+ */
+class RichBlockPreformatted extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “pre”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::PRE;
+
+    /**
+     * Text of the block
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * Optional. The programming language of the text
+     */
+    public ?string $language = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockPullQuotation.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockPullQuotation.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A quotation with centered text, loosely corresponding to the HTML tag <code><aside></code>.
+ * @see https://core.telegram.org/bots/api#richblockpullquotation
+ */
+class RichBlockPullQuotation extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “pullquote”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::PULLQUOTE;
+
+    /**
+     * Text of the block
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * Optional. Credit of the block
+     * @var string|RichText[]|RichText|null
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText|null $credit = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockSectionHeading.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockSectionHeading.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A section heading, corresponding to the HTML tags
+ * <code><h1></code>, <code><h2></code>, <code><h3></code>,
+ * <code><h4></code>, <code><h5></code>, or <code><h6></code>.
+ * @see https://core.telegram.org/bots/api#richblocksectionheading
+ */
+class RichBlockSectionHeading extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “heading”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::HEADING;
+
+    /**
+     * Text of the block
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * Relative size of the text font; 1-6, 1 is the largest, 6 is the smallest
+     */
+    public int $size;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockSlideshow.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockSlideshow.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A slideshow, corresponding to the custom HTML tag <code><tg-slideshow></code>.
+ * @see https://core.telegram.org/bots/api#richblockcollage
+ */
+class RichBlockSlideshow extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “slideshow”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::SLIDESHOW;
+
+    /**
+     * Elements of the slideshow
+     * @var RichBlock[]
+     */
+    #[ArrayType(RichBlock::class)]
+    public array $blocks;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public RichBlockCaption|null $caption = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockTable.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockTable.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A table, corresponding to the HTML tag <code><table></code>.
+ * @see https://core.telegram.org/bots/api#richblocktable
+ */
+class RichBlockTable extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “table”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::TABLE;
+
+    /**
+     * Cells of the table
+     * @var RichBlockTableCell[][]
+     */
+    #[ArrayType(RichBlockTableCell::class, 2)]
+    public array $cells;
+
+    /**
+     * Optional. True, if the table has borders
+     */
+    public ?bool $is_bordered = null;
+
+    /**
+     * Optional. True, if the table is striped
+     */
+    public ?bool $is_striped = null;
+
+    /**
+     * Optional. Caption of the table
+     * @var string|RichText[]|RichText|null
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText|null $caption = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockTableCell.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockTableCell.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockTableCellAlign;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockTableCellValign;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * Cell in a table.
+ * @see https://core.telegram.org/bots/api#richblocktablecell
+ */
+class RichBlockTableCell extends BaseType
+{
+    /**
+     * Optional. Text in the cell. If omitted, then the cell is invisible.
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText|null $text = null;
+
+    /**
+     * Optional. True, if the cell is a header cell
+     */
+    public ?bool $is_header = null;
+
+    /**
+     * Optional. The number of columns the cell spans if it is bigger than 1
+     */
+    public ?int $colspan = null;
+
+    /**
+     * Optional. The number of rows the cell spans if it is bigger than 1
+     */
+    public ?int $rowspan = null;
+
+    /**
+     * Horizontal cell content alignment. Currently, must be one of “left”, “center”, or “right”.
+     */
+    #[EnumOrScalar]
+    public RichBlockTableCellAlign|string $align;
+
+    /**
+     * Vertical cell content alignment. Currently, must be one of “top”, “middle”, or “bottom”.
+     */
+    #[EnumOrScalar]
+    public RichBlockTableCellValign|string $valign;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockThinking.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockThinking.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A block with a “Thinking…” placeholder, corresponding to the custom HTML tag <code><tg-thinking></code>.
+ * The block may be used only in {@see https://core.telegram.org/bots/api#sendrichmessagedraft sendRichMessageDraft}, therefore it can't be received in messages.
+ * See https://t.me/addemoji/AIActions for examples of custom emoji, which are recommended for usage in the block.
+ * @see https://core.telegram.org/bots/api#richblockanchor
+ */
+class RichBlockThinking extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “thinking”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::THINKING;
+
+    /**
+     * Text of the block.
+     * See https://t.me/addemoji/AIActions for examples of custom emoji,
+     * which are recommended for usage in the block.
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockVideo.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockVideo.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Media\Video;
+
+/**
+ * A block with a video, corresponding to the HTML tag <code><video></code>.
+ * @see https://core.telegram.org/bots/api#richblockvideo
+ */
+class RichBlockVideo extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “video”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::VIDEO;
+
+    /**
+     * The video
+     */
+    public Video $video;
+
+    /**
+     * Optional. True, if the media preview is covered by a spoiler animation
+     */
+    public ?bool $has_spoiler;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockVoiceNote.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockVoiceNote.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Media\Voice;
+
+/**
+ * A block with a voice note, corresponding to the HTML tag <code><audio></code>.
+ * @see https://core.telegram.org/bots/api#richblockvoicenote
+ */
+class RichBlockVoiceNote extends BaseType implements RichBlock
+{
+    /**
+     * Type of the block, always “voice_note”
+     */
+    #[EnumOrScalar]
+    public RichBlockType|string $type = RichBlockType::VOICE_NOTE;
+
+    /**
+     * The voice note
+     */
+    public Voice $voice_note;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+}

--- a/src/Telegram/Types/RichMessage/RichMessage.php
+++ b/src/Telegram/Types/RichMessage/RichMessage.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock\RichBlock;
+
+/**
+ * Rich formatted message.
+ * @see https://core.telegram.org/bots/api#richmessage
+ */
+class RichMessage extends BaseType
+{
+    /**
+     * Content of the message
+     * @var RichBlock[]
+     */
+    #[ArrayType(RichBlock::class)]
+    public array $blocks;
+
+    /**
+     * Optional. True, if the rich message must be shown right-to-left
+     */
+    public ?bool $is_rtl = null;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichText.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichText.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+/**
+ * This object represents a rich formatted text.
+ * Currently, it can be either a String for plain text, an Array of RichText, or any of the following types:
+ * {@see RichTextBold}
+ * {@see RichTextItalic}
+ * {@see RichTextUnderline}
+ * {@see RichTextStrikethrough}
+ * {@see RichTextSpoiler}
+ * {@see RichTextDateTime}
+ * {@see RichTextTextMention}
+ * {@see RichTextSubscript}
+ * {@see RichTextSuperscript}
+ * {@see RichTextMarked}
+ * {@see RichTextCode}
+ * {@see RichTextCustomEmoji}
+ * {@see RichTextMathematicalExpression}
+ * {@see RichTextUrl}
+ * {@see RichTextEmailAddress}
+ * {@see RichTextPhoneNumber}
+ * {@see RichTextBankCardNumber}
+ * {@see RichTextMention}
+ * {@see RichTextHashtag}
+ * {@see RichTextCashtag}
+ * {@see RichTextBotCommand}
+ * {@see RichTextAnchor}
+ * {@see RichTextAnchorLink}
+ * {@see RichTextReference}
+ * {@see RichTextReferenceLink}
+ * @see https://core.telegram.org/bots/api#richtext
+ */
+interface RichText
+{
+    // nothing here, this interface is only for type hinting
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextAnchor.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextAnchor.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * An anchor.
+ * @see https://core.telegram.org/bots/api#richtextanchor
+ */
+class RichTextAnchor extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “anchor”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::ANCHOR;
+
+    /**
+     * The name of the anchor
+     */
+    public string $name;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextAnchorLink.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextAnchorLink.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A link to an anchor.
+ * @see https://core.telegram.org/bots/api#richtextanchorlink
+ */
+class RichTextAnchorLink extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “anchor_link”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::ANCHOR_LINK;
+
+    /**
+     * The link text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The name of the anchor.
+     * If the name is empty, then the link brings back to the top of the message.
+     */
+    public string $anchor_name;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextBankCardNumber.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextBankCardNumber.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A text with a bank card number.
+ * @see https://core.telegram.org/bots/api#richtextbankcardnumber
+ */
+class RichTextBankCardNumber extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “bank_card_number”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::BANK_CARD_NUMBER;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The bank card number
+     */
+    public string $bank_card_number;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextBold.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextBold.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A bold text.
+ * @see https://core.telegram.org/bots/api#richtextbold
+ */
+class RichTextBold extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “bold”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::BOLD;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextBotCommand.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextBotCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A bot command.
+ * @see https://core.telegram.org/bots/api#richtextbotcommand
+ */
+class RichTextBotCommand extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “bot_command”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::BOT_COMMAND;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The bot command
+     */
+    public string $bot_command;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextCashtag.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextCashtag.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A cashtag.
+ * @see https://core.telegram.org/bots/api#richtextcashtag
+ */
+class RichTextCashtag extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “cashtag”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::CASHTAG;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The cashtag
+     */
+    public string $cashtag;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextCode.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextCode.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A monowidth text.
+ * @see https://core.telegram.org/bots/api#richtextcode
+ */
+class RichTextCode extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “code”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::CODE;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextCustomEmoji.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextCustomEmoji.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A custom emoji.
+ * @see https://core.telegram.org/bots/api#richtextcustomemoji
+ */
+class RichTextCustomEmoji extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “custom_emoji”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::CustomEmoji;
+
+    /**
+     * Unique identifier of the custom emoji.
+     * Use {@see https://core.telegram.org/bots/api#getcustomemojistickers getCustomEmojiStickers} to get full information about the sticker.
+     */
+    public string $custom_emoji_id;
+
+    /**
+     * Alternative emoji for the custom emoji
+     */
+    public string $alternative_text;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextDateTime.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextDateTime.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * Formatted date and time.
+ * @see https://core.telegram.org/bots/api#richtextdatetime
+ */
+class RichTextDateTime extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “date_time”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::DATETIME;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The Unix time associated with the entity
+     */
+    public int $unix_time;
+
+    /**
+     * The string that defines the formatting of the date and time.
+     * See {@see https://core.telegram.org/bots/api#date-time-entity-formatting date-time entity formatting}
+     * for more details.
+     */
+    public string $date_time_format;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextEmailAddress.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextEmailAddress.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A text with an email address.
+ * @see https://core.telegram.org/bots/api#richtextemailaddress
+ */
+class RichTextEmailAddress extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “email_address”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::EMAIL_ADDRESS;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The email address
+     */
+    public string $email_address;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextHashtag.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextHashtag.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A hashtag.
+ * @see https://core.telegram.org/bots/api#richtexthashtag
+ */
+class RichTextHashtag extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “hashtag”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::HASHTAG;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The hashtag
+     */
+    public string $hashtag;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextItalic.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextItalic.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * An italicized text.
+ * @see https://core.telegram.org/bots/api#richtextitalic
+ */
+class RichTextItalic extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “italic”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::ITALIC;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextMarked.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextMarked.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A marked text.
+ * @see https://core.telegram.org/bots/api#richtextmarked
+ */
+class RichTextMarked extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “marked”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::MARKED;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextMathematicalExpression.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextMathematicalExpression.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A mathematical expression.
+ * @see https://core.telegram.org/bots/api#richtextmathematicalexpression
+ */
+class RichTextMathematicalExpression extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “mathematical_expression”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::MATHEMATICAL_EXPRESSION;
+
+    /**
+     * The expression in LaTeX format
+     */
+    public string $expression;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextMention.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextMention.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A mention by a username.
+ * @see https://core.telegram.org/bots/api#richtextmention
+ */
+class RichTextMention extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “mention”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::MENTION;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The username
+     */
+    public string $username;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextPhoneNumber.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextPhoneNumber.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A text with a phone number.
+ * @see https://core.telegram.org/bots/api#richtextphonenumber
+ */
+class RichTextPhoneNumber extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “phone_number”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::PHONE_NUMBER;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The phone number
+     */
+    public string $phone_number;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextReference.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextReference.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A reference.
+ * @see https://core.telegram.org/bots/api#richtextreference
+ */
+class RichTextReference extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “reference”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::REFERENCE;
+
+    /**
+     * Text of the reference
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The name of the reference
+     */
+    public string $name;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextReferenceLink.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextReferenceLink.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A link to a reference.
+ * @see https://core.telegram.org/bots/api#richtextreferencelink
+ */
+class RichTextReferenceLink extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “reference_link”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::REFERENCE_LINK;
+
+    /**
+     * The link text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The name of the reference
+     */
+    public string $reference_name;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextSpoiler.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextSpoiler.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A text covered by a spoiler.
+ * @see https://core.telegram.org/bots/api#richtextspoiler
+ */
+class RichTextSpoiler extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “spoiler”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::SPOILER;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextStrikethrough.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextStrikethrough.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A strikethrough text.
+ * @see https://core.telegram.org/bots/api#richtextstrikethrough
+ */
+class RichTextStrikethrough extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “strikethrough”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::STRIKETHROUGH;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextSubscript.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextSubscript.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A subscript text.
+ * @see https://core.telegram.org/bots/api#richtextsubscript
+ */
+class RichTextSubscript extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “subscript”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::SUBSCRIPT;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextSuperscript.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextSuperscript.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A superscript text.
+ * @see https://core.telegram.org/bots/api#richtextsuperscript
+ */
+class RichTextSuperscript extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “superscript”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::SUPERSCRIPT;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextTextMention.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextTextMention.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\User\User;
+
+/**
+ * A mention of a Telegram user by their identifier.
+ * @see https://core.telegram.org/bots/api#richtexttextmention
+ */
+class RichTextTextMention extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “text_mention”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::TEXT_MENTION;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * The mentioned user
+     */
+    public User $user;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextUnderline.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextUnderline.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * An underlined text.
+ * @see https://core.telegram.org/bots/api#richtextunderline
+ */
+class RichTextUnderline extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “underline”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::UNDERLINE;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+}

--- a/src/Telegram/Types/RichMessage/RichText/RichTextUrl.php
+++ b/src/Telegram/Types/RichMessage/RichText/RichTextUrl.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichText;
+
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichTextType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A text with a link.
+ * @see https://core.telegram.org/bots/api#richtexturl
+ */
+class RichTextUrl extends BaseType implements RichText
+{
+    /**
+     * Type of the rich text, always “url”
+     */
+    #[EnumOrScalar]
+    public RichTextType|string $type = RichTextType::URL;
+
+    /**
+     * The text
+     * @var string|RichText[]|RichText
+     */
+    #[ArrayType(RichText::class)]
+    public string|array|RichText $text;
+
+    /**
+     * URL of the link
+     */
+    public string $url;
+}

--- a/src/Telegram/Types/User/User.php
+++ b/src/Telegram/Types/User/User.php
@@ -115,6 +115,12 @@ class User extends BaseType
      */
     public ?bool $can_manage_bots = null;
 
+    /**
+     * Optional. True, if the bot supports join request queries and can be assigned to process them.
+     * Returned only in {@see https://core.telegram.org/bots/api#getme getMe}.
+     */
+    public ?bool $supports_join_request_queries = null;
+
     public static function make(
         int $id,
         bool $is_bot,
@@ -133,6 +139,7 @@ class User extends BaseType
         ?bool $allows_users_to_create_topics = null,
         ?bool $can_manage_bots = null,
         ?bool $supports_guest_queries = null,
+        ?bool $supports_join_request_queries = null,
     ): User {
         $user = new self();
         $user->id = $id;
@@ -152,6 +159,7 @@ class User extends BaseType
         $user->allows_users_to_create_topics = $allows_users_to_create_topics;
         $user->can_manage_bots = $can_manage_bots;
         $user->supports_guest_queries = $supports_guest_queries;
+        $user->supports_join_request_queries = $supports_join_request_queries;
         return $user;
     }
 }

--- a/tests/Feature/Listeners/UpdateListenersTest.php
+++ b/tests/Feature/Listeners/UpdateListenersTest.php
@@ -395,6 +395,18 @@ it('calls onChatJoinRequest() handler', function ($update) {
     expect($bot->get('called'))->toBeTrue();
 })->with('chat_join_request');
 
+it('calls onChatJoinRequestQuery() handler', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onChatJoinRequestQuery('foo', function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called'))->toBeTrue();
+})->with('chat_join_request');
+
 it('calls onChatBoost() handler', function ($update) {
     $bot = Nutgram::fake($update);
 

--- a/tests/Fixtures/Updates/chat_join_request.json
+++ b/tests/Fixtures/Updates/chat_join_request.json
@@ -16,6 +16,7 @@
       "username": "mariobros"
     },
     "user_chat_id": 123654789,
-    "date": 123456789
+    "date": 123456789,
+    "query_id": "foo"
   }
 }


### PR DESCRIPTION
#### June 11, 2026
[**Bot API 10.1**](https://core.telegram.org/bots/api-changelog#june-11-2026)

**Rich Messages**

- [x] Added support for [Rich Messages](https://core.telegram.org/bots/features#rich-messages), allowing bots to send highly structured text and stream AI-generated replies with seamless rich formatting.
- [x] Added the classes:
    - [x] [RichTextBold](https://core.telegram.org/bots/api#richtextbold), 
    - [x] [RichTextItalic](https://core.telegram.org/bots/api#richtextitalic),
    - [x] [RichTextUnderline](https://core.telegram.org/bots/api#richtextunderline), 
    - [x] [RichTextStrikethrough](https://core.telegram.org/bots/api#richtextstrikethrough), 
    - [x] [RichTextSpoiler](https://core.telegram.org/bots/api#richtextspoiler), 
    - [x] [RichTextDateTime](https://core.telegram.org/bots/api#richtextdatetime), 
    - [x] [RichTextTextMention](https://core.telegram.org/bots/api#richtexttextmention), 
    - [x] [RichTextSubscript](https://core.telegram.org/bots/api#richtextsubscript), 
    - [x] [RichTextSuperscript](https://core.telegram.org/bots/api#richtextsuperscript), 
    - [x] [RichTextMarked](https://core.telegram.org/bots/api#richtextmarked), 
    - [x] [RichTextCode](https://core.telegram.org/bots/api#richtextcode), 
    - [x] [RichTextCustomEmoji](https://core.telegram.org/bots/api#richtextcustomemoji), 
    - [x] [RichTextMathematicalExpression](https://core.telegram.org/bots/api#richtextmathematicalexpression), 
    - [x] [RichTextUrl](https://core.telegram.org/bots/api#richtexturl), 
    - [x] [RichTextEmailAddress](https://core.telegram.org/bots/api#richtextemailaddress), 
    - [x] [RichTextPhoneNumber](https://core.telegram.org/bots/api#richtextphonenumber), 
    - [x] [RichTextBankCardNumber](https://core.telegram.org/bots/api#richtextbankcardnumber), 
    - [x] [RichTextMention](https://core.telegram.org/bots/api#richtextmention), 
    - [x] [RichTextHashtag](https://core.telegram.org/bots/api#richtexthashtag), 
    - [x] [RichTextCashtag](https://core.telegram.org/bots/api#richtextcashtag), 
    - [x] [RichTextBotCommand](https://core.telegram.org/bots/api#richtextbotcommand), 
    - [x] [RichTextAnchor](https://core.telegram.org/bots/api#richtextanchor), 
    - [x] [RichTextAnchorLink](https://core.telegram.org/bots/api#richtextanchorlink), 
    - [x] [RichTextReference](https://core.telegram.org/bots/api#richtextreference) and 
    - [x] [RichTextReferenceLink](https://core.telegram.org/bots/api#richtextreferencelink), 
which represent different types of rich formatted text.
- [x] Added the class [RichText](https://core.telegram.org/bots/api#richtext), which represents rich formatted text.
- [x] Added the class [RichBlockCaption](https://core.telegram.org/bots/api#richblockcaption), which represents the caption of a rich formatted text.
- [x] Added the class [RichBlockTableCell](https://core.telegram.org/bots/api#richblocktablecell), which represents a cell in a table.
- [x] Added the class [RichBlockListItem](https://core.telegram.org/bots/api#richblocklistitem), which represents an item in a list.
- [x] Added the classes:
    - [x] [RichBlockParagraph](https://core.telegram.org/bots/api#richblockparagraph),
    - [x] [RichBlockSectionHeading](https://core.telegram.org/bots/api#richblocksectionheading), 
    - [x] [RichBlockPreformatted](https://core.telegram.org/bots/api#richblockpreformatted), 
    - [x] [RichBlockFooter](https://core.telegram.org/bots/api#richblockfooter), 
    - [x] [RichBlockDivider](https://core.telegram.org/bots/api#richblockdivider), 
    - [x] [RichBlockMathematicalExpression](https://core.telegram.org/bots/api#richblockmathematicalexpression), 
    - [x] [RichBlockAnchor](https://core.telegram.org/bots/api#richblockanchor), 
    - [x] [RichBlockList](https://core.telegram.org/bots/api#richblocklist), 
    - [x] [RichBlockBlockQuotation](https://core.telegram.org/bots/api#richblockblockquotation), 
    - [x] [RichBlockPullQuotation](https://core.telegram.org/bots/api#richblockpullquotation), 
    - [x] [RichBlockCollage](https://core.telegram.org/bots/api#richblockcollage), 
    - [x] [RichBlockSlideshow](https://core.telegram.org/bots/api#richblockslideshow), 
    - [x] [RichBlockTable](https://core.telegram.org/bots/api#richblocktable), 
    - [x] [RichBlockDetails](https://core.telegram.org/bots/api#richblockdetails), 
    - [x] [RichBlockMap](https://core.telegram.org/bots/api#richblockmap), 
    - [x] [RichBlockAnimation](https://core.telegram.org/bots/api#richblockanimation),
    - [x] [RichBlockAudio](https://core.telegram.org/bots/api#richblockaudio), 
    - [x] [RichBlockPhoto](https://core.telegram.org/bots/api#richblockphoto), 
    - [x] [RichBlockVideo](https://core.telegram.org/bots/api#richblockvideo), 
    - [x] [RichBlockVoiceNote](https://core.telegram.org/bots/api#richblockvoicenote) and 
    - [x] [RichBlockThinking](https://core.telegram.org/bots/api#richblockthinking), 
    which represent different types of blocks in a rich formatted message.
- [x] Added the class [RichBlock](https://core.telegram.org/bots/api#richblock), which represents a block in a rich formatted message.
- [x] Added the class [RichMessage](https://core.telegram.org/bots/api#richmessage), which represents a rich formatted message.
- [x] Added the field _rich\_message_ to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the class [InputRichMessage](https://core.telegram.org/bots/api#inputrichmessage), describing a rich message to send.
- [x] Added the class [InputRichMessageContent](https://core.telegram.org/bots/api#inputrichmessagecontent) and allowed it to be used as [InputMessageContent](https://core.telegram.org/bots/api#inputmessagecontent) in results of inline, guest, and Web App queries.
- [x] Added the method [sendRichMessage](https://core.telegram.org/bots/api#sendrichmessage), allowing bots to send rich messages.
- [x] Added the method [sendRichMessageDraft](https://core.telegram.org/bots/api#sendrichmessagedraft), allowing bots to stream partial rich messages.
- [x] Added the parameter _rich\_message_ to the method [editMessageText](https://core.telegram.org/bots/api#editmessagetext), allowing bots to edit rich messages.

**Join Request Queries**

- [x] Added the field _supports\_join\_request\_queries_ to the class [User](https://core.telegram.org/bots/api#user).
- [x] Added the field _guard\_bot_ to the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).
- [x] Added the field _query\_id_ to the class [ChatJoinRequest](https://core.telegram.org/bots/api#chatjoinrequest).
- [x] Added the method [answerChatJoinRequestQuery](https://core.telegram.org/bots/api#answerchatjoinrequestquery).
- [x] Added the method [sendChatJoinRequestWebApp](https://core.telegram.org/bots/api#sendchatjoinrequestwebapp).

**Polls**

- [x] Added the class [Link](https://core.telegram.org/bots/api#link) and the field _link_ to the class [PollMedia](https://core.telegram.org/bots/api#pollmedia).
- [x] Added the class [InputMediaLink](https://core.telegram.org/bots/api#inputmedialink) and allowed it to be used as [InputPollOptionMedia](https://core.telegram.org/bots/api#inputpolloptionmedia).

**Nutgram**
- [x] Update badge
- [x] onChatJoinRequestQuery handler