### PR TITLE
[5.x]  Remove `$botId` from `Configuration` class

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -53,7 +53,6 @@ final readonly class Configuration
 
     public function __construct(
         public string $apiUrl = self::DEFAULT_API_URL,
-        public ?int $botId = null,
         public ?string $botName = null,
         public bool $testEnv = false,
         public bool $isLocal = false,
@@ -77,7 +76,6 @@ final readonly class Configuration
     {
         return new self(
             apiUrl: $config['api_url'] ?? self::DEFAULT_API_URL,
-            botId: $config['bot_id'] ?? null,
             botName: $config['bot_name'] ?? null,
             testEnv: $config['test_env'] ?? false,
             isLocal: $config['is_local'] ?? false,
@@ -102,7 +100,6 @@ final readonly class Configuration
     {
         return [
             'api_url' => $this->apiUrl,
-            'bot_id' => $this->botId,
             'bot_name' => $this->botName,
             'test_env' => $this->testEnv,
             'is_local' => $this->isLocal,

--- a/src/Nutgram.php
+++ b/src/Nutgram.php
@@ -136,7 +136,7 @@ class Nutgram extends ResolveHandlers
 
     public function getBotId(): int
     {
-        return $this->config->botId ?? (int)explode(':', $this->token)[0];
+        return (int)explode(':', $this->token)[0];
     }
 
     /**


### PR DESCRIPTION
The `botId` property has been removed from the `Configuration` class. Since the bot ID is always reliably derivable from the token, maintaining a separate, overridable configuration value introduced unnecessary complexity and the potential for inconsistent state between the configured ID and the actual token.

If you were instantiating `Configuration` and passing a `botId` argument, you should remove it:

```php
// Before...
$config = new Configuration(
    botId: 123456789,
    botName: 'my_bot',
);

// After...
$config = new Configuration(
    botName: 'my_bot',
);
```


### Retrieving the Bot ID

No changes are required when retrieving the bot ID. `Nutgram::getBotId()` continues to work as before and now always returns the ID parsed **from the token**:

```php
$bot->getBotId(); // (int) 123456789
```
