### PR TITLE
Update to Bot API 10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://i.imgur.com/yrd8jr2.png" width="400px">
 </p>
 
-[![API](https://img.shields.io/badge/Telegram%20Bot%20API-10.1%09--%20June%2011,%202026-28a8ea.svg?logo=telegram)](https://core.telegram.org/bots/api)
+[![API](https://img.shields.io/badge/Telegram%20Bot%20API-10.2%09--%20July%2014,%202026-28a8ea.svg?logo=telegram)](https://core.telegram.org/bots/api)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nutgram/nutgram.svg?label=composer&logo=composer)](https://packagist.org/packages/nutgram/nutgram)
 ![PHP](https://img.shields.io/packagist/dependency-v/nutgram/nutgram/php?logo=php)
 ![License](https://img.shields.io/github/license/nutgram/nutgram)

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -31,6 +31,7 @@ final readonly class Configuration
         'business_message',
         'edited_business_message',
         'deleted_business_messages',
+        'guest_message',
         'message_reaction',
         'message_reaction_count',
         'inline_query',
@@ -47,8 +48,9 @@ final readonly class Configuration
         'chat_boost',
         'removed_chat_boost',
         'managed_bot',
-        'guest_message',
+        'subscription',
     ];
+
     public const DEFAULT_ENABLE_HTTP2 = true;
 
     public const DEFAULT_CONVERSATION_TTL = 43200;

--- a/src/Handlers/HandlerGroup.php
+++ b/src/Handlers/HandlerGroup.php
@@ -7,12 +7,13 @@ use Illuminate\Support\Traits\Macroable;
 use SergiX44\Nutgram\Support\Constraints;
 use SergiX44\Nutgram\Support\Disable;
 use SergiX44\Nutgram\Support\InteractsWithRateLimit;
+use SergiX44\Nutgram\Support\IsEphemeral;
 use SergiX44\Nutgram\Support\Taggable;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScope;
 
 class HandlerGroup
 {
-    use Taggable, Macroable, Disable, Constraints, InteractsWithRateLimit;
+    use Taggable, Macroable, Disable, Constraints, InteractsWithRateLimit, IsEphemeral;
 
     protected array $middlewares = [];
 

--- a/src/Handlers/Listeners/MessageListeners.php
+++ b/src/Handlers/Listeners/MessageListeners.php
@@ -3,7 +3,6 @@
 namespace SergiX44\Nutgram\Handlers\Listeners;
 
 use InvalidArgumentException;
-use SergiX44\Nutgram\Exception\StatusFinalizedException;
 use SergiX44\Nutgram\Handlers\CollectHandlers;
 use SergiX44\Nutgram\Handlers\Handler;
 use SergiX44\Nutgram\Handlers\Type\Command;
@@ -685,15 +684,43 @@ trait MessageListeners
         return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::MANAGED_BOT_CREATED->value][] = new Handler($callable);
     }
 
+    /**
+     * @param callable|class-string|array $callable
+     * @return Handler
+     */
     public function onPollOptionAdded($callable): Handler
     {
         $this->checkFinalized();
         return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::POLL_OPTION_ADDED->value][] = new Handler($callable);
     }
 
+    /**
+     * @param callable|class-string|array $callable
+     * @return Handler
+     */
     public function onPollOptionDeleted($callable): Handler
     {
         $this->checkFinalized();
         return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::POLL_OPTION_DELETED->value][] = new Handler($callable);
+    }
+
+    /**
+     * @param callable|class-string|array $callable
+     * @return Handler
+     */
+    public function onCommunityChatAdded($callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::COMMUNITY_CHAT_ADDED->value][] = new Handler($callable);
+    }
+
+    /**
+     * @param callable|class-string|array $callable
+     * @return Handler
+     */
+    public function onCommunityChatRemoved($callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::MESSAGE->value][MessageType::COMMUNITY_CHAT_REMOVED->value][] = new Handler($callable);
     }
 }

--- a/src/Handlers/Listeners/UpdateListeners.php
+++ b/src/Handlers/Listeners/UpdateListeners.php
@@ -361,4 +361,25 @@ trait UpdateListeners
         $this->checkFinalized();
         return $this->{$this->target}[UpdateType::GUEST_MESSAGE->value][] = new Handler($callable);
     }
+
+    /**
+     * @param callable|class-string|array $callable
+     * @return Handler
+     */
+    public function onBotSubscriptionUpdated($callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::SUBSCRIPTION->value][] = new Handler($callable);
+    }
+
+    /**
+     * @param string $pattern
+     * @param callable|class-string|array $callable
+     * @return Handler
+     */
+    public function onBotSubscriptionUpdatedPayload(string $pattern, $callable): Handler
+    {
+        $this->checkFinalized();
+        return $this->{$this->target}[UpdateType::SUBSCRIPTION->value][$pattern] = new Handler($callable, $pattern);
+    }
 }

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -118,6 +118,9 @@ abstract class ResolveHandlers extends CollectHandlers
         } elseif ($updateType === UpdateType::CHAT_JOIN_REQUEST) {
             $data = $this->update->chat_join_request?->query_id;
             $this->addHandlersBy($resolvedHandlers, $updateType->value, value: $data);
+        } elseif ($updateType === UpdateType::SUBSCRIPTION) {
+            $data = $this->update->subscription?->invoice_payload;
+            $this->addHandlersBy($resolvedHandlers, $updateType->value, value: $data);
         }
 
         if (empty($resolvedHandlers) && $updateType !== null) {
@@ -325,8 +328,11 @@ abstract class ResolveHandlers extends CollectHandlers
                         foreach ($middlewares as $middleware) {
                             $leaf->middleware($middleware);
                         }
-                        if ($leaf instanceof Command && !empty($scopes)) {
-                            $leaf->scope($scopes);
+                        if ($leaf instanceof Command) {
+                            if(!empty($scopes)){
+                                $leaf->scope($scopes);
+                            }
+                            $leaf->ephemeral($group->isEphemeral());
                         }
                         $leaf->tags([...$leaf->getTags(), ...$tags]);
                         $leaf->unless($group->isDisabled());

--- a/src/Handlers/ResolveHandlers.php
+++ b/src/Handlers/ResolveHandlers.php
@@ -329,7 +329,7 @@ abstract class ResolveHandlers extends CollectHandlers
                             $leaf->middleware($middleware);
                         }
                         if ($leaf instanceof Command) {
-                            if(!empty($scopes)){
+                            if (!empty($scopes)) {
                                 $leaf->scope($scopes);
                             }
                             $leaf->ephemeral($group->isEphemeral());

--- a/src/Handlers/Type/Command.php
+++ b/src/Handlers/Type/Command.php
@@ -4,12 +4,15 @@ namespace SergiX44\Nutgram\Handlers\Type;
 
 use RuntimeException;
 use SergiX44\Nutgram\Handlers\Handler;
+use SergiX44\Nutgram\Support\IsEphemeral;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommand;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScope;
 use SergiX44\Nutgram\Telegram\Types\Command\BotCommandScopeDefault;
 
 class Command extends Handler
 {
+    use IsEphemeral;
+
     protected string $command = '#';
 
     protected ?string $description = null;
@@ -127,10 +130,15 @@ class Command extends Handler
         if ($languageCode !== null) {
             return new BotCommand(
                 command: $this->getName(),
-                description: $descriptions[$languageCode] ?? array_shift($descriptions)
+                description: $descriptions[$languageCode] ?? array_shift($descriptions),
+                is_ephemeral: $this->isEphemeral ? true : null,
             );
         }
 
-        return new BotCommand($this->getName(), $descriptions['*'] ?? null);
+        return new BotCommand(
+            command: $this->getName(),
+            description: $descriptions['*'] ?? null,
+            is_ephemeral: $this->isEphemeral ? true : null,
+        );
     }
 }

--- a/src/Proxies/UpdateProxy.php
+++ b/src/Proxies/UpdateProxy.php
@@ -93,6 +93,16 @@ trait UpdateProxy
         return $this->message()?->guest_query_id;
     }
 
+    public function receiverUserId(): ?int
+    {
+        return $this->message()?->receiver_user?->id;
+    }
+
+    public function ephemeralMessageId(): ?int
+    {
+        return $this->message()?->ephemeral_message_id;
+    }
+
     /*
     |--------------------------------------------------------------------------
     | Special proxies

--- a/src/Support/IsEphemeral.php
+++ b/src/Support/IsEphemeral.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SergiX44\Nutgram\Support;
+
+trait IsEphemeral
+{
+    protected bool $isEphemeral = false;
+
+    public function ephemeral(bool $value = true): self
+    {
+        $this->isEphemeral = $value;
+        return $this;
+    }
+
+    public function isEphemeral(): bool
+    {
+        return $this->isEphemeral;
+    }
+}

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -131,6 +131,8 @@ trait AvailableMethods
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @return Message|null
      */
     public function sendMessage(
@@ -152,11 +154,9 @@ trait AvailableMethods
         ?bool $allow_paid_broadcast = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
     ): ?Message {
-        $chat_id ??= $this->chatId();
-        $message_thread_id ??= $this->messageThreadId();
-        $business_connection_id ??= $this->businessConnectionId();
-        $direct_messages_topic_id ??= $this->directMessagesTopicId();
         $parameters = compact(
             'chat_id',
             'message_thread_id',
@@ -176,7 +176,18 @@ trait AvailableMethods
             'allow_paid_broadcast',
             'direct_messages_topic_id',
             'suggested_post_parameters',
+            'receiver_user_id',
+            'callback_query_id',
         );
+        $parameters['chat_id'] ??= $this->chatId();
+        $parameters['message_thread_id'] ??= $this->messageThreadId();
+        $parameters['business_connection_id'] ??= $this->businessConnectionId();
+        $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
 
         return $this->requestJson(__FUNCTION__, $parameters, Message::class);
     }
@@ -451,6 +462,8 @@ trait AvailableMethods
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -474,6 +487,8 @@ trait AvailableMethods
         ?bool $allow_paid_broadcast = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
         array $clientOpt = [],
     ): ?Message {
         $parameters = compact(
@@ -496,11 +511,18 @@ trait AvailableMethods
             'allow_paid_broadcast',
             'direct_messages_topic_id',
             'suggested_post_parameters',
+            'receiver_user_id',
+            'callback_query_id',
         );
         $parameters['chat_id'] ??= $this->chatId();
         $parameters['message_thread_id'] ??= $this->messageThreadId();
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
 
         return $this->sendAttachments(__FUNCTION__, ['photo'], $parameters, $clientOpt);
     }
@@ -602,6 +624,8 @@ trait AvailableMethods
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -627,6 +651,8 @@ trait AvailableMethods
         ?bool $allow_paid_broadcast = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
         array $clientOpt = [],
     ): ?Message {
         $parameters = compact(
@@ -651,11 +677,18 @@ trait AvailableMethods
             'allow_paid_broadcast',
             'direct_messages_topic_id',
             'suggested_post_parameters',
+            'receiver_user_id',
+            'callback_query_id',
         );
         $parameters['chat_id'] ??= $this->chatId();
         $parameters['message_thread_id'] ??= $this->messageThreadId();
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
 
         return $this->sendAttachments(__FUNCTION__, ['audio'], $parameters, $clientOpt);
     }
@@ -684,6 +717,8 @@ trait AvailableMethods
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -707,6 +742,8 @@ trait AvailableMethods
         ?bool $allow_paid_broadcast = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
         array $clientOpt = [],
     ): ?Message {
         $parameters = compact(
@@ -729,11 +766,18 @@ trait AvailableMethods
             'allow_paid_broadcast',
             'direct_messages_topic_id',
             'suggested_post_parameters',
+            'receiver_user_id',
+            'callback_query_id',
         );
         $parameters['chat_id'] ??= $this->chatId();
         $parameters['message_thread_id'] ??= $this->messageThreadId();
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
 
         return $this->sendAttachments(__FUNCTION__, ['document'], $parameters, $clientOpt);
     }
@@ -769,6 +813,8 @@ trait AvailableMethods
      * @param int|null $start_timestamp Start timestamp for the video in the message
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -799,6 +845,8 @@ trait AvailableMethods
         ?int $start_timestamp = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
         array $clientOpt = [],
     ): ?Message {
         $parameters = compact(
@@ -828,11 +876,18 @@ trait AvailableMethods
             'start_timestamp',
             'direct_messages_topic_id',
             'suggested_post_parameters',
+            'receiver_user_id',
+            'callback_query_id',
         );
         $parameters['chat_id'] ??= $this->chatId();
         $parameters['message_thread_id'] ??= $this->messageThreadId();
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
 
         return $this->sendAttachments(__FUNCTION__, ['video'], $parameters, $clientOpt);
     }
@@ -865,6 +920,8 @@ trait AvailableMethods
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -892,6 +949,8 @@ trait AvailableMethods
         ?bool $allow_paid_broadcast = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
         array $clientOpt = [],
     ): ?Message {
         $parameters = compact(
@@ -918,11 +977,18 @@ trait AvailableMethods
             'allow_paid_broadcast',
             'direct_messages_topic_id',
             'suggested_post_parameters',
+            'receiver_user_id',
+            'callback_query_id',
         );
         $parameters['chat_id'] ??= $this->chatId();
         $parameters['message_thread_id'] ??= $this->messageThreadId();
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
 
         return $this->sendAttachments(__FUNCTION__, ['animation'], $parameters, $clientOpt);
     }
@@ -951,6 +1017,8 @@ trait AvailableMethods
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -973,6 +1041,8 @@ trait AvailableMethods
         ?bool $allow_paid_broadcast = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
         array $clientOpt = [],
     ): ?Message {
         $parameters = compact(
@@ -994,11 +1064,18 @@ trait AvailableMethods
             'allow_paid_broadcast',
             'direct_messages_topic_id',
             'suggested_post_parameters',
+            'receiver_user_id',
+            'callback_query_id',
         );
         $parameters['chat_id'] ??= $this->chatId();
         $parameters['message_thread_id'] ??= $this->messageThreadId();
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
 
         return $this->sendAttachments(__FUNCTION__, ['voice'], $parameters, $clientOpt);
     }
@@ -1025,6 +1102,8 @@ trait AvailableMethods
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -1046,6 +1125,8 @@ trait AvailableMethods
         ?bool $allow_paid_broadcast = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
         array $clientOpt = [],
     ): ?Message {
         $parameters = compact(
@@ -1066,11 +1147,18 @@ trait AvailableMethods
             'allow_paid_broadcast',
             'direct_messages_topic_id',
             'suggested_post_parameters',
+            'receiver_user_id',
+            'callback_query_id',
         );
         $parameters['chat_id'] ??= $this->chatId();
         $parameters['message_thread_id'] ??= $this->messageThreadId();
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
 
         return $this->sendAttachments(__FUNCTION__, ['video_note'], $parameters, $clientOpt);
     }
@@ -1229,6 +1317,8 @@ trait AvailableMethods
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @return Message|null
      */
     public function sendLocation(
@@ -1251,12 +1341,10 @@ trait AvailableMethods
         ?bool $allow_paid_broadcast = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
     ): ?Message {
-        $chat_id ??= $this->chatId();
-        $message_thread_id ??= $this->messageThreadId();
-        $business_connection_id ??= $this->businessConnectionId();
-        $direct_messages_topic_id ??= $this->directMessagesTopicId();
-        return $this->requestJson(__FUNCTION__, compact(
+        $parameters = compact(
             'chat_id',
             'message_thread_id',
             'latitude',
@@ -1276,7 +1364,20 @@ trait AvailableMethods
             'allow_paid_broadcast',
             'direct_messages_topic_id',
             'suggested_post_parameters',
-        ), Message::class);
+            'receiver_user_id',
+            'callback_query_id',
+        );
+        $parameters['chat_id'] ??= $this->chatId();
+        $parameters['message_thread_id'] ??= $this->messageThreadId();
+        $parameters['business_connection_id'] ??= $this->businessConnectionId();
+        $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
+
+        return $this->requestJson(__FUNCTION__, $parameters, Message::class);
     }
 
     /**
@@ -1334,6 +1435,8 @@ trait AvailableMethods
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @return Message|null
      */
     public function sendVenue(
@@ -1358,13 +1461,10 @@ trait AvailableMethods
         ?bool $allow_paid_broadcast = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
     ): ?Message {
-        $chat_id ??= $this->chatId();
-        $message_thread_id ??= $this->messageThreadId();
-        $business_connection_id ??= $this->businessConnectionId();
-        $direct_messages_topic_id ??= $this->directMessagesTopicId();
-
-        return $this->requestJson(__FUNCTION__, compact(
+        $parameters = compact(
             'chat_id',
             'message_thread_id',
             'latitude',
@@ -1386,7 +1486,20 @@ trait AvailableMethods
             'allow_paid_broadcast',
             'direct_messages_topic_id',
             'suggested_post_parameters',
-        ), Message::class);
+            'receiver_user_id',
+            'callback_query_id',
+        );
+        $parameters['chat_id'] ??= $this->chatId();
+        $parameters['message_thread_id'] ??= $this->messageThreadId();
+        $parameters['business_connection_id'] ??= $this->businessConnectionId();
+        $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
+
+        return $this->requestJson(__FUNCTION__, $parameters, Message::class);
     }
 
     /**
@@ -1410,6 +1523,8 @@ trait AvailableMethods
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @return Message|null
      */
     public function sendContact(
@@ -1430,13 +1545,10 @@ trait AvailableMethods
         ?bool $allow_paid_broadcast = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
     ): ?Message {
-        $chat_id ??= $this->chatId();
-        $message_thread_id ??= $this->messageThreadId();
-        $business_connection_id ??= $this->businessConnectionId();
-        $direct_messages_topic_id ??= $this->directMessagesTopicId();
-
-        return $this->requestJson(__FUNCTION__, compact(
+        $parameters = compact(
             'chat_id',
             'message_thread_id',
             'phone_number',
@@ -1454,7 +1566,20 @@ trait AvailableMethods
             'allow_paid_broadcast',
             'direct_messages_topic_id',
             'suggested_post_parameters',
-        ), Message::class);
+            'receiver_user_id',
+            'callback_query_id',
+        );
+        $parameters['chat_id'] ??= $this->chatId();
+        $parameters['message_thread_id'] ??= $this->messageThreadId();
+        $parameters['business_connection_id'] ??= $this->businessConnectionId();
+        $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
+
+        return $this->requestJson(__FUNCTION__, $parameters, Message::class);
     }
 
     /**

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -184,7 +184,7 @@ trait AvailableMethods
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }
@@ -519,7 +519,7 @@ trait AvailableMethods
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }
@@ -685,7 +685,7 @@ trait AvailableMethods
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }
@@ -774,7 +774,7 @@ trait AvailableMethods
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }
@@ -884,7 +884,7 @@ trait AvailableMethods
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }
@@ -985,7 +985,7 @@ trait AvailableMethods
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }
@@ -1072,7 +1072,7 @@ trait AvailableMethods
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }
@@ -1155,7 +1155,7 @@ trait AvailableMethods
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }
@@ -1372,7 +1372,7 @@ trait AvailableMethods
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }
@@ -1494,7 +1494,7 @@ trait AvailableMethods
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }
@@ -1574,7 +1574,7 @@ trait AvailableMethods
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }

--- a/src/Telegram/Endpoints/Stickers.php
+++ b/src/Telegram/Endpoints/Stickers.php
@@ -96,7 +96,7 @@ trait Stickers
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
 
-        if($this->message()?->isEphemeral()) {
+        if ($this->message()?->isEphemeral()) {
             $parameters['receiver_user_id'] ??= $this->receiverUserId();
             $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
         }

--- a/src/Telegram/Endpoints/Stickers.php
+++ b/src/Telegram/Endpoints/Stickers.php
@@ -47,6 +47,8 @@ trait Stickers
      * @param bool|null $allow_paid_broadcast Pass True to allow up to 1000 messages per second, ignoring {@see https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once broadcasting limits} for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
      * @param int|null $direct_messages_topic_id Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat
      * @param SuggestedPostParameters|null $suggested_post_parameters A JSON-serialized object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined.
+     * @param int|null $receiver_user_id For outgoing ephemeral messages, unique identifier of the user who will receive the message; for group and supergroup chats only. It is not guaranteed that the user will receive the message, especially if they are offline. See {@see https://core.telegram.org/bots/api#ephemeral-messages-and-commands ephemeral message sending} for more details.
+     * @param string|null $callback_query_id For outgoing ephemeral messages, identifier of the callback query which triggerred the message if any
      * @param array $clientOpt Client options
      * @return Message|null
      */
@@ -66,6 +68,8 @@ trait Stickers
         ?bool $allow_paid_broadcast = null,
         ?int $direct_messages_topic_id = null,
         ?SuggestedPostParameters $suggested_post_parameters = null,
+        ?int $receiver_user_id = null,
+        ?string $callback_query_id = null,
         array $clientOpt = [],
     ): ?Message {
         $parameters = compact(
@@ -84,11 +88,18 @@ trait Stickers
             'allow_paid_broadcast',
             'direct_messages_topic_id',
             'suggested_post_parameters',
+            'receiver_user_id',
+            'callback_query_id',
         );
         $parameters['chat_id'] ??= $this->chatId();
         $parameters['message_thread_id'] ??= $this->messageThreadId();
         $parameters['business_connection_id'] ??= $this->businessConnectionId();
         $parameters['direct_messages_topic_id'] ??= $this->directMessagesTopicId();
+
+        if($this->message()?->isEphemeral()) {
+            $parameters['receiver_user_id'] ??= $this->receiverUserId();
+            $parameters['callback_query_id'] ??= $this->callbackQuery()?->id;
+        }
 
         return $this->sendAttachments(__FUNCTION__, ['sticker'], $parameters, $clientOpt);
     }

--- a/src/Telegram/Endpoints/UpdatesMessages.php
+++ b/src/Telegram/Endpoints/UpdatesMessages.php
@@ -290,6 +290,150 @@ trait UpdatesMessages
     }
 
     /**
+     * Use this method to edit an ephemeral text message.
+     * Note that it is not guaranteed that the user will receive the message edit event, especially if they are offline.
+     * On success, True is returned.
+     * @param string $text New text of the message, 1-4096 characters after entity parsing
+     * @param int|string|null $chat_id Unique identifier for the target chat or username of the target supergroup in the format &#64;username
+     * @param int|null $receiver_user_id Identifier of the user who received the message
+     * @param int|null $ephemeral_message_id Identifier of the ephemeral message to edit
+     * @param ParseMode|string|null $parse_mode Mode for parsing entities in the message text. See {@see https://core.telegram.org/bots/api#formatting-options formatting options} for more details.
+     * @param MessageEntity[]|null $entities A JSON-serialized list of special entities that appear in message text, which can be specified instead of parse_mode
+     * @param LinkPreviewOptions|null $link_preview_options Link preview generation options for the message
+     * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#editephemeralmessagetext
+     */
+    public function editEphemeralMessageText(
+        string $text,
+        int|string|null $chat_id = null,
+        ?int $receiver_user_id = null,
+        ?int $ephemeral_message_id = null,
+        ParseMode|string|null $parse_mode = null,
+        ?array $entities = null,
+        ?LinkPreviewOptions $link_preview_options = null,
+        ?InlineKeyboardMarkup $reply_markup = null,
+    ): ?bool {
+        $parameters = compact(
+            'text',
+            'chat_id',
+            'receiver_user_id',
+            'ephemeral_message_id',
+            'parse_mode',
+            'entities',
+            'link_preview_options',
+            'reply_markup',
+        );
+        $parameters['chat_id'] ??= $this->chatId();
+        $parameters['receiver_user_id'] ??= $this->receiverUserId();
+        $parameters['ephemeral_message_id'] ??= $this->ephemeralMessageId();
+
+        return $this->requestJson(__FUNCTION__, $parameters);
+    }
+
+    /**
+     * Use this method to edit the media of an ephemeral message.
+     * Note that it is not guaranteed that the user will receive the message edit event, especially if they are offline.
+     * On success, True is returned.
+     * @param InputMedia $media A JSON-serialized object for the new media content of the message. A new file can't be uploaded; use a previously uploaded file via its file_id or specify a URL.
+     * @param int|string|null $chat_id Unique identifier for the target chat or username of the target supergroup in the format &#64;username
+     * @param int|null $receiver_user_id Identifier of the user who received the message
+     * @param int|null $ephemeral_message_id Identifier of the ephemeral message to edit
+     * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#editephemeralmessagemedia
+     */
+    public function editEphemeralMessageMedia(
+        InputMedia $media,
+        int|string|null $chat_id = null,
+        ?int $receiver_user_id = null,
+        ?int $ephemeral_message_id = null,
+        ?InlineKeyboardMarkup $reply_markup = null,
+    ): ?bool {
+        $parameters = compact(
+            'media',
+            'chat_id',
+            'receiver_user_id',
+            'ephemeral_message_id',
+            'reply_markup',
+        );
+        $parameters['chat_id'] ??= $this->chatId();
+        $parameters['receiver_user_id'] ??= $this->receiverUserId();
+        $parameters['ephemeral_message_id'] ??= $this->ephemeralMessageId();
+
+        return $this->requestJson(__FUNCTION__, $parameters);
+    }
+
+    /**
+     * Use this method to edit the caption of an ephemeral message.
+     * Note that it is not guaranteed that the user will receive the message edit event, especially if they are offline.
+     * On success, True is returned.
+     * @param int|string|null $chat_id Unique identifier for the target chat or username of the target supergroup in the format &#64;username
+     * @param int|null $receiver_user_id Identifier of the user who received the message
+     * @param int|null $ephemeral_message_id Identifier of the ephemeral message to edit
+     * @param string|null $caption New caption of the message, 0-1024 characters after entities parsing
+     * @param ParseMode|string|null $parse_mode Mode for parsing entities in the message caption. See {@see https://core.telegram.org/bots/api#formatting-options formatting options} for more details.
+     * @param array|null $caption_entities A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
+     * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#editephemeralmessagecaption
+     */
+    public function editEphemeralMessageCaption(
+        int|string|null $chat_id = null,
+        ?int $receiver_user_id = null,
+        ?int $ephemeral_message_id = null,
+        ?string $caption = null,
+        ParseMode|string|null $parse_mode = null,
+        ?array $caption_entities = null,
+        ?InlineKeyboardMarkup $reply_markup = null,
+    ): ?bool {
+        $parameters = compact(
+            'chat_id',
+            'receiver_user_id',
+            'ephemeral_message_id',
+            'caption',
+            'parse_mode',
+            'caption_entities',
+            'reply_markup',
+        );
+        $parameters['chat_id'] ??= $this->chatId();
+        $parameters['receiver_user_id'] ??= $this->receiverUserId();
+        $parameters['ephemeral_message_id'] ??= $this->ephemeralMessageId();
+
+        return $this->requestJson(__FUNCTION__, $parameters);
+    }
+
+    /**
+     * Use this method to edit only the reply markup of an ephemeral message.
+     * Note that it is not guaranteed that the user will receive the message edit event, especially if they are offline.
+     * On success, True is returned.
+     * @param int|string|null $chat_id Unique identifier for the target chat or username of the target supergroup in the format &#64;username
+     * @param int|null $receiver_user_id Identifier of the user who received the message
+     * @param int|null $ephemeral_message_id Identifier of the ephemeral message to edit
+     * @param InlineKeyboardMarkup|null $reply_markup A JSON-serialized object for an {@see https://core.telegram.org/bots/features#inline-keyboards inline keyboard}
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#editephemeralmessagereplymarkup
+     */
+    public function editEphemeralMessageReplyMarkup(
+        int|string|null $chat_id = null,
+        ?int $receiver_user_id = null,
+        ?int $ephemeral_message_id = null,
+        ?InlineKeyboardMarkup $reply_markup = null,
+    ): ?bool {
+        $parameters = compact(
+            'chat_id',
+            'receiver_user_id',
+            'ephemeral_message_id',
+            'reply_markup',
+        );
+        $parameters['chat_id'] ??= $this->chatId();
+        $parameters['receiver_user_id'] ??= $this->receiverUserId();
+        $parameters['ephemeral_message_id'] ??= $this->ephemeralMessageId();
+
+        return $this->requestJson(__FUNCTION__, $parameters);
+    }
+
+    /**
      * Use this method to approve a suggested post in a direct messages chat.
      * The bot must have the 'can_post_messages' administrator right in the corresponding channel chat.
      * Returns True on success.
@@ -362,6 +506,30 @@ trait UpdatesMessages
     public function deleteMessages(int|string $chat_id, array $message_ids): ?bool
     {
         return $this->requestJson(__FUNCTION__, compact('chat_id', 'message_ids'));
+    }
+
+    /**
+     * Use this method to delete an ephemeral message.
+     * Note that it is not guaranteed that the user will receive the message deletion event,
+     * especially if they are offline.
+     * Returns True on success.
+     * @param int|string|null $chat_id Unique identifier for the target chat or username of the target supergroup in the format &#64;username
+     * @param int|null $receiver_user_id Identifier of the user who received the message
+     * @param int|null $ephemeral_message_id Identifier of the ephemeral message to delete
+     * @return bool|null
+     * @see https://core.telegram.org/bots/api#deleteephemeralmessage
+     */
+    public function deleteEphemeralMessage(
+        int|string|null $chat_id = null,
+        int|null $receiver_user_id = null,
+        int|null $ephemeral_message_id = null,
+    ): ?bool {
+        $parameters = compact('chat_id', 'receiver_user_id', 'ephemeral_message_id');
+        $parameters['chat_id'] ??= $this->chatId();
+        $parameters['receiver_user_id'] ??= $this->receiverUserId();
+        $parameters['ephemeral_message_id'] ??= $this->ephemeralMessageId();
+
+        return $this->requestJson(__FUNCTION__, $parameters);
     }
 
     /**

--- a/src/Telegram/Properties/InputMediaType.php
+++ b/src/Telegram/Properties/InputMediaType.php
@@ -15,4 +15,5 @@ enum InputMediaType: string
     case STICKER = 'sticker';
     case VENUE = 'venue';
     case VIDEO = 'video';
+    case VOICE_NOTE = 'voicenote';
 }

--- a/src/Telegram/Properties/InputRichBlockType.php
+++ b/src/Telegram/Properties/InputRichBlockType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum InputRichBlockType: string
+{
+    case PARAGRAPH = 'paragraph';
+    case HEADING = 'heading';
+    case PRE = 'pre';
+    case FOOTER = 'footer';
+    case DIVIDER = 'divider';
+    case MATHEMATICAL_EXPRESSION = 'mathematical_expression';
+    case ANCHOR = 'anchor';
+    case LIST = 'list';
+    case BLOCKQUOTE = 'blockquote';
+    case PULLQUOTE = 'pullquote';
+    case COLLAGE = 'collage';
+    case SLIDESHOW = 'slideshow';
+    case TABLE = 'table';
+    case DETAILS = 'details';
+    case MAP = 'map';
+    case ANIMATION = 'animation';
+    case AUDIO = 'audio';
+    case PHOTO = 'photo';
+    case VIDEO = 'video';
+    case VOICE_NOTE = 'voice_note';
+    case THINKING = 'thinking';
+}

--- a/src/Telegram/Properties/MessageType.php
+++ b/src/Telegram/Properties/MessageType.php
@@ -49,6 +49,8 @@ enum MessageType: string
     case BOOST_ADDED = 'boost_added';
     case CHECKLIST_TASKS_DONE = 'checklist_tasks_done';
     case CHECKLIST_TASKS_ADDED = 'checklist_tasks_added';
+    case COMMUNITY_CHAT_ADDED = 'community_chat_added';
+    case COMMUNITY_CHAT_REMOVED = 'community_chat_removed';
     case DIRECT_MESSAGE_PRICE_CHANGED = 'direct_message_price_changed';
     case FORUM_TOPIC_CREATED = 'forum_topic_created';
     case FORUM_TOPIC_EDITED = 'forum_topic_edited';

--- a/src/Telegram/Properties/SubscriptionState.php
+++ b/src/Telegram/Properties/SubscriptionState.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Properties;
+
+enum SubscriptionState: string
+{
+    case CANCELED = 'canceled';
+    case ACTIVE = 'active';
+    case FAILED = 'failed';
+}

--- a/src/Telegram/Properties/UpdateType.php
+++ b/src/Telegram/Properties/UpdateType.php
@@ -31,6 +31,7 @@ enum UpdateType: string
     case CHAT_BOOST = 'chat_boost';
     case REMOVED_CHAT_BOOST = 'removed_chat_boost';
     case MANAGED_BOT = 'managed_bot';
+    case SUBSCRIPTION = 'subscription';
 
     public static function messageTypes(): array
     {

--- a/src/Telegram/Types/Chat/Chat.php
+++ b/src/Telegram/Types/Chat/Chat.php
@@ -9,6 +9,7 @@ use SergiX44\Nutgram\Telegram\Types\BaseType;
 use SergiX44\Nutgram\Telegram\Types\Business\BusinessIntro;
 use SergiX44\Nutgram\Telegram\Types\Business\BusinessLocation;
 use SergiX44\Nutgram\Telegram\Types\Business\BusinessOpeningHours;
+use SergiX44\Nutgram\Telegram\Types\Community\Community;
 use SergiX44\Nutgram\Telegram\Types\Media\Audio;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
 use SergiX44\Nutgram\Telegram\Types\Reaction\ReactionType;
@@ -392,7 +393,18 @@ class Chat extends BaseType
      */
     public ?int $paid_message_star_count = null;
 
+    /**
+     * Optional.
+     * The bot that processes join request queries in the chat.
+     * The field is only available to chat administrators.
+     */
     public ?User $guard_bot = null;
+
+    /**
+     * Optional.
+     * The {@see https://core.telegram.org/bots/api#community Community} to which the chat belongs
+     */
+    public ?Community $community = null;
 
     public static function make(
         int $id,
@@ -431,6 +443,7 @@ class Chat extends BaseType
         ?int $paid_message_star_count = null,
         ?Audio $first_profile_audio = null,
         ?User $guard_bot = null,
+        ?Community $community = null
     ): Chat {
         $chat = new self();
         $chat->id = $id;
@@ -469,6 +482,7 @@ class Chat extends BaseType
         $chat->paid_message_star_count = $paid_message_star_count;
         $chat->first_profile_audio = $first_profile_audio;
         $chat->guard_bot = $guard_bot;
+        $chat->community = $community;
         return $chat;
     }
 

--- a/src/Telegram/Types/Command/BotCommand.php
+++ b/src/Telegram/Types/Command/BotCommand.php
@@ -4,6 +4,7 @@ namespace SergiX44\Nutgram\Telegram\Types\Command;
 
 use JsonSerializable;
 use SergiX44\Hydrator\Annotation\SkipConstructor;
+use function SergiX44\Nutgram\Support\array_filter_null;
 
 /**
  * This object represents a bot command.
@@ -25,22 +26,35 @@ class BotCommand implements JsonSerializable
      */
     public string $description;
 
-    public function __construct(string $command, string $description)
+    /**
+     * Optional.
+     * True, if the command sends an ephemeral message,
+     * which can be seen only by the sender of the message and the bot
+     */
+    public ?bool $is_ephemeral = null;
+
+    public function __construct(string $command, string $description, ?bool $is_ephemeral = null)
     {
         $this->command = $command;
         $this->description = $description;
+        $this->is_ephemeral = $is_ephemeral;
     }
 
-    public static function make(string $command, string $description): self
+    public static function make(string $command, string $description, ?bool $is_ephemeral = null): self
     {
-        return new self($command, $description);
+        return new self(
+            command: $command,
+            description: $description,
+            is_ephemeral: $is_ephemeral,
+        );
     }
 
     public function jsonSerialize(): array
     {
-        return [
+        return array_filter_null([
             'command' => $this->command,
             'description' => $this->description,
-        ];
+            'is_ephemeral' => $this->is_ephemeral,
+        ]);
     }
 }

--- a/src/Telegram/Types/Common/Update.php
+++ b/src/Telegram/Types/Common/Update.php
@@ -17,6 +17,7 @@ use SergiX44\Nutgram\Telegram\Types\Inline\ChosenInlineResult;
 use SergiX44\Nutgram\Telegram\Types\Inline\InlineQuery;
 use SergiX44\Nutgram\Telegram\Types\ManagedBot\ManagedBotUpdated;
 use SergiX44\Nutgram\Telegram\Types\Message\Message;
+use SergiX44\Nutgram\Telegram\Types\Payment\BotSubscriptionUpdated;
 use SergiX44\Nutgram\Telegram\Types\Payment\PaidMediaPurchased;
 use SergiX44\Nutgram\Telegram\Types\Payment\PreCheckoutQuery;
 use SergiX44\Nutgram\Telegram\Types\Payment\ShippingQuery;
@@ -202,6 +203,11 @@ class Update extends BaseType
     public ?ManagedBotUpdated $managed_bot = null;
 
     /**
+     * Optional. User payment subscription has changed
+     */
+    public ?BotSubscriptionUpdated $subscription = null;
+
+    /**
      * Return the current update type
      * @return UpdateType|null
      */
@@ -233,6 +239,7 @@ class Update extends BaseType
             $this->chat_boost !== null => UpdateType::CHAT_BOOST,
             $this->removed_chat_boost !== null => UpdateType::REMOVED_CHAT_BOOST,
             $this->managed_bot !== null => UpdateType::MANAGED_BOT,
+            $this->subscription !== null => UpdateType::SUBSCRIPTION,
             default => null
         };
     }
@@ -269,6 +276,7 @@ class Update extends BaseType
             $this->chat_boost !== null => $this->chat_boost->boost->source->user,
             $this->removed_chat_boost !== null => $this->removed_chat_boost->source->user,
             $this->managed_bot !== null => $this->managed_bot->user,
+            $this->subscription !== null => $this->subscription->user,
             default => null,
         };
     }
@@ -301,6 +309,7 @@ class Update extends BaseType
             $this->chat_boost !== null => $this->chat_boost->boost->source->user = $user,
             $this->removed_chat_boost !== null => $this->removed_chat_boost->source->user = $user,
             $this->managed_bot !== null => $this->managed_bot->user = $user,
+            $this->subscription !== null => $this->subscription->user = $user,
             default => null,
         };
     }
@@ -333,6 +342,7 @@ class Update extends BaseType
             $this->chat_boost !== null => $this->chat_boost->chat,
             $this->removed_chat_boost !== null => $this->removed_chat_boost->chat,
             // managed_bot doesn't have a chat
+            // subscription doesn't have a chat
             default => null
         };
     }
@@ -365,6 +375,7 @@ class Update extends BaseType
             $this->chat_boost !== null => $this->chat_boost->chat = $chat,
             $this->removed_chat_boost !== null => $this->removed_chat_boost->chat = $chat,
             // managed_bot doesn't have a chat
+            // subscription doesn't have a chat
             default => null
         };
     }

--- a/src/Telegram/Types/Community/Community.php
+++ b/src/Telegram/Types/Community/Community.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Community;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * Represents a community (a group of chats).
+ * @see https://core.telegram.org/bots/api#community
+ */
+class Community extends BaseType
+{
+    /**
+     * Unique identifier for this community.
+     * This number may have more than 32 significant bits and some
+     * programming languages may have difficulty/silent defects in interpreting it.
+     * But it has at most 52 significant bits, so a signed 64-bit integer
+     * or double-precision float type are safe for storing this identifier.
+     */
+    public int $id;
+
+    /**
+     * Name of the community
+     */
+    public string $name;
+}

--- a/src/Telegram/Types/Community/CommunityChatAdded.php
+++ b/src/Telegram/Types/Community/CommunityChatAdded.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Community;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * Describes a service message about a chat being added to a community.
+ * @see https://core.telegram.org/bots/api#communitychatadded
+ */
+class CommunityChatAdded extends BaseType
+{
+    /**
+     * The new community to which the chat belongs
+     */
+    public Community $community;
+}

--- a/src/Telegram/Types/Community/CommunityChatRemoved.php
+++ b/src/Telegram/Types/Community/CommunityChatRemoved.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Community;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * Describes a service message about a chat being removed from a community.
+ * Currently holds no information.
+ * @see https://core.telegram.org/bots/api#communitychatremoved
+ */
+class CommunityChatRemoved extends BaseType
+{
+    // Currently holds no information.
+}

--- a/src/Telegram/Types/Input/InputMediaVoiceNote.php
+++ b/src/Telegram/Types/Input/InputMediaVoiceNote.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Input;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputMediaType;
+use SergiX44\Nutgram\Telegram\Properties\ParseMode;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Internal\InputFile;
+use SergiX44\Nutgram\Telegram\Types\Internal\Uploadables;
+use SergiX44\Nutgram\Telegram\Types\Message\MessageEntity;
+use function SergiX44\Nutgram\Support\array_filter_null;
+
+/**
+ * Represents a video to be sent.
+ * @see https://core.telegram.org/bots/api#inputmediavideo
+ */
+#[SkipConstructor]
+class InputMediaVoiceNote extends BaseType implements Uploadables, JsonSerializable
+{
+    /** Type of the result, must be video */
+    #[EnumOrScalar]
+    public InputMediaType|string $type = InputMediaType::VOICE_NOTE;
+
+    /**
+     * File to send.
+     * Pass a file_id to send a file that exists on the Telegram servers (recommended),
+     * pass an HTTP URL for Telegram to get a file from the Internet,
+     * or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.
+     * {@see https://core.telegram.org/bots/api#sending-files More information on Sending Files »}
+     */
+    public InputFile|string $media;
+
+    /**
+     * Optional.
+     * Caption of the voice message to be sent, 0-1024 characters after entities parsing
+     */
+    public ?string $caption = null;
+
+    /**
+     * Optional.
+     * Mode for parsing entities in the voice message caption.
+     * See {@see https://core.telegram.org/bots/api#formatting-options formatting options} for more details.
+     */
+    #[EnumOrScalar]
+    public ParseMode|string|null $parse_mode = null;
+
+    /**
+     * Optional.
+     * List of special entities that appear in the caption, which can be specified instead of parse_mode
+     * @var MessageEntity[] $caption_entities
+     */
+    #[ArrayType(MessageEntity::class)]
+    public ?array $caption_entities = null;
+
+    /**
+     * Optional.
+     * Duration of the voice message in seconds
+     */
+    public ?int $duration = null;
+
+    public function __construct(
+        InputFile|string $media,
+        ?string $caption = null,
+        ParseMode|string|null $parse_mode = null,
+        ?array $caption_entities = null,
+        ?int $duration = null,
+    ) {
+        parent::__construct();
+        $this->media = $media;
+        $this->caption = $caption;
+        $this->parse_mode = $parse_mode;
+        $this->caption_entities = $caption_entities;
+        $this->duration = $duration;
+    }
+
+    public static function make(
+        InputFile|string $media,
+        ?string $caption = null,
+        ParseMode|string|null $parse_mode = null,
+        ?array $caption_entities = null,
+        ?int $duration = null,
+    ): self {
+        return new self(
+            media: $media,
+            caption: $caption,
+            parse_mode: $parse_mode,
+            caption_entities: $caption_entities,
+            duration: $duration,
+        );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return array_filter_null([
+            'type' => $this->type,
+            'media' => $this->media,
+            'caption' => $this->caption,
+            'parse_mode' => $this->parse_mode,
+            'caption_entities' => $this->caption_entities,
+            'duration' => $this->duration,
+        ]);
+    }
+
+    public function uploadables(): array
+    {
+        return ['media'];
+    }
+}

--- a/src/Telegram/Types/Location/Location.php
+++ b/src/Telegram/Types/Location/Location.php
@@ -2,39 +2,43 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\Location;
 
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
 use SergiX44\Nutgram\Telegram\Types\BaseType;
 
 /**
  * This object represents a point on the map.
  * @see https://core.telegram.org/bots/api#location
  */
-class Location extends BaseType
+#[SkipConstructor]
+class Location extends BaseType implements JsonSerializable
 {
-    /** Longitude as defined by sender */
+    /**
+     * Longitude as defined by sender
+     */
     public float $longitude;
 
-    /** Latitude as defined by sender */
+    /**
+     * Latitude as defined by sender
+     */
     public float $latitude;
 
     /**
      * Optional.
-     * The radius of uncertainty for the location, measured in meters;
-     * 0-1500
+     * The radius of uncertainty for the location, measured in meters; 0-1500
      */
     public ?float $horizontal_accuracy = null;
 
     /**
      * Optional.
-     * Time relative to the message sending date, during which the location can be updated;
-     * in seconds.
+     * Time relative to the message sending date, during which the location can be updated; in seconds.
      * For active live locations only.
      */
     public ?int $live_period = null;
 
     /**
      * Optional.
-     * The direction in which user is moving, in degrees;
-     * 1-360.
+     * The direction in which user is moving, in degrees; 1-360.
      * For active live locations only.
      */
     public ?int $heading = null;
@@ -45,4 +49,26 @@ class Location extends BaseType
      * For sent live locations only.
      */
     public ?int $proximity_alert_radius = null;
+
+    public function __construct(
+        float $longitude,
+        float $latitude,
+        ?float $horizontal_accuracy = null,
+        ?int $live_period = null,
+        ?int $heading = null,
+        ?int $proximity_alert_radius = null,
+    ) {
+        parent::__construct();
+        $this->longitude = $longitude;
+        $this->latitude = $latitude;
+        $this->horizontal_accuracy = $horizontal_accuracy;
+        $this->live_period = $live_period;
+        $this->heading = $heading;
+        $this->proximity_alert_radius = $proximity_alert_radius;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
 }

--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -13,6 +13,8 @@ use SergiX44\Nutgram\Telegram\Types\Chat\ChatOwnerLeft;
 use SergiX44\Nutgram\Telegram\Types\Checklist\Checklist;
 use SergiX44\Nutgram\Telegram\Types\Checklist\ChecklistTasksAdded;
 use SergiX44\Nutgram\Telegram\Types\Checklist\ChecklistTasksDone;
+use SergiX44\Nutgram\Telegram\Types\Community\CommunityChatAdded;
+use SergiX44\Nutgram\Telegram\Types\Community\CommunityChatRemoved;
 use SergiX44\Nutgram\Telegram\Types\Forum\ForumTopicClosed;
 use SergiX44\Nutgram\Telegram\Types\Forum\ForumTopicCreated;
 use SergiX44\Nutgram\Telegram\Types\Forum\ForumTopicEdited;
@@ -129,6 +131,17 @@ class Message extends BaseType
      * Optional. Tag or custom title of the sender of the message; for supergroups only
      */
     public ?string $sender_tag = null;
+
+    /**
+     * Optional. For ephemeral messages, the user who received the message
+     */
+    public ?User $receiver_user = null;
+
+    /**
+     * Optional. For ephemeral messages, identifier of the ephemeral message inside this chat.
+     * The identifier may be reused for another ephemeral message after the message is deleted or expires.
+     */
+    public ?int $ephemeral_message_id = null;
 
     /** Date the message was sent in Unix time */
     public int $date;
@@ -664,6 +677,16 @@ class Message extends BaseType
     public ?ChecklistTasksAdded $checklist_tasks_added = null;
 
     /**
+     * Optional. Service message: chat added to a {@see https://core.telegram.org/bots/api#community Community}
+     */
+    public ?CommunityChatAdded $community_chat_added = null;
+
+    /**
+     * Optional. Service message: chat removed from a {@see https://core.telegram.org/bots/api#community Community}
+     */
+    public ?CommunityChatRemoved $community_chat_removed = null;
+
+    /**
      * Optional.
      * Service message: the price for paid messages in the corresponding direct messages chat of a channel has changed
      */
@@ -886,6 +909,8 @@ class Message extends BaseType
             $this->boost_added !== null => MessageType::BOOST_ADDED,
             $this->checklist_tasks_done !== null => MessageType::CHECKLIST_TASKS_DONE,
             $this->checklist_tasks_added !== null => MessageType::CHECKLIST_TASKS_ADDED,
+            $this->community_chat_added !== null => MessageType::COMMUNITY_CHAT_ADDED,
+            $this->community_chat_removed !== null => MessageType::COMMUNITY_CHAT_REMOVED,
             $this->direct_message_price_changed !== null => MessageType::DIRECT_MESSAGE_PRICE_CHANGED,
             $this->forum_topic_created !== null => MessageType::FORUM_TOPIC_CREATED,
             $this->forum_topic_edited !== null => MessageType::FORUM_TOPIC_EDITED,
@@ -925,6 +950,11 @@ class Message extends BaseType
     public function getEntities(): ?array
     {
         return $this->entities ?? $this->caption_entities;
+    }
+
+    public function isEphemeral(): bool
+    {
+        return $this->receiver_user !== null && $this->ephemeral_message_id !== null;
     }
 
     /**

--- a/src/Telegram/Types/Message/ReplyParameters.php
+++ b/src/Telegram/Types/Message/ReplyParameters.php
@@ -16,17 +16,28 @@ use function SergiX44\Nutgram\Support\array_filter_null;
 class ReplyParameters extends BaseType implements JsonSerializable
 {
     /**
-     * Identifier of the message that will be replied to in the current chat, or in the chat chat_id if it is specified
-     * @var int
+     * Optional.
+     * Identifier of the message that will be replied to in the current chat, or in the chat chat_id if it is specified.
+     * Required if ephemeral_message_id isn't specified.
      */
-    public int $message_id;
+    public ?int $message_id = null;
 
     /**
-     * Optional. If the message to be replied to is from a different chat,
+     * Optional.
+     * If the message to be replied to is from a different chat,
      * unique identifier for the chat or username of the channel (in the format [at]channelusername)
      * @var int|string|null
      */
     public int|string|null $chat_id = null;
+
+    /**
+     * Optional.
+     * Identifier of the incoming ephemeral message that will be replied to in the current chat.
+     * A reply to an ephemeral message must itself be an ephemeral message.
+     * An ephemeral message may only be replied to within 15 seconds of being sent.
+     * Required if message_id isn't specified.
+     */
+    public ?int $ephemeral_message_id = null;
 
     /**
      * Optional. Pass True if the message should be sent even if the specified message to be replied to is not found;
@@ -76,7 +87,7 @@ class ReplyParameters extends BaseType implements JsonSerializable
     public ?string $poll_option_id = null;
 
     /**
-     * @param int $message_id
+     * @param int|null $message_id
      * @param int|string|null $chat_id
      * @param bool|null $allow_sending_without_reply
      * @param string|null $quote
@@ -85,9 +96,10 @@ class ReplyParameters extends BaseType implements JsonSerializable
      * @param int|null $quote_position
      * @param int|null $checklist_task_id
      * @param string|null $poll_option_id
+     * @param int|null $ephemeral_message_id
      */
     public function __construct(
-        int $message_id,
+        ?int $message_id = null,
         int|string|null $chat_id = null,
         ?bool $allow_sending_without_reply = null,
         ?string $quote = null,
@@ -96,6 +108,7 @@ class ReplyParameters extends BaseType implements JsonSerializable
         ?int $quote_position = null,
         ?int $checklist_task_id = null,
         ?string $poll_option_id = null,
+        ?int $ephemeral_message_id = null,
     ) {
         parent::__construct();
         $this->message_id = $message_id;
@@ -107,10 +120,11 @@ class ReplyParameters extends BaseType implements JsonSerializable
         $this->quote_position = $quote_position;
         $this->checklist_task_id = $checklist_task_id;
         $this->poll_option_id = $poll_option_id;
+        $this->ephemeral_message_id = $ephemeral_message_id;
     }
 
     /**
-     * @param int $message_id
+     * @param int|null $message_id
      * @param int|string|null $chat_id
      * @param bool|null $allow_sending_without_reply
      * @param string|null $quote
@@ -119,10 +133,11 @@ class ReplyParameters extends BaseType implements JsonSerializable
      * @param int|null $quote_position
      * @param int|null $checklist_task_id
      * @param string|null $poll_option_id
+     * @param int|null $ephemeral_message_id
      * @return self
      */
     public static function make(
-        int $message_id,
+        ?int $message_id = null,
         int|string|null $chat_id = null,
         ?bool $allow_sending_without_reply = null,
         ?string $quote = null,
@@ -131,6 +146,7 @@ class ReplyParameters extends BaseType implements JsonSerializable
         ?int $quote_position = null,
         ?int $checklist_task_id = null,
         ?string $poll_option_id = null,
+        ?int $ephemeral_message_id = null,
     ): self {
         return new self(
             message_id: $message_id,
@@ -142,6 +158,7 @@ class ReplyParameters extends BaseType implements JsonSerializable
             quote_position: $quote_position,
             checklist_task_id: $checklist_task_id,
             poll_option_id: $poll_option_id,
+            ephemeral_message_id: $ephemeral_message_id,
         );
     }
 
@@ -150,6 +167,7 @@ class ReplyParameters extends BaseType implements JsonSerializable
         return array_filter_null([
             'message_id' => $this->message_id,
             'chat_id' => $this->chat_id,
+            'ephemeral_message_id' => $this->ephemeral_message_id,
             'allow_sending_without_reply' => $this->allow_sending_without_reply,
             'quote' => $this->quote,
             'quote_parse_mode' => $this->quote_parse_mode,

--- a/src/Telegram/Types/Payment/BotSubscriptionUpdated.php
+++ b/src/Telegram/Types/Payment/BotSubscriptionUpdated.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\Payment;
+
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\SubscriptionState;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\User\User;
+
+/**
+ * This object contains information about changes to a user payment subscription toward the current bot.
+ * @see https://core.telegram.org/bots/api#botsubscriptionupdated
+ */
+class BotSubscriptionUpdated extends BaseType
+{
+    /**
+     * User who subscribed for payments toward the bot
+     */
+    public User $user;
+
+    /**
+     * Bot-specified invoice payload
+     */
+    public string $invoice_payload;
+
+    /**
+     * The new state of the subscription.
+     * Currently, it can be one of
+     * - “canceled” if the user canceled the subscription,
+     * - “active” if the user re-enabled a previously canceled subscription, or
+     * - “failed” if payment for the subscription failed.
+     */
+    #[EnumOrScalar]
+    public SubscriptionState|string $state;
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlock.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlock.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+/**
+ * This object represents a block in a rich formatted message to be sent.
+ * Currently, it can be any of the following types:
+ * - {@see InputRichBlockParagraph}
+ * - {@see InputRichBlockSectionHeading}
+ * - {@see InputRichBlockPreformatted}
+ * - {@see InputRichBlockFooter}
+ * - {@see InputRichBlockDivider}
+ * - {@see InputRichBlockMathematicalExpression}
+ * - {@see InputRichBlockAnchor}
+ * - {@see InputRichBlockList}
+ * - {@see InputRichBlockBlockQuotation}
+ * - {@see InputRichBlockPullQuotation}
+ * - {@see InputRichBlockCollage}
+ * - {@see InputRichBlockSlideshow}
+ * - {@see InputRichBlockTable}
+ * - {@see InputRichBlockDetails}
+ * - {@see InputRichBlockMap}
+ * - {@see InputRichBlockAnimation}
+ * - {@see InputRichBlockAudio}
+ * - {@see InputRichBlockPhoto}
+ * - {@see InputRichBlockVideo}
+ * - {@see InputRichBlockVoiceNote}
+ * - {@see InputRichBlockThinking}
+ * @see https://core.telegram.org/bots/api#inputrichblock
+ */
+interface InputRichBlock
+{
+    // nothing here, this interface is only for type hinting
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockAnchor.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockAnchor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A block with an anchor, corresponding to the HTML tag <code><a></code> with the attribute <code>name</code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockanchor
+ */
+#[SkipConstructor]
+class InputRichBlockAnchor extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “anchor”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::ANCHOR;
+
+    /**
+     * The name of the anchor
+     */
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        parent::__construct();
+        $this->name = $name;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockAnimation.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockAnimation.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Input\InputMediaAnimation;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock\RichBlockCaption;
+
+/**
+ * A block with an animation, corresponding to the HTML tag <code><video></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockanimation
+ */
+#[SkipConstructor]
+class InputRichBlockAnimation extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “animation”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::ANIMATION;
+
+    /**
+     * The animation. Caption is ignored.
+     */
+    public InputMediaAnimation $animation;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+
+    public function __construct(InputMediaAnimation $animation, ?RichBlockCaption $caption = null)
+    {
+        parent::__construct();
+        $this->animation = $animation;
+        $this->caption = $caption;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockAudio.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockAudio.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Input\InputMediaAudio;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock\RichBlockCaption;
+
+/**
+ * A block with a music file, corresponding to the HTML tag <code><audio></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockaudio
+ */
+#[SkipConstructor]
+class InputRichBlockAudio extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “audio”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::AUDIO;
+
+    /**
+     * The audio. Caption is ignored.
+     */
+    public InputMediaAudio $audio;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+
+    public function __construct(InputMediaAudio $audio, ?RichBlockCaption $caption = null)
+    {
+        parent::__construct();
+        $this->audio = $audio;
+        $this->caption = $caption;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockBlockQuotation.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockBlockQuotation.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A block quotation, corresponding to the HTML tag <code><blockquote></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockblockquotation
+ */
+#[SkipConstructor]
+class InputRichBlockBlockQuotation extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “blockquote”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::BLOCKQUOTE;
+
+    /**
+     * Content of the block
+     * @var InputRichBlock[]
+     */
+    #[ArrayType(InputRichBlock::class)]
+    public array $blocks;
+
+    /**
+     * Optional. Credit of the block
+     */
+    public ?RichText $credit = null;
+
+    public function __construct(array $blocks, ?RichText $credit = null)
+    {
+        parent::__construct();
+        $this->blocks = $blocks;
+        $this->credit = $credit;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockCollage.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockCollage.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock\RichBlockCaption;
+
+/**
+ * A collage, corresponding to the custom HTML tag <code><tg-collage></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockcollage
+ */
+#[SkipConstructor]
+class InputRichBlockCollage extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “collage”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::COLLAGE;
+
+    /**
+     * Elements of the collage
+     * @var InputRichBlock[]
+     */
+    #[ArrayType(InputRichBlock::class)]
+    public array $blocks;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+
+    public function __construct(array $blocks, ?RichBlockCaption $caption = null)
+    {
+        parent::__construct();
+        $this->blocks = $blocks;
+        $this->caption = $caption;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockDetails.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockDetails.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * An expandable block for details disclosure, corresponding to the HTML tag <code><details></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockdetails
+ */
+#[SkipConstructor]
+class InputRichBlockDetails extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “details”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::DETAILS;
+
+    /**
+     * Always shown summary of the block
+     */
+    public RichText $summary;
+
+    /**
+     * Content of the block
+     * @var InputRichBlock[]
+     */
+    #[ArrayType(InputRichBlock::class)]
+    public array $blocks;
+
+    /**
+     * Optional. Pass True if the content of the block is visible by default
+     */
+    public ?bool $is_open = null;
+
+    public function __construct(RichText $summary, array $blocks, ?bool $is_open = null)
+    {
+        parent::__construct();
+        $this->summary = $summary;
+        $this->blocks = $blocks;
+        $this->is_open = $is_open;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockDivider.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockDivider.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A divider, corresponding to the HTML tag <code><hr/></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockdivider
+ */
+#[SkipConstructor]
+class InputRichBlockDivider extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “divider”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::DIVIDER;
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockFooter.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockFooter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A footer, corresponding to the HTML tag <code><footer></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockfooter
+ */
+#[SkipConstructor]
+class InputRichBlockFooter extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “footer”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::FOOTER;
+
+    /**
+     * Text of the block
+     */
+    public RichText $text;
+
+    public function __construct(RichText $text)
+    {
+        parent::__construct();
+        $this->text = $text;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockList.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockList.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A list of blocks, corresponding to the HTML tag <code><ul></code> or <code><ol></code> with multiple nested tags <code><li></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblocklist
+ */
+#[SkipConstructor]
+class InputRichBlockList extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “list”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::LIST;
+
+    /**
+     * Items of the list
+     * @var InputRichBlockListItem[]
+     */
+    #[ArrayType(InputRichBlockListItem::class)]
+    public array $items;
+
+    public function __construct(array $items)
+    {
+        parent::__construct();
+        $this->items = $items;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockListItem.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockListItem.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\RichBlockListItemType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * An item of a list to be sent.
+ * @see https://core.telegram.org/bots/api#inputrichblocklistitem
+ */
+#[SkipConstructor]
+class InputRichBlockListItem extends BaseType implements JsonSerializable
+{
+    /**
+     * The content of the item
+     * @var InputRichBlock[]
+     */
+    #[ArrayType(InputRichBlock::class)]
+    public array $blocks;
+
+    /**
+     * Optional. Pass True if the item has a checkbox
+     */
+    public ?bool $has_checkbox = null;
+
+    /**
+     * Optional. Pass True if the item has a checked checkbox
+     */
+    public ?bool $is_checked = null;
+
+    /**
+     * Optional. For ordered lists, the numeric value of the item label
+     */
+    public ?int $value = null;
+
+    /**
+     * Optional.
+     * For ordered lists, the type of the item label; must be one of
+     * - “a” for lowercase letters
+     * - “A” for uppercase letters
+     * - “i” for lowercase Roman numerals
+     * - “I” for uppercase Roman numerals
+     * - “1” for decimal numbers
+     */
+    #[EnumOrScalar]
+    public RichBlockListItemType|string|null $type = null;
+
+    public function __construct(
+        array $blocks,
+        ?bool $has_checkbox = null,
+        ?bool $is_checked = null,
+        ?int $value = null,
+        RichBlockListItemType|string|null $type = null,
+    ) {
+        parent::__construct();
+        $this->blocks = $blocks;
+        $this->has_checkbox = $has_checkbox;
+        $this->is_checked = $is_checked;
+        $this->value = $value;
+        $this->type = $type;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockMap.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockMap.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Location\Location;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock\RichBlockCaption;
+
+/**
+ * A block with a map, corresponding to the custom HTML tag <code><tg-map></code>.
+ * The map's width and height must not exceed 10000 in total.
+ * The width and height ratio must be at most 20.
+ * @see https://core.telegram.org/bots/api#inputrichblockmap
+ */
+#[SkipConstructor]
+class InputRichBlockMap extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “map”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::MAP;
+
+    /**
+     * Location of the center of the map
+     */
+    public Location $location;
+
+    /**
+     * Map zoom level; 0-24
+     */
+    public int $zoom;
+
+    /**
+     * Map width; 0-10000
+     */
+    public int $width;
+
+    /**
+     * Map height; 0-10000
+     */
+    public int $height;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+
+    public function __construct(
+        Location $location,
+        int $zoom,
+        int $width,
+        int $height,
+        ?RichBlockCaption $caption = null)
+    {
+        parent::__construct();
+        $this->location = $location;
+        $this->zoom = $zoom;
+        $this->width = $width;
+        $this->height = $height;
+        $this->caption = $caption;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockMap.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockMap.php
@@ -55,7 +55,8 @@ class InputRichBlockMap extends BaseType implements InputRichBlock, JsonSerializ
         int $zoom,
         int $width,
         int $height,
-        ?RichBlockCaption $caption = null)
+        ?RichBlockCaption $caption = null
+    )
     {
         parent::__construct();
         $this->location = $location;

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockMathematicalExpression.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockMathematicalExpression.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+
+/**
+ * A block with a mathematical expression in LaTeX format, corresponding to the custom HTML tag <code><tg-math-block></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockmathematicalexpression
+ */
+#[SkipConstructor]
+class InputRichBlockMathematicalExpression extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “mathematical_expression”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::MATHEMATICAL_EXPRESSION;
+
+    /**
+     * The mathematical expression in LaTeX format
+     */
+    public string $expression;
+
+    public function __construct(string $expression)
+    {
+        parent::__construct();
+        $this->expression = $expression;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockParagraph.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockParagraph.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A text paragraph, corresponding to the HTML tag <code><p></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockparagraph
+ */
+#[SkipConstructor]
+class InputRichBlockParagraph extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “paragraph”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::PARAGRAPH;
+
+    /**
+     * Text of the block
+     */
+    public RichText $text;
+
+    public function __construct(RichText $text)
+    {
+        parent::__construct();
+        $this->text = $text;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockPhoto.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockPhoto.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Input\InputMediaPhoto;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock\RichBlockCaption;
+
+/**
+ * A block with a photo, corresponding to the HTML tag <code><img></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockphoto
+ */
+#[SkipConstructor]
+class InputRichBlockPhoto extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “photo”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::PHOTO;
+
+    /**
+     * The photo. Caption is ignored.
+     */
+    public InputMediaPhoto $photo;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+
+    public function __construct(InputMediaPhoto $photo, ?RichBlockCaption $caption = null)
+    {
+        parent::__construct();
+        $this->photo = $photo;
+        $this->caption = $caption;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockPreformatted.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockPreformatted.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A preformatted text block, corresponding to the nested HTML tags <code><pre></code> and <code><code></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockpreformatted
+ */
+#[SkipConstructor]
+class InputRichBlockPreformatted extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “pre”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::PRE;
+
+    /**
+     * Text of the block
+     */
+    public RichText $text;
+
+    /**
+     * Optional. The programming language of the text
+     */
+    public ?string $language = null;
+
+    public function __construct(RichText $text, ?string $language = null)
+    {
+        parent::__construct();
+        $this->text = $text;
+        $this->language = $language;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockPullQuotation.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockPullQuotation.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A quotation with centered text, loosely corresponding to the HTML tag <code><aside></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockpullquotation
+ */
+#[SkipConstructor]
+class InputRichBlockPullQuotation extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “pullquote”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::PULLQUOTE;
+
+    /**
+     * Text of the block
+     */
+    public RichText $text;
+
+    /**
+     * Optional. Credit of the block
+     */
+    public ?RichText $credit = null;
+
+    public function __construct(RichText $text, ?RichText $credit = null)
+    {
+        parent::__construct();
+        $this->text = $text;
+        $this->credit = $credit;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockSectionHeading.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockSectionHeading.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A section heading, corresponding to the HTML tags
+ * <code><h1></code>, <code><h2></code>, <code><h3></code>, <code><h4></code>, <code><h5></code>, or <code><h6></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblocksectionheading
+ */
+#[SkipConstructor]
+class InputRichBlockSectionHeading extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “heading”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::HEADING;
+
+    /**
+     * Text of the block
+     */
+    public RichText $text;
+
+    /**
+     * Relative size of the text font; 1-6, 1 is the largest, 6 is the smallest
+     */
+    public int $size;
+
+    public function __construct(RichText $text, int $size)
+    {
+        parent::__construct();
+        $this->text = $text;
+        $this->size = $size;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockSlideshow.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockSlideshow.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock\RichBlockCaption;
+
+/**
+ * A slideshow, corresponding to the custom HTML tag <code><tg-slideshow></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockslideshow
+ */
+#[SkipConstructor]
+class InputRichBlockSlideshow extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “slideshow”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::SLIDESHOW;
+
+    /**
+     * Elements of the slideshow
+     * @var InputRichBlock[]
+     */
+    #[ArrayType(InputRichBlock::class)]
+    public array $blocks;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+
+    public function __construct(array $blocks, ?RichBlockCaption $caption = null)
+    {
+        parent::__construct();
+        $this->blocks = $blocks;
+        $this->caption = $caption;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockTable.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockTable.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock\RichBlockTableCell;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A table, corresponding to the HTML tag <code><table></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblocktable
+ */
+#[SkipConstructor]
+class InputRichBlockTable extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “table”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::TABLE;
+
+    /**
+     * Cells of the table
+     * @var RichBlockTableCell[][]
+     */
+    #[ArrayType(RichBlockTableCell::class, 2)]
+    public array $cells;
+
+    /**
+     * Optional. Pass True if the table has borders
+     */
+    public ?bool $is_bordered = null;
+
+    /**
+     * Optional. Pass True if the table is striped
+     */
+    public ?bool $is_striped = null;
+
+    /**
+     * Optional. Caption of the table
+     */
+    public ?RichText $caption = null;
+
+    public function __construct(
+        array $cells,
+        ?bool $is_bordered = null,
+        ?bool $is_striped = null,
+        ?RichText $caption = null,
+    ) {
+        parent::__construct();
+        $this->cells = $cells;
+        $this->is_bordered = $is_bordered;
+        $this->is_striped = $is_striped;
+        $this->caption = $caption;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockThinking.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockThinking.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
+
+/**
+ * A block with a “Thinking…” placeholder, corresponding to the custom HTML tag <code><tg-thinking></code>.
+ * The block may be used only in {@see https://core.telegram.org/bots/api#sendrichmessagedraft sendRichMessageDraft},
+ * therefore it can't be received in messages.
+ * See https://t.me/addemoji/AIActions for examples of custom emoji that are recommended for usage in the block.
+ * @see https://core.telegram.org/bots/api#inputrichblockthinking
+ */
+#[SkipConstructor]
+class InputRichBlockThinking extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “thinking”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::THINKING;
+
+    /**
+     * Text of the block.
+     * See https://t.me/addemoji/AIActions for examples of custom emoji that are recommended for usage in the block.
+     */
+    public RichText $text;
+
+    public function __construct(RichText $text)
+    {
+        parent::__construct();
+        $this->text = $text;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockVideo.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockVideo.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Input\InputMediaVideo;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock\RichBlockCaption;
+
+/**
+ * A block with a video, corresponding to the HTML tag <code><video></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockvideo
+ */
+#[SkipConstructor]
+class InputRichBlockVideo extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “video”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::VIDEO;
+
+    /**
+     * The video. Caption is ignored.
+     */
+    public InputMediaVideo $video;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+
+    public function __construct(InputMediaVideo $video, ?RichBlockCaption $caption = null)
+    {
+        parent::__construct();
+        $this->video = $video;
+        $this->caption = $caption;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockVoiceNote.php
+++ b/src/Telegram/Types/RichMessage/InputRichBlock/InputRichBlockVoiceNote.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock;
+
+use JsonSerializable;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
+use SergiX44\Hydrator\Resolver\EnumOrScalar;
+use SergiX44\Nutgram\Telegram\Properties\InputRichBlockType;
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Input\InputMediaVoiceNote;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock\RichBlockCaption;
+
+/**
+ * A block with a voice note, corresponding to the HTML tag <code><audio></code>.
+ * @see https://core.telegram.org/bots/api#inputrichblockvoicenote
+ */
+#[SkipConstructor]
+class InputRichBlockVoiceNote extends BaseType implements InputRichBlock, JsonSerializable
+{
+    /**
+     * Type of the block, always “voice_note”
+     */
+    #[EnumOrScalar]
+    public InputRichBlockType|string $type = InputRichBlockType::VOICE_NOTE;
+
+    /**
+     * The voice note. Caption is ignored.
+     */
+    public InputMediaVoiceNote $voice_note;
+
+    /**
+     * Optional. Caption of the block
+     */
+    public ?RichBlockCaption $caption = null;
+
+    public function __construct(InputMediaVoiceNote $voice_note, ?RichBlockCaption $caption = null)
+    {
+        parent::__construct();
+        $this->voice_note = $voice_note;
+        $this->caption = $caption;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Telegram/Types/RichMessage/InputRichMessage.php
+++ b/src/Telegram/Types/RichMessage/InputRichMessage.php
@@ -3,17 +3,26 @@
 namespace SergiX44\Nutgram\Telegram\Types\RichMessage;
 
 use JsonSerializable;
+use SergiX44\Hydrator\Annotation\ArrayType;
 use SergiX44\Hydrator\Annotation\SkipConstructor;
 use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\RichMessage\InputRichBlock\InputRichBlock;
 
 /**
  * Describes a rich message to be sent.
- * Exactly one of the fields html or markdown must be used.
+ * Exactly one of the fields html, markdown, or blocks must be used.
  * @see https://core.telegram.org/bots/api#inputrichmessage
  */
 #[SkipConstructor]
 class InputRichMessage extends BaseType implements JsonSerializable
 {
+    /**
+     * Optional. Content of the rich message to send described as a list of blocks
+     * @var InputRichBlock[]|null
+     */
+    #[ArrayType(InputRichBlock::class)]
+    public ?array $blocks = null;
+
     /**
      * Optional. Content of the rich message to send described using HTML formatting.
      * See {@see https://core.telegram.org/bots/api#rich-message-formatting-options rich message formatting options} for more details.
@@ -27,6 +36,14 @@ class InputRichMessage extends BaseType implements JsonSerializable
     public ?string $markdown = null;
 
     /**
+     * Optional.
+     * List of media that are specified in the markdown or html fields using tg://photo?id=, tg://video?id=, and tg://audio?id= links
+     * @var InputRichMessageMedia[]|null
+     */
+    #[ArrayType(InputRichMessageMedia::class)]
+    public ?array $media = null;
+
+    /**
      * Optional. Pass True if the rich message must be shown right-to-left
      */
     public ?bool $is_rtl = null;
@@ -37,17 +54,29 @@ class InputRichMessage extends BaseType implements JsonSerializable
      */
     public ?bool $skip_entity_detection = null;
 
+    /**
+     * @param string|null $html
+     * @param string|null $markdown
+     * @param bool|null $is_rtl
+     * @param bool|null $skip_entity_detection
+     * @param InputRichMessageMedia[]|null $media
+     * @param InputRichBlock[]|null $blocks
+     */
     public function __construct(
         ?string $html = null,
         ?string $markdown = null,
         ?bool $is_rtl = null,
         ?bool $skip_entity_detection = null,
+        ?array $media = null,
+        ?array $blocks = null
     ) {
         parent::__construct();
         $this->html = $html;
         $this->markdown = $markdown;
         $this->is_rtl = $is_rtl;
         $this->skip_entity_detection = $skip_entity_detection;
+        $this->media = $media;
+        $this->blocks = $blocks;
     }
 
     public function jsonSerialize(): array

--- a/src/Telegram/Types/RichMessage/InputRichMessageContent.php
+++ b/src/Telegram/Types/RichMessage/InputRichMessageContent.php
@@ -7,6 +7,7 @@ use SergiX44\Nutgram\Telegram\Types\Input\InputMessageContent;
 /**
  * Represents the {@see https://core.telegram.org/bots/api#inputmessagecontent content}
  * of a rich message to be sent as the result of an inline query.
+ * @see https://core.telegram.org/bots/api#inputrichmessagecontent
  */
 class InputRichMessageContent extends InputMessageContent
 {

--- a/src/Telegram/Types/RichMessage/InputRichMessageMedia.php
+++ b/src/Telegram/Types/RichMessage/InputRichMessageMedia.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SergiX44\Nutgram\Telegram\Types\RichMessage;
+
+use SergiX44\Nutgram\Telegram\Types\BaseType;
+use SergiX44\Nutgram\Telegram\Types\Input\InputMediaAnimation;
+use SergiX44\Nutgram\Telegram\Types\Input\InputMediaAudio;
+use SergiX44\Nutgram\Telegram\Types\Input\InputMediaPhoto;
+use SergiX44\Nutgram\Telegram\Types\Input\InputMediaVideo;
+use SergiX44\Nutgram\Telegram\Types\Input\InputMediaVoiceNote;
+
+/**
+ * Describes a media element embedded in an outgoing rich message.
+ * @see https://core.telegram.org/bots/api#inputrichmessagemedia
+ */
+class InputRichMessageMedia extends BaseType
+{
+    /**
+     * Unique identifier of the media used in a
+     * tg://photo?id=, tg://video?id=, or tg://audio?id= link.
+     * 1-64 characters, only A-Z, a-z, 0-9, _ and - are allowed.
+     */
+    public string $id;
+
+    /**
+     * The message to be sent
+     */
+    public InputMediaAnimation|InputMediaAudio|InputMediaPhoto|InputMediaVideo|InputMediaVoiceNote $media;
+}

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockCaption.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockCaption.php
@@ -2,7 +2,9 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
 
+use JsonSerializable;
 use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
 use SergiX44\Nutgram\Telegram\Types\BaseType;
 use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichText;
 use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichTextUnionResolver;
@@ -11,7 +13,8 @@ use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichTextUnionResolver;
  * Caption of a rich formatted block.
  * @see https://core.telegram.org/bots/api#richblockcaption
  */
-class RichBlockCaption extends BaseType
+#[SkipConstructor]
+class RichBlockCaption extends BaseType implements JsonSerializable
 {
     /**
      * Block caption
@@ -28,4 +31,16 @@ class RichBlockCaption extends BaseType
     #[ArrayType(RichText::class)]
     #[RichTextUnionResolver]
     public string|array|RichText|null $credit = null;
+
+    public function __construct(string|array|RichText $text, string|array|RichText|null $credit = null)
+    {
+        parent::__construct();
+        $this->text = $text;
+        $this->credit = $credit;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
 }

--- a/src/Telegram/Types/RichMessage/RichBlock/RichBlockTableCell.php
+++ b/src/Telegram/Types/RichMessage/RichBlock/RichBlockTableCell.php
@@ -2,7 +2,9 @@
 
 namespace SergiX44\Nutgram\Telegram\Types\RichMessage\RichBlock;
 
+use JsonSerializable;
 use SergiX44\Hydrator\Annotation\ArrayType;
+use SergiX44\Hydrator\Annotation\SkipConstructor;
 use SergiX44\Hydrator\Resolver\EnumOrScalar;
 use SergiX44\Nutgram\Telegram\Properties\RichBlockTableCellAlign;
 use SergiX44\Nutgram\Telegram\Properties\RichBlockTableCellValign;
@@ -14,7 +16,8 @@ use SergiX44\Nutgram\Telegram\Types\RichMessage\RichText\RichTextUnionResolver;
  * Cell in a table.
  * @see https://core.telegram.org/bots/api#richblocktablecell
  */
-class RichBlockTableCell extends BaseType
+#[SkipConstructor]
+class RichBlockTableCell extends BaseType implements JsonSerializable
 {
     /**
      * Optional. Text in the cell. If omitted, then the cell is invisible.
@@ -50,4 +53,26 @@ class RichBlockTableCell extends BaseType
      */
     #[EnumOrScalar]
     public RichBlockTableCellValign|string $valign;
+
+    public function __construct(
+        RichBlockTableCellAlign|string $align,
+        RichBlockTableCellValign|string $valign,
+        string|array|RichText|null $text = null,
+        ?bool $is_header = null,
+        ?int $colspan = null,
+        ?int $rowspan = null,
+    ) {
+        parent::__construct();
+        $this->align = $align;
+        $this->valign = $valign;
+        $this->text = $text;
+        $this->is_header = $is_header;
+        $this->colspan = $colspan;
+        $this->rowspan = $rowspan;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
 }

--- a/tests/Datasets/community_chat_added.php
+++ b/tests/Datasets/community_chat_added.php
@@ -1,0 +1,7 @@
+<?php
+
+dataset('community_chat_added', function () {
+    $file = file_get_contents(__DIR__.'/../Fixtures/Updates/community_chat_added.json');
+
+    return [json_decode($file)];
+});

--- a/tests/Datasets/community_chat_removed.php
+++ b/tests/Datasets/community_chat_removed.php
@@ -1,0 +1,7 @@
+<?php
+
+dataset('community_chat_removed', function () {
+    $file = file_get_contents(__DIR__.'/../Fixtures/Updates/community_chat_removed.json');
+
+    return [json_decode($file)];
+});

--- a/tests/Datasets/subscription.php
+++ b/tests/Datasets/subscription.php
@@ -1,0 +1,7 @@
+<?php
+
+dataset('subscription', function () {
+    $file = file_get_contents(__DIR__.'/../Fixtures/Updates/subscription.json');
+
+    return [json_decode($file)];
+});

--- a/tests/Feature/Listeners/MessageListenersTest.php
+++ b/tests/Feature/Listeners/MessageListenersTest.php
@@ -740,7 +740,7 @@ it('calls onPollOptionDeleted handler', function ($update) {
     expect($bot->get('called'))->toBeTrue();
 })->with('poll_option_deleted');
 
-it('calls onCommunityChatAdded handler', function($update){
+it('calls onCommunityChatAdded handler', function ($update) {
     $bot = Nutgram::fake($update);
 
     $bot->onCommunityChatAdded(function (Nutgram $bot) {
@@ -752,7 +752,7 @@ it('calls onCommunityChatAdded handler', function($update){
     expect($bot->get('called'))->toBeTrue();
 })->with('community_chat_added');
 
-it('calls onCommunityChatRemoved handler', function($update) {
+it('calls onCommunityChatRemoved handler', function ($update) {
     $bot = Nutgram::fake($update);
 
     $bot->onCommunityChatRemoved(function (Nutgram $bot) {

--- a/tests/Feature/Listeners/MessageListenersTest.php
+++ b/tests/Feature/Listeners/MessageListenersTest.php
@@ -3,7 +3,6 @@
 use SergiX44\Nutgram\Configuration;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Properties\UpdateType;
-use SergiX44\Nutgram\Telegram\Types\User\User;
 
 it('calls onText() handler', function ($update) {
     $bot = Nutgram::fake($update);
@@ -740,3 +739,27 @@ it('calls onPollOptionDeleted handler', function ($update) {
 
     expect($bot->get('called'))->toBeTrue();
 })->with('poll_option_deleted');
+
+it('calls onCommunityChatAdded handler', function($update){
+    $bot = Nutgram::fake($update);
+
+    $bot->onCommunityChatAdded(function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called'))->toBeTrue();
+})->with('community_chat_added');
+
+it('calls onCommunityChatRemoved handler', function($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onCommunityChatRemoved(function (Nutgram $bot) {
+        $bot->set('called', true);
+    });
+
+    $bot->run();
+
+    expect($bot->get('called'))->toBeTrue();
+})->with('community_chat_removed');

--- a/tests/Feature/Listeners/UpdateListenersTest.php
+++ b/tests/Feature/Listeners/UpdateListenersTest.php
@@ -458,3 +458,29 @@ it('calls onGuestMessage() handler', function ($update) {
 
     expect($bot->get('called', false))->toBeTrue();
 })->with('guest_message');
+
+it('calls onBotSubscriptionUpdated() handler', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onBotSubscriptionUpdated(function (Nutgram $bot) {
+        $bot->set('called', true);
+        expect($bot->update()->subscription->invoice_payload)->toBe('foo');
+    });
+
+    $bot->run();
+
+    expect($bot->get('called', false))->toBeTrue();
+})->with('subscription');
+
+it('calls onBotSubscriptionUpdatedPayload() handler', function ($update) {
+    $bot = Nutgram::fake($update);
+
+    $bot->onBotSubscriptionUpdatedPayload('foo', function (Nutgram $bot) {
+        $bot->set('called', true);
+        expect($bot->update()->subscription->invoice_payload)->toBe('foo');
+    });
+
+    $bot->run();
+
+    expect($bot->get('called', false))->toBeTrue();
+})->with('subscription');

--- a/tests/Feature/RegisterMyCommandsTest.php
+++ b/tests/Feature/RegisterMyCommandsTest.php
@@ -608,3 +608,54 @@ test('register command with languages', function () {
             ->language_code->toBe('it'),
     );
 });
+
+test('register ephimeral commands', function () {
+    $bot = Nutgram::fake();
+
+    $history = [];
+
+    $bot->onCommand('start', function (Nutgram $bot) {
+        $bot->sendMessage('Start command!');
+    })->description('Start command');
+
+    $bot->onCommand('admin', function(Nutgram $bot){
+        $bot->sendMessage('Admin command!');
+    })->description('Admin command')->ephemeral();
+
+    $bot->group(function(Nutgram $bot){
+
+        $bot->onCommand('ban', function(Nutgram $bot){
+            $bot->sendMessage('ban command!');
+        })->description('ban command');
+
+        $bot->onCommand('mute', function(Nutgram $bot){
+            $bot->sendMessage('mute command!');
+        })->description('mute command');
+
+    })->ephemeral();
+
+    $bot->registerCommand(new class extends Command {
+        protected string $command = 'deprecated';
+        protected ?string $description = 'deprecated command';
+        protected bool $isEphemeral = true;
+
+        public function handle(Nutgram $bot): void
+        {
+            $bot->sendMessage('deprecated!');
+        }
+    });
+
+    $bot->beforeApiRequest(function (Nutgram $bot, array $request) use (&$history) {
+        $history[] = $request['json'];
+
+        return $request;
+    });
+
+    $bot->registerMyCommands();
+
+    expect($history)->sequence(
+        fn ($x) => $x
+            ->commands->toBe('[{"command":"start","description":"Start command"},{"command":"admin","description":"Admin command","is_ephemeral":true},{"command":"deprecated","description":"deprecated command","is_ephemeral":true},{"command":"ban","description":"ban command","is_ephemeral":true},{"command":"mute","description":"mute command","is_ephemeral":true}]')
+            ->scope->toBe('{"type":"default"}'),
+    );
+});

--- a/tests/Feature/RegisterMyCommandsTest.php
+++ b/tests/Feature/RegisterMyCommandsTest.php
@@ -618,20 +618,18 @@ test('register ephimeral commands', function () {
         $bot->sendMessage('Start command!');
     })->description('Start command');
 
-    $bot->onCommand('admin', function(Nutgram $bot){
+    $bot->onCommand('admin', function (Nutgram $bot) {
         $bot->sendMessage('Admin command!');
     })->description('Admin command')->ephemeral();
 
-    $bot->group(function(Nutgram $bot){
-
-        $bot->onCommand('ban', function(Nutgram $bot){
+    $bot->group(function (Nutgram $bot) {
+        $bot->onCommand('ban', function (Nutgram $bot) {
             $bot->sendMessage('ban command!');
         })->description('ban command');
 
-        $bot->onCommand('mute', function(Nutgram $bot){
+        $bot->onCommand('mute', function (Nutgram $bot) {
             $bot->sendMessage('mute command!');
         })->description('mute command');
-
     })->ephemeral();
 
     $bot->registerCommand(new class extends Command {

--- a/tests/Fixtures/Updates/community_chat_added.json
+++ b/tests/Fixtures/Updates/community_chat_added.json
@@ -1,0 +1,29 @@
+{
+  "update_id": 144011148,
+  "message": {
+    "message_id": 123456,
+    "date": 1668633998,
+    "from": {
+      "id": 12345,
+      "is_bot": false,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "language_code": "it",
+      "is_premium": false
+    },
+    "chat": {
+      "id": 12345,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "type": "private"
+    },
+    "community_chat_added": {
+      "community": {
+        "id": 989898,
+        "name": "MyCommunity"
+      }
+    }
+  }
+}

--- a/tests/Fixtures/Updates/community_chat_removed.json
+++ b/tests/Fixtures/Updates/community_chat_removed.json
@@ -1,0 +1,24 @@
+{
+  "update_id": 144011148,
+  "message": {
+    "message_id": 123456,
+    "date": 1668633998,
+    "from": {
+      "id": 12345,
+      "is_bot": false,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "language_code": "it",
+      "is_premium": false
+    },
+    "chat": {
+      "id": 12345,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "type": "private"
+    },
+    "community_chat_removed": {}
+  }
+}

--- a/tests/Fixtures/Updates/subscription.json
+++ b/tests/Fixtures/Updates/subscription.json
@@ -1,0 +1,16 @@
+{
+  "update_id": 144011148,
+  "subscription": {
+    "user": {
+      "id": 12345,
+      "is_bot": false,
+      "first_name": "Mario",
+      "last_name": "Bros",
+      "username": "MarioBros",
+      "language_code": "it",
+      "is_premium": false
+    },
+    "invoice_payload": "foo",
+    "state": "active"
+  }
+}


### PR DESCRIPTION
### [July 14, 2026](https://core.telegram.org/bots/api-changelog#july-14-2026)

**Bot API 10.2**

**Rich Messages**

- [x] Added the class [InputRichMessageMedia](https://core.telegram.org/bots/api#inputrichmessagemedia) and the field _media_ to the class [InputRichMessage](https://core.telegram.org/bots/api#inputrichmessage), allowing bots to explicitly specify media used in _markdown_ or _html_ formatting when sending a rich message.
- [x] Added the class [InputMediaVoiceNote](https://core.telegram.org/bots/api#inputmediavoicenote), representing a voice message to be sent.
- [x] Added the class [InputRichBlockListItem](https://core.telegram.org/bots/api#inputrichblocklistitem), which represents an item in a list to be sent.
- [x] Added the classes XXX which represent different types of blocks available to format an outgoing rich message:
    - [x] [InputRichBlockParagraph](https://core.telegram.org/bots/api#inputrichblockparagraph)
    - [x] [InputRichBlockSectionHeading](https://core.telegram.org/bots/api#inputrichblocksectionheading)
    - [x] [InputRichBlockPreformatted](https://core.telegram.org/bots/api#inputrichblockpreformatted)
    - [x] [InputRichBlockFooter](https://core.telegram.org/bots/api#inputrichblockfooter)
    - [x] [InputRichBlockDivider](https://core.telegram.org/bots/api#inputrichblockdivider)
    - [x] [InputRichBlockMathematicalExpression](https://core.telegram.org/bots/api#inputrichblockmathematicalexpression)
    - [x] [InputRichBlockAnchor](https://core.telegram.org/bots/api#inputrichblockanchor)
    - [x] [InputRichBlockList](https://core.telegram.org/bots/api#inputrichblocklist)
    - [x] [InputRichBlockBlockQuotation](https://core.telegram.org/bots/api#inputrichblockblockquotation)
    - [x] [InputRichBlockPullQuotation](https://core.telegram.org/bots/api#inputrichblockpullquotation)
    - [x] [InputRichBlockCollage](https://core.telegram.org/bots/api#inputrichblockcollage)
    - [x] [InputRichBlockSlideshow](https://core.telegram.org/bots/api#inputrichblockslideshow)
    - [x] [InputRichBlockTable](https://core.telegram.org/bots/api#inputrichblocktable)
    - [x] [InputRichBlockDetails](https://core.telegram.org/bots/api#inputrichblockdetails)
    - [x] [InputRichBlockMap](https://core.telegram.org/bots/api#inputrichblockmap)
    - [x] [InputRichBlockAnimation](https://core.telegram.org/bots/api#inputrichblockanimation)
    - [x] [InputRichBlockAudio](https://core.telegram.org/bots/api#inputrichblockaudio)
    - [x] [InputRichBlockPhoto](https://core.telegram.org/bots/api#inputrichblockphoto)
    - [x] [InputRichBlockVideo](https://core.telegram.org/bots/api#inputrichblockvideo)
    - [x] [InputRichBlockVoiceNote](https://core.telegram.org/bots/api#inputrichblockvoicenote) 
    - [x] [InputRichBlockThinking](https://core.telegram.org/bots/api#inputrichblockthinking)
- [x] Added the field _blocks_ to the class [InputRichMessage](https://core.telegram.org/bots/api#inputrichmessage), allowing bots to specify rich message formatting via block entities.

**Ephemeral Messages**

- [x] Introduced support for [Ephemeral Messages](https://core.telegram.org/bots/features#ephemeral-messages), allowing bots to send group messages and receive commands that are visible only to a specific user and the bot.
- [x] Added the field _is\_ephemeral_ to the class [BotCommand](https://core.telegram.org/bots/api#botcommand).
- [x] Added the field _receiver\_user_ to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the field _ephemeral\_message\_id_ to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the parameters _receiver\_user\_id_ and _callback\_query\_id_ to the methods 
    - [x] [sendMessage](https://core.telegram.org/bots/api#sendmessage)
    - [x] [sendAnimation](https://core.telegram.org/bots/api#sendanimation)
    - [x] [sendAudio](https://core.telegram.org/bots/api#sendaudio)
    - [x] [sendDocument](https://core.telegram.org/bots/api#senddocument)
    - [x] [sendPhoto](https://core.telegram.org/bots/api#sendphoto)
    - [x] [sendSticker](https://core.telegram.org/bots/api#sendsticker)
    - [x] [sendVideo](https://core.telegram.org/bots/api#sendvideo)
    - [x] [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote)
    - [x] [sendVoice](https://core.telegram.org/bots/api#sendvoice)
    - [x] [sendContact](https://core.telegram.org/bots/api#sendcontact)
    - [x] [sendLocation](https://core.telegram.org/bots/api#sendlocation)
    - [x] [sendVenue](https://core.telegram.org/bots/api#sendvenue).
- [x] Added the field _ephemeral\_message\_id_ to the class [ReplyParameters](https://core.telegram.org/bots/api#replyparameters), allowing bots to reply to ephemeral messages.
- [x] Marked the field _message\_id_ in the class [ReplyParameters](https://core.telegram.org/bots/api#replyparameters) as optional if the field _ephemeral\_message\_id_ is present.
- [x] Added the methods allowing bots to edit ephemeral messages:
    - [x] [editEphemeralMessageText](https://core.telegram.org/bots/api#editephemeralmessagetext)
    - [x] [editEphemeralMessageMedia](https://core.telegram.org/bots/api#editephemeralmessagemedia)
    - [x] [editEphemeralMessageCaption](https://core.telegram.org/bots/api#editephemeralmessagecaption)
    - [x] [editEphemeralMessageReplyMarkup](https://core.telegram.org/bots/api#editephemeralmessagereplymarkup) 
- [x] Added the method [deleteEphemeralMessage](https://core.telegram.org/bots/api#deleteephemeralmessage) allowing bots to delete ephemeral messages.

**Communities**

- [x] Introduced initial support for **Communities** - several supergroups, channels, and bots linked together around a shared topic or audience.
- [x] Added the class [Community](https://core.telegram.org/bots/api#community) which represents a community.
- [x] Added the class [CommunityChatAdded](https://core.telegram.org/bots/api#communitychatadded) and the field _community\_chat\_added_ to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the class [CommunityChatRemoved](https://core.telegram.org/bots/api#communitychatremoved) and the field _community\_chat\_removed_ to the class [Message](https://core.telegram.org/bots/api#message).
- [x] Added the field _community_ to the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).

**General**

- [x] Added updates about changes to a user payment subscription, represented by the class [BotSubscriptionUpdated](https://core.telegram.org/bots/api#botsubscriptionupdated) and the field _subscription_ in the class [Update](https://core.telegram.org/bots/api#update).
- [x] Hardened the security of Mini Apps by disallowing the usage of Mini App methods from origins different from the original Mini App domain. The protection will be automatically enabled for all Mini Apps on July 20, 2026. You can opt-out from the protection through the [@BotFather](https://t.me/BotFather) Mini App. If you do so, you acknowledge that it is the responsibility of the bot to ensure that the Mini App has no links to untrusted sites.

### Nutgram
- [x] Update badge
- [x] `onBotSubscriptionUpdated` handler
- [x] `onBotSubscriptionUpdatedPayload` handler
- [x] `onCommunityChatAdded` handler
- [x] `onCommunityChatRemoved` handler
- [x] `$bot->onCommand()->ephemeral();`
- [x] `$bot->group()->ephemeral();`
